### PR TITLE
Add support for multi-line comments

### DIFF
--- a/lib/parlour/rbi_generator/rbi_object.rb
+++ b/lib/parlour/rbi_generator/rbi_object.rb
@@ -40,12 +40,18 @@ module Parlour
       # file.
       attr_reader :comments
 
-      sig { params(comment: String).void }
-      # Adds a comment to this RBI object.
-      # @param comment The new comment.
+      sig { params(comment: T.any(String, T::Array[String])).void }
+      # Adds one or more comments to this RBI object.
+      # @param comment The new comment(s).
       def add_comment(comment)
-        comments << comment
+        if comment.is_a?(String)
+          comments << comment
+        elsif comment.is_a?(Array)
+          comments.concat(comment)
+        end
       end
+
+      alias_method :add_comments, :add_comment
 
       sig do
         params(

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -258,4 +258,18 @@ RSpec.describe Parlour::RbiGenerator do
       end
     RUBY
   end
+
+  it 'supports multi-line comments' do
+    mod = subject.root.create_module('M') do |m|
+      m.add_comment(['This is a', 'multi-line', 'comment'])
+    end
+
+    expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
+      # This is a
+      # multi-line
+      # comment
+      module M
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Input:
```ruby
create_module('M') do |m|
  m.add_comment(['This is a', 'multi-line', 'comment'])
end
```

Output:
```ruby
# This is a
# multi-line
# comment
module M
end
```

It also aliases `add_comment` to `add_comments`.