### PR TITLE
Add YARD types to all parameters and return tags.

### DIFF
--- a/lib/parlour/conflict_resolver.rb
+++ b/lib/parlour/conflict_resolver.rb
@@ -30,11 +30,14 @@ module Parlour
     # definitions. The block may be invoked many times from one call to 
     # {resolve_conflicts}, one for each unresolvable conflict.
     #
-    # @param namespace The starting namespace to resolve conflicts in.
-    # @yieldparam message A descriptional message on what the conflict is.
-    # @yieldparam candidates The objects for which there is a conflict.
-    # @yieldreturn One of the +candidates+, which will be kept, or nil to keep
-    #   none of them.
+    # @param namespace [RbiGenerator::Namespace] The starting namespace to
+    #   resolve conflicts in.
+    # @yieldparam message [String] A descriptional message on what the conflict is.
+    # @yieldparam candidates [Array<RbiGenerator::RbiObject>] The objects for
+    #   which there is a conflict.
+    # @yieldreturn [RbiGenerator::RbiObject] One of the +candidates+, which
+    #   will be kept, or nil to keep none of them.
+    # @return [void]
     def resolve_conflicts(namespace, &resolver)
       # Check for multiple definitions with the same name
       grouped_by_name_children = namespace.children.group_by(&:name)
@@ -82,8 +85,9 @@ module Parlour
     sig { params(arr: T::Array[T.untyped]).returns(T.nilable(Class)) }
     # Given an array, if all elements in the array are instances of the exact
     # same class, returns that class. If they are not, returns nil.
-    # @param arr The array.
-    # @return Either a class, or nil.
+    #
+    # @param arr [Array] The array.
+    # @return [Class, nil] Either a class, or nil.
     def single_type_of_array(arr)
       array_types = arr.map { |c| c.class }.uniq
       array_types.length == 1 ? array_types.first : nil
@@ -92,8 +96,9 @@ module Parlour
     sig { params(arr: T::Array[T.untyped]).returns(T::Boolean) }
     # Given an array, returns true if all elements in the array are equal by
     # +==+. (Assumes a transitive definition of +==+.)
-    # @param arr The array.
-    # @return A boolean indicating if all elements are equal by +==+.
+    #
+    # @param arr [Array] The array.
+    # @return [Boolean] A boolean indicating if all elements are equal by +==+.
     def all_eql?(arr)
       arr.each_cons(2).all? { |x, y| x == y }
     end

--- a/lib/parlour/plugin.rb
+++ b/lib/parlour/plugin.rb
@@ -12,6 +12,8 @@ module Parlour
     sig { returns(T::Hash[String, Plugin]) }
     # Returns all registered plugins, as a hash of their paths to the {Plugin}
     # instances themselves.
+    #
+    # @return [{String, Plugin}]
     def self.registered_plugins
       @@registered_plugins
     end
@@ -19,15 +21,19 @@ module Parlour
     sig { params(new_plugin: T.class_of(Plugin)).void }
     # Called automatically by the Ruby interpreter when {Plugin} is subclassed.
     # This registers the new subclass into {registered_plugins}.
-    # @param new_plugin The new plugin.
+    #
+    # @param new_plugin [Plugin] The new plugin.
+    # @return [void]
     def self.inherited(new_plugin)
       registered_plugins[T.must(new_plugin.name)] = new_plugin.new
     end
 
     sig { params(plugins: T::Array[Plugin], generator: RbiGenerator).void }
     # Runs an array of plugins on a given generator instance.
-    # @param plugins An array of {Plugin} instances.
-    # @param generator The {RbiGenerator} to run the plugins on.
+    #
+    # @param plugins [Array<Plugin>] An array of {Plugin} instances.
+    # @param generator [RbiGenerator] The {RbiGenerator} to run the plugins on.
+    # @return [void]
     def self.run_plugins(plugins, generator)
       plugins.each do |plugin|
         generator.current_plugin = plugin
@@ -38,8 +44,10 @@ module Parlour
     sig { abstract.params(root: RbiGenerator::Namespace).void }
     # Plugin subclasses should redefine this method and do their RBI generation
     # inside it.
+    #
     # @abstract
-    # @param root The root {RbiGenerator::Namespace}.
+    # @param root [RbiGenerator::Namespace] The root {RbiGenerator::Namespace}.
+    # @return [void]
     def generate(root); end
   end
 end

--- a/lib/parlour/rbi_generator.rb
+++ b/lib/parlour/rbi_generator.rb
@@ -8,7 +8,7 @@ module Parlour
     # Creates a new RBI generator.
     #
     # @param break_params [Integer] If there are at least this many parameters in a 
-    #   Sorbet `sig`, then it is broken onto separate lines.
+    #   Sorbet +sig+, then it is broken onto separate lines.
     # @param tab_size [Integer] The number of spaces to use per indent.
     # @return [void]
     def initialize(break_params: 4, tab_size: 2)

--- a/lib/parlour/rbi_generator.rb
+++ b/lib/parlour/rbi_generator.rb
@@ -17,15 +17,18 @@ module Parlour
 
     sig { returns(Options) }
     # The formatting options for this generator.
+    # @return [Options]
     attr_reader :options
 
     sig { returns(Namespace) }
     # The root {Namespace} of this generator.
+    # @return [Namespace]
     attr_reader :root
 
     sig { returns(T.nilable(Plugin)) }
     # The plugin which is currently generating new definitions.
     # {Plugin#run_plugins} controls this value.
+    # @return [Plugin, nil]
     attr_accessor :current_plugin
 
     sig { returns(String) }

--- a/lib/parlour/rbi_generator.rb
+++ b/lib/parlour/rbi_generator.rb
@@ -6,6 +6,7 @@ module Parlour
 
     sig { params(break_params: Integer, tab_size: Integer).void }
     # Creates a new RBI generator.
+    #
     # @param break_params If there are at least this many parameters in a 
     #   Sorbet `sig`, then it is broken onto separate lines.
     # @param tab_size The number of spaces to use per indent.
@@ -29,6 +30,8 @@ module Parlour
 
     sig { returns(String) }
     # Returns the complete contents of the generated RBI file as a string.
+    #
+    # @return [String] The generated RBI file
     def rbi
       root.generate_rbi(0, options).join("\n")
     end

--- a/lib/parlour/rbi_generator.rb
+++ b/lib/parlour/rbi_generator.rb
@@ -7,9 +7,10 @@ module Parlour
     sig { params(break_params: Integer, tab_size: Integer).void }
     # Creates a new RBI generator.
     #
-    # @param break_params If there are at least this many parameters in a 
+    # @param break_params [Integer] If there are at least this many parameters in a 
     #   Sorbet `sig`, then it is broken onto separate lines.
-    # @param tab_size The number of spaces to use per indent.
+    # @param tab_size [Integer] The number of spaces to use per indent.
+    # @return [void]
     def initialize(break_params: 4, tab_size: 2)
       @options = Options.new(break_params: break_params, tab_size: tab_size)
       @root = Namespace.new(self)

--- a/lib/parlour/rbi_generator/attribute.rb
+++ b/lib/parlour/rbi_generator/attribute.rb
@@ -43,7 +43,8 @@ module Parlour
       end
 
       sig { returns(Symbol) }
-      # The kind of attribute this is; one of :writer, :reader or :accessor. 
+      # The kind of attribute this is; one of :writer, :reader or :accessor.
+      # @return [Symbol]
       attr_reader :kind
 
       sig do

--- a/lib/parlour/rbi_generator/attribute.rb
+++ b/lib/parlour/rbi_generator/attribute.rb
@@ -14,13 +14,15 @@ module Parlour
       end
       # Creates a new attribute. (You should use
       # {Namespace#create_attribute} rather than this directly.)
-      # @param generator The current RbiGenerator.
-      # @param name The name of this attribute.
-      # @param kind The kind of attribute this is; one of :writer, :reader or
+      #
+      # @param generator [RbiGenerator] The current RbiGenerator.
+      # @param name [String] The name of this attribute.
+      # @param kind [Symbol] The kind of attribute this is; one of :writer, :reader or
       #   :accessor.
-      # @param type A Sorbet string of this attribute's type, such as
+      # @param type [String] A Sorbet string of this attribute's type, such as
       #   +"String"+ or +"T.untyped"+.
       # @param block A block which the new instance yields itself to.
+      # @return [void]
       def initialize(generator, name, kind, type, &block)
         # According to this source: 
         #   https://github.com/sorbet/sorbet/blob/2275752e51604acfb79b30a0a96debc996c089d9/test/testdata/dsl/attr_multi.rb
@@ -51,9 +53,10 @@ module Parlour
         ).returns(T::Array[String])
       end
       # Generates the RBI lines for this method.
-      # @param indent_level The indentation level to generate the lines at.
-      # @param options The formatting options to use.
-      # @return The RBI lines, formatted as specified.
+      # 
+      # @param indent_level [Integer] The indentation level to generate the lines at.
+      # @param options [Options] The formatting options to use.
+      # @return [Array<String>] The RBI lines, formatted as specified.
       def generate_definition(indent_level, options)
         [options.indented(indent_level, "attr_#{kind} :#{name}")]
       end

--- a/lib/parlour/rbi_generator/class_namespace.rb
+++ b/lib/parlour/rbi_generator/class_namespace.rb
@@ -55,10 +55,12 @@ module Parlour
 
       sig { returns(T.nilable(String)) }
       # The superclass of this class, or nil if it doesn't have one.
+      # @return [String, nil]
       attr_reader :superclass
 
       sig { returns(T::Boolean) }
       # A boolean indicating whether this class is abstract or not.
+      # @return [Boolean]
       attr_reader :abstract
 
       sig do

--- a/lib/parlour/rbi_generator/class_namespace.rb
+++ b/lib/parlour/rbi_generator/class_namespace.rb
@@ -16,12 +16,14 @@ module Parlour
       end
       # Creates a new class definition. (You should use {Namespace#create_class}
       # rather than this directly.)
-      # @param generator The current RbiGenerator.
-      # @param name The name of this class.
-      # @param superclass The superclass of this class, or nil if it doesn't
+      #
+      # @param generator [RbiGenerator] The current RbiGenerator.
+      # @param name [String] The name of this class.
+      # @param superclass [String, nil] The superclass of this class, or nil if it doesn't
       #   have one.
-      # @param abstract A boolean indicating whether this class is abstract.
+      # @param abstract [Boolean] A boolean indicating whether this class is abstract.
       # @param block A block which the new instance yields itself to.
+      # @return [void]
       def initialize(generator, name, superclass, abstract, &block)
         super(generator, name, &block)
         @superclass = superclass
@@ -35,9 +37,10 @@ module Parlour
         ).returns(T::Array[String])
       end
       # Generates the RBI lines for this class.
-      # @param indent_level The indentation level to generate the lines at.
-      # @param options The formatting options to use.
-      # @return The RBI lines, formatted as specified.
+      # 
+      # @param indent_level [Integer] The indentation level to generate the lines at.
+      # @param options [Options] The formatting options to use.
+      # @return [Array<String>] The RBI lines, formatted as specified.
       def generate_rbi(indent_level, options)
         class_definition = superclass.nil? \
           ? "class #{name}"
@@ -67,8 +70,9 @@ module Parlour
       # be merged into this instance using {merge_into_self}. For instances to
       # be mergeable, they must either all be abstract or all not be abstract,
       # and they must define the same superclass (or none at all).
-      # @param others An array of other {ClassNamespace} instances.
-      # @return Whether this instance may be merged with them.
+      #
+      # @param others [Array<RbiGenerator::RbiObject>] An array of other {ClassNamespace} instances.
+      # @return [Boolean] Whether this instance may be merged with them.
       def mergeable?(others)
         others = T.cast(others, T::Array[ClassNamespace]) rescue (return false)
         all = others + [self]
@@ -85,7 +89,9 @@ module Parlour
       # Given an array of {ClassNamespace} instances, merges them into this one.
       # All children, extends and includes are copied into this instance.
       # You MUST ensure that {mergeable?} is true for those instances.
-      # @param others An array of other {ClassNamespace} instances.
+      # 
+      # @param others [Array<RbiGenerator::RbiObject>] An array of other {ClassNamespace} instances.
+      # @return [void]
       def merge_into_self(others)
         others.each do |other|
           other = T.cast(other, ClassNamespace)
@@ -100,6 +106,7 @@ module Parlour
 
       sig { override.returns(String) }
       # Returns a human-readable brief string description of this class.
+      # @return [String]
       def describe
         "Class #{name} - #{"superclass #{superclass}, " if superclass}" +
           "#{"abstract, " if abstract}#{children.length} children, " +

--- a/lib/parlour/rbi_generator/method.rb
+++ b/lib/parlour/rbi_generator/method.rb
@@ -21,22 +21,24 @@ module Parlour
       end
       # Creates a new method definition. (You should use
       # {Namespace#create_method} rather than this directly.)
-      # @param generator The current RbiGenerator.
-      # @param name The name of this method. You should not specify +self.+ in
+      #
+      # @param generator [RbiGenerator] The current RbiGenerator.
+      # @param name [String] The name of this method. You should not specify +self.+ in
       #   this - use the +class_method+ parameter instead.
-      # @param parameters An array of {Parameter} instances representing this 
+      # @param parameters [Array<Parameter>] An array of {Parameter} instances representing this 
       #   method's parameters.
-      # @param return_type A Sorbet string of what this method returns, such as
+      # @param return_type [String, nil] A Sorbet string of what this method returns, such as
       #   +"String"+ or +"T.untyped"+. Passing nil denotes a void return.
-      # @param abstract Whether this method is abstract.
-      # @param implementation Whether this method is an implementation of a
+      # @param abstract [Boolean] Whether this method is abstract.
+      # @param implementation [Boolean] Whether this method is an implementation of a
       #   parent abstract method.
-      # @param override Whether this method is overriding a parent overridable
+      # @param override [Boolean] Whether this method is overriding a parent overridable
       #   method.
-      # @param overridable Whether this method is overridable by subclasses.
-      # @param class_method Whether this method is a class method; that is, it
+      # @param overridable [Boolean] Whether this method is overridable by subclasses.
+      # @param class_method [Boolean] Whether this method is a class method; that is, it
       #   it is defined using +self.+.
       # @param block A block which the new instance yields itself to.
+      # @return [void]
       def initialize(generator, name, parameters, return_type = nil, abstract: false, implementation: false, override: false, overridable: false, class_method: false, &block)
         super(generator, name)
         @parameters = parameters
@@ -51,8 +53,10 @@ module Parlour
 
       sig { params(other: Object).returns(T::Boolean) }
       # Returns true if this instance is equal to another method.
-      # @param other The other instance. If this is not a {Method} (or a
+      #
+      # @param other [Object] The other instance. If this is not a {Method} (or a
       #   subclass of it), this will always return false.
+      # @return [Boolean]
       def ==(other)
         Method === other &&
           name           == other.name && 
@@ -102,9 +106,10 @@ module Parlour
         ).returns(T::Array[String])
       end
       # Generates the RBI lines for this method.
-      # @param indent_level The indentation level to generate the lines at.
-      # @param options The formatting options to use.
-      # @return The RBI lines, formatted as specified.
+      #
+      # @param indent_level [Integer] The indentation level to generate the lines at.
+      # @param options [Options] The formatting options to use.
+      # @return [Array<String>] The RBI lines, formatted as specified.
       def generate_rbi(indent_level, options)
         return_call = return_type ? "returns(#{return_type})" : 'void'
 
@@ -162,6 +167,8 @@ module Parlour
       # Returns the qualifiers which go in front of the +params+ part of this
       # method's Sorbet +sig+. For example, if {abstract} is true, then this
       # will return +abstract.+.
+      #
+      # @return [String]
       def qualifiers
         result = ''
         result += 'abstract.' if abstract
@@ -179,8 +186,9 @@ module Parlour
       # Given an array of {Method} instances, returns true if they may be merged
       # into this instance using {merge_into_self}. For instances to be
       # mergeable, their signatures and definitions must be identical.
-      # @param others An array of other {Method} instances.
-      # @return Whether this instance may be merged with them.
+      #
+      # @param others [Array<RbiGenerator::RbiObject>] An array of other {Method} instances.
+      # @return [Boolean] Whether this instance may be merged with them.
       def mergeable?(others)
         others.all? { |other| self == other }
       end
@@ -195,13 +203,17 @@ module Parlour
       # instances are only mergeable if they are identical, so nothing needs
       # to be changed.
       # You MUST ensure that {mergeable?} is true for those instances.
-      # @param others An array of other {Method} instances.
+      #
+      # @param others [Array<RbiGenerator::RbiObject>] An array of other {Method} instances.
+      # @return [void]
       def merge_into_self(others)
         # We don't need to change anything! We only merge identical methods
       end
 
       sig { override.returns(String) }
       # Returns a human-readable brief string description of this method.
+      #
+      # @return [String]
       def describe
         # TODO: more info
         "Method #{name} - #{parameters.length} parameters, " +

--- a/lib/parlour/rbi_generator/method.rb
+++ b/lib/parlour/rbi_generator/method.rb
@@ -71,32 +71,39 @@ module Parlour
 
       sig { returns(T::Array[Parameter]) }
       # An array of {Parameter} instances representing this method's parameters.
+      # @return [Array<Parameter>]
       attr_reader :parameters
 
       sig { returns(T.nilable(String)) }
       # A Sorbet string of what this method returns, such as "String" or
       # "T.untyped". Passing nil denotes a void return.
+      # @return [String, nil]
       attr_reader :return_type
 
       sig { returns(T::Boolean) }
       # Whether this method is abstract.
+      # @return [Boolean]
       attr_reader :abstract
 
       sig { returns(T::Boolean) }
       # Whether this method is an implementation of a parent abstract method.
+      # @return [Boolean]
       attr_reader :implementation
 
       sig { returns(T::Boolean) }
       # Whether this method is overriding a parent overridable method.
+      # @return [Boolean]
       attr_reader :override
 
       sig { returns(T::Boolean) }
       # Whether this method is overridable by subclasses.
+      # @return [Boolean]
       attr_reader :overridable
 
       sig { returns(T::Boolean) }
       # Whether this method is a class method; that is, it it is defined using
       # +self.+.
+      # @return [Boolean]
       attr_reader :class_method
 
       sig do

--- a/lib/parlour/rbi_generator/method.rb
+++ b/lib/parlour/rbi_generator/method.rb
@@ -149,9 +149,10 @@ module Parlour
         ).returns(T::Array[String])
       end
       # Generates the RBI lines for this method.
-      # @param indent_level The indentation level to generate the lines at.
-      # @param options The formatting options to use.
-      # @return The RBI lines, formatted as specified.
+      # 
+      # @param indent_level [Integer] The indentation level to generate the lines at.
+      # @param options [Options] The formatting options to use.
+      # @return [Array<String>] The RBI lines, formatted as specified.
       def generate_definition(indent_level, options)
         def_params = parameters.map(&:to_def_param)
         name_prefix = class_method ? 'self.' : ''

--- a/lib/parlour/rbi_generator/module_namespace.rb
+++ b/lib/parlour/rbi_generator/module_namespace.rb
@@ -15,11 +15,13 @@ module Parlour
       end
       # Creates a new module definition. (You should use 
       # {Namespace#create_module} rather than this directly.)
-      # @param generator The current RbiGenerator.
-      # @param name The name of this module.
-      # @param interface A boolean indicating whether this module is an
+      # 
+      # @param generator [RbiGenerator] The current RbiGenerator.
+      # @param name [String] The name of this module.
+      # @param interface [Boolean] A boolean indicating whether this module is an
       #   interface.
       # @param block A block which the new instance yields itself to.
+      # @return [void]
       def initialize(generator, name, interface, &block)
         super(generator, name, &block)
         @name = name
@@ -33,9 +35,10 @@ module Parlour
         ).returns(T::Array[String])
       end
       # Generates the RBI lines for this module.
-      # @param indent_level The indentation level to generate the lines at.
-      # @param options The formatting options to use.
-      # @return The RBI lines, formatted as specified.
+      #
+      # @param indent_level [Integer] The indentation level to generate the lines at.
+      # @param options [Options] The formatting options to use.
+      # @return [Array<String>] The RBI lines, formatted as specified.
       def generate_rbi(indent_level, options)        
         lines = generate_comments(indent_level, options)
         lines << options.indented(indent_level, "module #{name}")
@@ -57,8 +60,9 @@ module Parlour
       # be merged into this instance using {merge_into_self}. For instances to
       # be mergeable, they must either all be interfaces or all not be 
       # interfaces.
-      # @param others An array of other {ModuleNamespace} instances.
-      # @return Whether this instance may be merged with them.
+      #
+      # @param others [Array<RbiGenerator::RbiObject>] An array of other {ModuleNamespace} instances.
+      # @return [Boolean] Whether this instance may be merged with them.
       def mergeable?(others)
         others = T.cast(others, T::Array[RbiGenerator::ModuleNamespace]) rescue (return false)
         all = others + [self]
@@ -74,7 +78,9 @@ module Parlour
       # Given an array of {ModuleNamespace} instances, merges them into this one.
       # All children, extends and includes are copied into this instance.
       # You MUST ensure that {mergeable?} is true for those instances.
-      # @param others An array of other {ModuleNamespace} instances.
+      #
+      # @param others [Array<RbiGenerator::RbiObject>] An array of other {ModuleNamespace} instances.
+      # @return [void]
       def merge_into_self(others)
         others.each do |other|
           other = T.cast(other, ModuleNamespace)
@@ -87,6 +93,7 @@ module Parlour
 
       sig { override.returns(String) }
       # Returns a human-readable brief string description of this module.
+      # @return [String]
       def describe
         "Module #{name} - #{"interface, " if interface}#{children.length} " +
           "children, #{includes.length} includes, #{extends.length} extends"

--- a/lib/parlour/rbi_generator/module_namespace.rb
+++ b/lib/parlour/rbi_generator/module_namespace.rb
@@ -49,6 +49,7 @@ module Parlour
 
       sig { returns(T::Boolean) }
       # A boolean indicating whether this module is an interface or not.
+      # @return [Boolean]
       attr_reader :interface
 
       sig do

--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -185,12 +185,14 @@ module Parlour
       end
 
       # Creates a new attribute.
-      # @param name The name of this attribute.
-      # @param kind The kind of attribute this is; one of :writer, :reader or
+      #
+      # @param name [String] The name of this attribute.
+      # @param kind [Symbol] The kind of attribute this is; one of :writer, :reader or
       #   :accessor.
-      # @param type A Sorbet string of this attribute's type, such as
+      # @param type [String] A Sorbet string of this attribute's type, such as
       #   +"String"+ or +"T.untyped"+.
       # @param block A block which the new instance yields itself to.
+      # @return [RbiGenerator::Attribute]
       def create_attribute(name, kind, type, &block)
         new_attribute = RbiGenerator::Attribute.new(
           generator,
@@ -205,28 +207,34 @@ module Parlour
       alias_method :create_attr, :create_attribute
 
       # Creates a new read-only attribute (attr_reader).
-      # @param name The name of this attribute.
-      # @param type A Sorbet string of this attribute's type, such as
+      #
+      # @param name [String] The name of this attribute.
+      # @param type [String] A Sorbet string of this attribute's type, such as
       #   +"String"+ or +"T.untyped"+.
       # @param block A block which the new instance yields itself to.
+      # @return [RbiGenerator::Attribute]
       def create_attr_reader(name, type, &block)
         create_attribute(name, :reader, type, &block)
       end
 
       # Creates a new write-only attribute (attr_writer).
-      # @param name The name of this attribute.
-      # @param type A Sorbet string of this attribute's type, such as
+      #
+      # @param name [String] The name of this attribute.
+      # @param type [String] A Sorbet string of this attribute's type, such as
       #   +"String"+ or +"T.untyped"+.
       # @param block A block which the new instance yields itself to.
+      # @return [RbiGenerator::Attribute]
       def create_attr_writer(name, type, &block)
         create_attribute(name, :writer, type, &block)
       end
 
       # Creates a new read and write attribute (attr_accessor).
-      # @param name The name of this attribute.
-      # @param type A Sorbet string of this attribute's type, such as
+      #
+      # @param name [String] The name of this attribute.
+      # @param type [String] A Sorbet string of this attribute's type, such as
       #   +"String"+ or +"T.untyped"+.
       # @param block A block which the new instance yields itself to.
+      # @return [RbiGenerator::Attribute]
       def create_attr_accessor(name, type, &block)
         create_attribute(name, :accessor, type, &block)
       end

--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -82,16 +82,19 @@ module Parlour
 
       sig { returns(T::Array[RbiObject]) }
       # The child {RbiObject} instances inside this namespace.
+      # @return [Array<RbiObject>]
       attr_reader :children
 
       sig { returns(T::Array[String]) }
       # A list of strings which are each used in an +extend+ statement in this
       # namespace.
+      # @return [Array<String>]
       attr_reader :extends
 
       sig { returns(T::Array[String]) }
       # A list of strings which are each used in an +include+ statement in this
       # namespace.
+      # @return [Array<String>]
       attr_reader :includes
 
       sig do

--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -13,9 +13,10 @@ module Parlour
         ).returns(T::Array[String])
       end
       # Generates the RBI lines for this namespace.
-      # @param indent_level The indentation level to generate the lines at.
-      # @param options The formatting options to use.
-      # @return The RBI lines, formatted as specified.
+      #
+      # @param indent_level [Integer] The indentation level to generate the lines at.
+      # @param options [Options] The formatting options to use.
+      # @return [Array<String>] The RBI lines, formatted as specified.
       def generate_rbi(indent_level, options)
         generate_comments(indent_level, options) +  
           generate_body(indent_level, options)
@@ -29,9 +30,10 @@ module Parlour
       end
       # Generates the RBI lines for the body of this namespace. This consists of
       # {includes}, {extends} and {children}.
-      # @param indent_level The indentation level to generate the lines at.
-      # @param options The formatting options to use.
-      # @return The RBI lines for the body, formatted as specified.
+      #
+      # @param indent_level [Integer] The indentation level to generate the lines at.
+      # @param options [Options] The formatting options to use.
+      # @return [Array<String>] The RBI lines for the body, formatted as specified.
       def generate_body(indent_level, options)
         result = []
 
@@ -65,9 +67,11 @@ module Parlour
       end
       # Creates a new namespace. Unless you're doing something impressively 
       # hacky, this shouldn't be invoked outside of {RbiGenerator#initialize}.
-      # @param generator The current RbiGenerator.
-      # @param name The name of this module.
+      #
+      # @param generator [RbiGenerator] The current RbiGenerator.
+      # @param name [String, nil] The name of this module.
       # @param block A block which the new instance yields itself to.
+      # @return [void]
       def initialize(generator, name = nil, &block)
         super(generator, name || '<anonymous namespace>')
         @children = []
@@ -99,11 +103,13 @@ module Parlour
         ).returns(ClassNamespace)
       end
       # Creates a new class definition as a child of this namespace.
-      # @param name The name of this class.
-      # @param superclass The superclass of this class, or nil if it doesn't
+      #
+      # @param name [String] The name of this class.
+      # @param superclass [String, nil] The superclass of this class, or nil if it doesn't
       #   have one.
-      # @param abstract A boolean indicating whether this class is abstract.
+      # @param abstract [Boolean] A boolean indicating whether this class is abstract.
       # @param block A block which the new instance yields itself to.
+      # @return [ClassNamespace]
       def create_class(name, superclass: nil, abstract: false, &block)
         new_class = ClassNamespace.new(generator, name, superclass, abstract, &block)
         children << new_class
@@ -118,10 +124,12 @@ module Parlour
         ).returns(ModuleNamespace)
       end
       # Creates a new module definition as a child of this namespace.
-      # @param name The name of this module.
-      # @param interface A boolean indicating whether this module is an
+      #
+      # @param name [String] The name of this module.
+      # @param interface [Boolean] A boolean indicating whether this module is an
       #   interface.
       # @param block A block which the new instance yields itself to.
+      # @return [ModuleNamespace]
       def create_module(name, interface: false, &block)
         new_module = ModuleNamespace.new(generator, name, interface, &block)
         children << new_module
@@ -142,21 +150,23 @@ module Parlour
         ).returns(Method)
       end
       # Creates a new method definition as a child of this namespace.
-      # @param name The name of this method. You should not specify +self.+ in
+      #
+      # @param name [String] The name of this method. You should not specify +self.+ in
       #   this - use the +class_method+ parameter instead.
-      # @param parameters An array of {Parameter} instances representing this 
+      # @param parameters [Array<Parameter>] An array of {Parameter} instances representing this 
       #   method's parameters.
-      # @param return_type A Sorbet string of what this method returns, such as
+      # @param return_type [String, nil] A Sorbet string of what this method returns, such as
       #   +"String"+ or +"T.untyped"+. Passing nil denotes a void return.
-      # @param abstract Whether this method is abstract.
-      # @param implementation Whether this method is an implementation of a
+      # @param abstract [Boolean] Whether this method is abstract.
+      # @param implementation [Boolean] Whether this method is an implementation of a
       #   parent abstract method.
-      # @param override Whether this method is overriding a parent overridable
+      # @param override [Boolean] Whether this method is overriding a parent overridable
       #   method.
-      # @param overridable Whether this method is overridable by subclasses.
-      # @param class_method Whether this method is a class method; that is, it
+      # @param overridable [Boolean] Whether this method is overridable by subclasses.
+      # @param class_method [Boolean] Whether this method is a class method; that is, it
       #   it is defined using +self.+.
       # @param block A block which the new instance yields itself to.
+      # @return [Method]
       def create_method(name, parameters, return_type = nil, abstract: false, implementation: false, override: false, overridable: false, class_method: false, &block)
         new_method = RbiGenerator::Method.new(
           generator,
@@ -223,16 +233,20 @@ module Parlour
 
       sig { params(name: String).void }
       # Adds a new +extend+ to this namespace.
-      # @param name A code string for what is extended, for example
+      #
+      # @param name [String] A code string for what is extended, for example
       #   +"MyModule"+.
+      # @return [void]
       def add_extend(name)
         extends << name
       end
 
       sig { params(name: String).void }
       # Adds a new +include+ to this namespace.
-      # @param name A code string for what is included, for example
+      #
+      # @param name [String] A code string for what is included, for example
       #   +"Enumerable"+.
+      # @return [void]
       def add_include(name)
         includes << name
       end
@@ -247,8 +261,9 @@ module Parlour
       # can be merged into each other, as they lack definitions for themselves,
       # so there is nothing to conflict. (This isn't the case for subclasses
       # such as {ClassNamespace}.)
-      # @param others An array of other {Namespace} instances.
-      # @return Always true.
+      # 
+      # @param others [Array<RbiGenerator::RbiObject>] An array of other {Namespace} instances.
+      # @return [true] Always true.
       def mergeable?(others)
         true
       end
@@ -260,7 +275,9 @@ module Parlour
       end
       # Given an array of {Namespace} instances, merges them into this one.
       # All children, extends and includes are copied into this instance.
-      # @param others An array of other {Namespace} instances.
+      # 
+      # @param others [Array<RbiGenerator::RbiObject>] An array of other {Namespace} instances.
+      # @return [void]
       def merge_into_self(others)
         others.each do |other|
           other = T.cast(other, Namespace)
@@ -273,6 +290,8 @@ module Parlour
 
       sig { implementation.overridable.returns(String) }
       # Returns a human-readable brief string description of this namespace.
+      #
+      # @return [String]
       def describe
         "Namespace #{name} - #{children.length} children, #{includes.length} " +
           "includes, #{extends.length} extends"

--- a/lib/parlour/rbi_generator/options.rb
+++ b/lib/parlour/rbi_generator/options.rb
@@ -8,9 +8,11 @@ module Parlour
 
       sig { params(break_params: Integer, tab_size: Integer).void }
       # Creates a new set of formatting options.
-      # @param break_params If there are at least this many parameters in a 
+      #
+      # @param break_params [Integer] If there are at least this many parameters in a 
       #   Sorbet `sig`, then it is broken onto separate lines.
-      # @param tab_size The number of spaces to use per indent.
+      # @param tab_size [Integer] The number of spaces to use per indent.
+      # @return [void]
       def initialize(break_params:, tab_size:)
         @break_params = break_params
         @tab_size = tab_size
@@ -28,9 +30,10 @@ module Parlour
       sig { params(level: Integer, str: String).returns(String) }
       # Returns a string indented to the given indent level, according to the
       # set {tab_size}.
-      # @param level The indent level, as an integer. 0 is totally unindented.
-      # @param str The string to indent.
-      # @return The indented string.
+      #
+      # @param level [Integer] The indent level, as an integer. 0 is totally unindented.
+      # @param str [String] The string to indent.
+      # @return [String] The indented string.
       def indented(level, str)
         " " * (level * tab_size) + str
       end

--- a/lib/parlour/rbi_generator/options.rb
+++ b/lib/parlour/rbi_generator/options.rb
@@ -10,7 +10,7 @@ module Parlour
       # Creates a new set of formatting options.
       #
       # @param break_params [Integer] If there are at least this many parameters in a 
-      #   Sorbet `sig`, then it is broken onto separate lines.
+      #   Sorbet +sig+, then it is broken onto separate lines.
       # @param tab_size [Integer] The number of spaces to use per indent.
       # @return [void]
       def initialize(break_params:, tab_size:)
@@ -19,7 +19,7 @@ module Parlour
       end
       
       sig { returns(Integer) }
-      # If there are at least this many parameters in a  Sorbet `sig`, then it 
+      # If there are at least this many parameters in a Sorbet +sig+, then it 
       # is broken onto separate lines.
       # @return [Integer]
       attr_reader :break_params

--- a/lib/parlour/rbi_generator/options.rb
+++ b/lib/parlour/rbi_generator/options.rb
@@ -21,10 +21,12 @@ module Parlour
       sig { returns(Integer) }
       # If there are at least this many parameters in a  Sorbet `sig`, then it 
       # is broken onto separate lines.
+      # @return [Integer]
       attr_reader :break_params
 
       sig { returns(Integer) }
-      # The number of spaces to use per indent.      
+      # The number of spaces to use per indent.
+      # @return [Integer]
       attr_reader :tab_size
 
       sig { params(level: Integer, str: String).returns(String) }

--- a/lib/parlour/rbi_generator/parameter.rb
+++ b/lib/parlour/rbi_generator/parameter.rb
@@ -53,6 +53,7 @@ module Parlour
       sig { returns(String) }
       # The name of this parameter, including any prefixes or suffixes such as
       # +*+.
+      # @return [String]
       attr_reader :name
 
       sig { returns(String) }
@@ -72,17 +73,20 @@ module Parlour
       sig { returns(T.nilable(String)) }
       # A Sorbet string of this parameter's type, such as +"String"+ or
       # +"T.untyped"+.
+      # @return [String, nil]
       attr_reader :type
 
       sig { returns(T.nilable(String)) }
       # A string of Ruby code for this parameter's default value. For example,
       # the default value of an empty string would be represented as +"\"\""+
       # (or +'""'+). The default value of the decimal +3.14+ would be +"3.14"+.
+      # @return [String, nil]
       attr_reader :default
 
       sig { returns(Symbol) }
       # The kind of parameter that this is. This will be one of +:normal+, 
       #   +:splat+, +:double_splat+, +:block+ or +:keyword+.
+      # @return [Symbol]
       attr_reader :kind
 
       sig { returns(String) }

--- a/lib/parlour/rbi_generator/parameter.rb
+++ b/lib/parlour/rbi_generator/parameter.rb
@@ -13,15 +13,17 @@ module Parlour
         ).void
       end
       # Create a new method parameter.
-      # @param name The name of this parameter. This may start with +*+, +**+,
+      #
+      # @param name [String] The name of this parameter. This may start with +*+, +**+,
       #   or +&+, or end with +:+, which will infer the {kind} of this
       #   parameter. (If it contains none of those, {kind} will be +:normal+.)
-      # @param type A Sorbet string of this parameter's type, such as
+      # @param type [String, nil] A Sorbet string of this parameter's type, such as
       #   +"String"+ or +"T.untyped"+.
-      # @param default A string of Ruby code for this parameter's default value.
+      # @param default [String, nil] A string of Ruby code for this parameter's default value.
       #   For example, the default value of an empty string would be represented
       #   as +"\"\""+ (or +'""'+). The default value of the decimal +3.14+
       #   would be +"3.14"+.
+      # @return [void]
       def initialize(name, type: nil, default: nil)
         @name = name
 
@@ -36,8 +38,10 @@ module Parlour
 
       sig { params(other: Object).returns(T::Boolean) }
       # Returns true if this instance is equal to another method.
-      # @param other The other instance. If this is not a {Parameter} (or a
+      #
+      # @param other [Object] The other instance. If this is not a {Parameter} (or a
       #   subclass of it), this will always return false.
+      # @return [Boolean]
       def ==(other)
         Parameter === other &&
           name    == other.name &&
@@ -54,6 +58,8 @@ module Parlour
       sig { returns(String) }
       # The name of this parameter, stripped of any prefixes or suffixes. For
       # example, +*rest+ would become +rest+, or +foo:+ would become +foo+.
+      #
+      # @return [String]
       def name_without_kind
         return T.must(name[0..-2]) if kind == :keyword
 
@@ -81,6 +87,8 @@ module Parlour
 
       sig { returns(String) }
       # A string of how this parameter should be defined in a method definition.
+      #
+      # @return [String]
       def to_def_param
         if default.nil?
           "#{name}"
@@ -93,6 +101,8 @@ module Parlour
 
       sig { returns(String) }
       # A string of how this parameter should be defined in a Sorbet `sig`.
+      #
+      # @return [String]
       def to_sig_param
         "#{name_without_kind}: #{type || 'T.untyped'}"
       end

--- a/lib/parlour/rbi_generator/parameter.rb
+++ b/lib/parlour/rbi_generator/parameter.rb
@@ -85,7 +85,7 @@ module Parlour
 
       sig { returns(Symbol) }
       # The kind of parameter that this is. This will be one of +:normal+, 
-      #   +:splat+, +:double_splat+, +:block+ or +:keyword+.
+      # +:splat+, +:double_splat+, +:block+ or +:keyword+.
       # @return [Symbol]
       attr_reader :kind
 
@@ -104,7 +104,7 @@ module Parlour
       end
 
       sig { returns(String) }
-      # A string of how this parameter should be defined in a Sorbet `sig`.
+      # A string of how this parameter should be defined in a Sorbet +sig+.
       #
       # @return [String]
       def to_sig_param

--- a/lib/parlour/rbi_generator/rbi_object.rb
+++ b/lib/parlour/rbi_generator/rbi_object.rb
@@ -13,8 +13,10 @@ module Parlour
 
       sig { params(generator: RbiGenerator, name: String).void }
       # Creates a new RBI object. Don't call this directly.
-      # @param generator The current RbiGenerator.
-      # @param name The name of this module.
+      #
+      # @param generator [RbiGenerator] The current RbiGenerator.
+      # @param name [String] The name of this module.
+      # @return [void]
       def initialize(generator, name)
         @generator = generator
         @generated_by = generator.current_plugin
@@ -42,7 +44,9 @@ module Parlour
 
       sig { params(comment: T.any(String, T::Array[String])).void }
       # Adds one or more comments to this RBI object.
-      # @param comment The new comment(s).
+      #
+      # @param comment [String, Array<String>] The new comment(s).
+      # @return [void]
       def add_comment(comment)
         if comment.is_a?(String)
           comments << comment
@@ -60,9 +64,10 @@ module Parlour
         ).returns(T::Array[String])
       end
       # Generates the RBI lines for this object's comments.
-      # @param indent_level The indentation level to generate the lines at.
-      # @param options The formatting options to use.
-      # @return The RBI lines for each comment, formatted as specified.
+      #
+      # @param indent_level [Integer] The indentation level to generate the lines at.
+      # @param options [Options] The formatting options to use.
+      # @return [Array<String>] The RBI lines for each comment, formatted as specified.
       def generate_comments(indent_level, options)
         comments.any? \
           ? comments.map { |c| options.indented(indent_level, "# #{c}") }
@@ -76,10 +81,11 @@ module Parlour
         ).returns(T::Array[String])
       end
       # Generates the RBI lines for this object.
+      #
       # @abstract
-      # @param indent_level The indentation level to generate the lines at.
-      # @param options The formatting options to use.
-      # @return The RBI lines, formatted as specified.
+      # @param indent_level [Integer] The indentation level to generate the lines at.
+      # @param options [Options] The formatting options to use.
+      # @return [Array<String>] The RBI lines, formatted as specified.
       def generate_rbi(indent_level, options); end
 
       sig do
@@ -90,9 +96,10 @@ module Parlour
       # Given an array of other objects, returns true if they may be merged
       # into this instance using {merge_into_self}. Each subclass will have its
       # own criteria on what allows objects to be mergeable.
+      #
       # @abstract
-      # @param others An array of other {RbiObject} instances.
-      # @return Whether this instance may be merged with them.
+      # @param others [Array<RbiGenerator::RbiObject>] An array of other {RbiObject} instances.
+      # @return [Boolean] Whether this instance may be merged with them.
       def mergeable?(others); end
 
       sig do 
@@ -102,15 +109,19 @@ module Parlour
       end
       # Given an array of other objects, merges them into this one. Each
       # subclass will do this differently.
-      # @abstract
       # You MUST ensure that {mergeable?} is true for those instances.
-      # @param others An array of other {RbiObject} instances.
+      #
+      # @abstract
+      # @param others [Array<RbiGenerator::RbiObject>] An array of other {RbiObject} instances.
+      # @return [void]
       def merge_into_self(others); end
 
       sig { abstract.returns(String) }
       # Returns a human-readable brief string description of this object. This
       # is displayed during manual conflict resolution with the +parlour+ CLI.
+      #
       # @abstract
+      # @return [String]
       def describe; end
     end
   end

--- a/lib/parlour/rbi_generator/rbi_object.rb
+++ b/lib/parlour/rbi_generator/rbi_object.rb
@@ -26,20 +26,24 @@ module Parlour
 
       sig { returns(RbiGenerator) }
       # The generator which this object belongs to.
+      # @return [RbiGenerator]
       attr_reader :generator
 
       sig { returns(T.nilable(Plugin)) }
       # The {Plugin} which was controlling the {generator} when this object was
       # created.
+      # @return [Plugin, nil]
       attr_reader :generated_by
 
       sig { returns(String) }
       # The name of this object.
+      # @return [String]
       attr_reader :name
 
       sig { returns(T::Array[String]) }
       # An array of comments which will be placed above the object in the RBI
       # file.
+      # @return [Array<String>]
       attr_reader :comments
 
       sig { params(comment: T.any(String, T::Array[String])).void }


### PR DESCRIPTION
I know this is repetitive of the Sorbet types, but if the documentation is going to be generated with YARD it should use these.