### PR TITLE
Change "name" to a positional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ Here's a quick example of how you can generate an RBI:
 require 'parlour'
 
 generator = Parlour::RbiGenerator.new
-generator.root.create_module(name: 'A') do |a|
-  a.create_class(name: 'Foo') do |foo|
-    foo.create_method(name: 'add_two_integers', parameters: [
-      Parlour::RbiGenerator::Parameter.new(name: 'a', type: 'Integer'),
-      Parlour::RbiGenerator::Parameter.new(name: 'b', type: 'Integer')
+generator.root.create_module('A') do |a|
+  a.create_class('Foo') do |foo|
+    foo.create_method('add_two_integers', parameters: [
+      Parlour::RbiGenerator::Parameter.new('a', type: 'Integer'),
+      Parlour::RbiGenerator::Parameter.new('b', type: 'Integer')
     ], return_type: 'Integer')
   end
 
-  a.create_class(name: 'Bar', superclass: 'Foo')
+  a.create_class('Bar', superclass: 'Foo')
 end
 
 generator.rbi # => Our RBI as a string
@@ -74,15 +74,15 @@ require 'parlour'
 
 class MyPlugin < Parlour::Plugin
   def generate(root)
-    root.create_module(name: 'A') do |a|
-      a.create_class(name: 'Foo') do |foo|
-        foo.create_method(name: 'add_two_integers', parameters: [
-          Parlour::RbiGenerator::Parameter.new(name: 'a', type: 'Integer'),
-          Parlour::RbiGenerator::Parameter.new(name: 'b', type: 'Integer')
+    root.create_module('A') do |a|
+      a.create_class('Foo') do |foo|
+        foo.create_method('add_two_integers', parameters: [
+          Parlour::RbiGenerator::Parameter.new('a', type: 'Integer'),
+          Parlour::RbiGenerator::Parameter.new('b', type: 'Integer')
         ], return_type: 'Integer')
       end
 
-      a.create_class(name: 'Bar', superclass: 'Foo')
+      a.create_class('Bar', superclass: 'Foo')
     end
   end
 end

--- a/lib/parlour/rbi_generator/attribute.rb
+++ b/lib/parlour/rbi_generator/attribute.rb
@@ -35,7 +35,7 @@ module Parlour
           super(generator, name, [], type, &block)
         when :writer
           super(generator, name, [
-            Parameter.new(name: name, type: type)
+            Parameter.new(name, type: type)
           ], type, &block)
         else
           raise 'unknown kind'

--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -96,9 +96,9 @@ module Parlour
         current_part = self
         parts_with_types.each do |(name, type)|
           if type == Class
-            current_part = current_part.create_class(name: name)
+            current_part = current_part.create_class(name)
           elsif type == Module
-            current_part = current_part.create_module(name: name)
+            current_part = current_part.create_module(name)
           else
             raise "unexpected type: path part #{name} is a #{type}"
           end
@@ -112,11 +112,11 @@ module Parlour
       #
       # @example Creating a module with a comment.
       #   namespace.add_comment_to_next_child('This is a module')
-      #   namespace.create_module(name: 'M')
+      #   namespace.create_module('M')
       #
       # @example Creating a class with a multi-line comment.
       #   namespace.add_comment_to_next_child(['This is a multi-line comment!', 'It can be as long as you want!'])
-      #   namespace.create_class(name: 'C')
+      #   namespace.create_class('C')
       #
       # @param comment [String, Array<String>] The new comment(s).
       # @return [void]
@@ -139,12 +139,12 @@ module Parlour
       # Creates a new class definition as a child of this namespace.
       #
       # @example Create a class with a nested module.
-      #   namespace.create_class(name: 'Foo') do |foo|
-      #     foo.create_module(name: 'Bar')
+      #   namespace.create_class('Foo') do |foo|
+      #     foo.create_module('Bar')
       #   end
       #
       # @example Create a class that is the child of another class.
-      #   namespace.create_class(name: 'Bar', superclass: 'Foo') #=> class Bar < Foo
+      #   namespace.create_class('Bar', superclass: 'Foo') #=> class Bar < Foo
       #
       # @param name [String] The name of this class.
       # @param superclass [String, nil] The superclass of this class, or nil if it doesn't
@@ -152,7 +152,7 @@ module Parlour
       # @param abstract [Boolean] A boolean indicating whether this class is abstract.
       # @param block A block which the new instance yields itself to.
       # @return [ClassNamespace]
-      def create_class(name:, superclass: nil, abstract: false, &block)
+      def create_class(name, superclass: nil, abstract: false, &block)
         new_class = ClassNamespace.new(generator, name, superclass, abstract, &block)
         move_next_comments(new_class)
         children << new_class
@@ -169,11 +169,11 @@ module Parlour
       # Creates a new module definition as a child of this namespace.
       #
       # @example Create a basic module.
-      #   namespace.create_module(name: 'Foo')
+      #   namespace.create_module('Foo')
       #
       # @example Create a module with a method.
-      #   namespace.create_module(name: 'Foo') do |foo|
-      #     foo.create_method(name: 'method_name', parameters: [], return_type: 'Integer')
+      #   namespace.create_module('Foo') do |foo|
+      #     foo.create_method('method_name', parameters: [], return_type: 'Integer')
       #   end
       #
       # @param name [String] The name of this module.
@@ -181,7 +181,7 @@ module Parlour
       #   interface.
       # @param block A block which the new instance yields itself to.
       # @return [ModuleNamespace]
-      def create_module(name:, interface: false, &block)
+      def create_module(name, interface: false, &block)
         new_module = ModuleNamespace.new(generator, name, interface, &block)
         move_next_comments(new_module)
         children << new_module
@@ -221,7 +221,7 @@ module Parlour
       #   it is defined using +self.+.
       # @param block A block which the new instance yields itself to.
       # @return [Method]
-      def create_method(name:, parameters: nil, return_type: nil, returns: nil, abstract: false, implementation: false, override: false, overridable: false, class_method: false, &block)
+      def create_method(name, parameters: nil, return_type: nil, returns: nil, abstract: false, implementation: false, override: false, overridable: false, class_method: false, &block)
         parameters = parameters || []
         raise 'cannot specify both return_type: and returns:' if return_type && returns
         return_type ||= returns
@@ -266,7 +266,7 @@ module Parlour
       #   +"String"+ or +"T.untyped"+.
       # @param block A block which the new instance yields itself to.
       # @return [RbiGenerator::Attribute]
-      def create_attribute(name:, kind:, type:, &block)
+      def create_attribute(name, kind:, type:, &block)
         new_attribute = RbiGenerator::Attribute.new(
           generator,
           name,
@@ -287,8 +287,8 @@ module Parlour
       #   +"String"+ or +"T.untyped"+.
       # @param block A block which the new instance yields itself to.
       # @return [RbiGenerator::Attribute]
-      def create_attr_reader(name:, type:, &block)
-        create_attribute(name: name, kind: :reader, type: type, &block)
+      def create_attr_reader(name, type:, &block)
+        create_attribute(name, kind: :reader, type: type, &block)
       end
 
       # Creates a new write-only attribute (+attr_writer+).
@@ -298,8 +298,8 @@ module Parlour
       #   +"String"+ or +"T.untyped"+.
       # @param block A block which the new instance yields itself to.
       # @return [RbiGenerator::Attribute]
-      def create_attr_writer(name:, type:, &block)
-        create_attribute(name: name, kind: :writer, type: type, &block)
+      def create_attr_writer(name, type:, &block)
+        create_attribute(name, kind: :writer, type: type, &block)
       end
 
       # Creates a new read and write attribute (+attr_accessor+).
@@ -309,8 +309,8 @@ module Parlour
       #   +"String"+ or +"T.untyped"+.
       # @param block A block which the new instance yields itself to.
       # @return [RbiGenerator::Attribute]
-      def create_attr_accessor(name:, type:, &block)
-        create_attribute(name: name, kind: :accessor, type: type, &block)
+      def create_attr_accessor(name, type:, &block)
+        create_attribute(name, kind: :accessor, type: type, &block)
       end
 
       # Creates a new arbitrary code section.
@@ -334,13 +334,13 @@ module Parlour
       # Adds a new +extend+ to this namespace.
       #
       # @example Add an +extend+ to a class.
-      #   class.create_extend(name: 'ExtendableClass') #=> extend ExtendableClass
+      #   class.create_extend('ExtendableClass') #=> extend ExtendableClass
       #
       # @param object [String] A code string for what is extended, for example
       #   +"MyModule"+.
       # @param block A block which the new instance yields itself to.
       # @return [RbiGenerator::Extend]
-      def create_extend(name:, &block)
+      def create_extend(name, &block)
         new_extend = RbiGenerator::Extend.new(
           generator,
           name: name,
@@ -362,7 +362,7 @@ module Parlour
       def create_extends(extendables)
         returned_extendables = []
         extendables.each do |extendable|
-          returned_extendables << create_extend(name: extendable)
+          returned_extendables << create_extend(extendable)
         end
         returned_extendables
       end
@@ -371,13 +371,13 @@ module Parlour
       # Adds a new +include+ to this namespace.
       #
       # @example Add an +include+ to a class.
-      #   class.create_include(name: 'IncludableClass') #=> include IncludableClass
+      #   class.create_include('IncludableClass') #=> include IncludableClass
       #
       # @param [String] name A code string for what is included, for example
       #   +"Enumerable"+.
       # @param block A block which the new instance yields itself to.
       # @return [RbiGenerator::Include]
-      def create_include(name:, &block)
+      def create_include(name, &block)
         new_include = RbiGenerator::Include.new(
           generator,
           name: name,
@@ -399,7 +399,7 @@ module Parlour
       def create_includes(includables)
         returned_includables = []
         includables.each do |includable|
-          returned_includables << create_include(name: includable)
+          returned_includables << create_include(includable)
         end
         returned_includables
       end
@@ -408,13 +408,13 @@ module Parlour
       # Adds a new constant definition to this namespace.
       #
       # @example Add an +Elem+ constant to the class.
-      #   class.create_constant(name: 'Elem', value: 'String') #=> Elem = String
+      #   class.create_constant('Elem', value: 'String') #=> Elem = String
       #
       # @param name [String] The name of the constant.
       # @param value [String] The value of the constant, as a Ruby code string.
       # @param block A block which the new instance yields itself to.
       # @return [RbiGenerator::Constant]
-      def create_constant(name:, value:, &block)
+      def create_constant(name, value:, &block)
         new_constant = RbiGenerator::Constant.new(
           generator,
           name: name,

--- a/lib/parlour/rbi_generator/parameter.rb
+++ b/lib/parlour/rbi_generator/parameter.rb
@@ -15,13 +15,13 @@ module Parlour
       # Create a new method parameter.
       #
       # @example Create a simple Integer parameter named +num+.
-      #   Parlour::RbiGenerator::Parameter.new(name: 'num', type: 'Integer')
+      #   Parlour::RbiGenerator::Parameter.new('num', type: 'Integer')
       # @example Create a nilable array parameter.
-      #   Parlour::RbiGenerator::Parameter.new(name: 'array_of_strings_or_symbols', type: 'T.nilable(T::Array(String, Symbol))')
+      #   Parlour::RbiGenerator::Parameter.new('array_of_strings_or_symbols', type: 'T.nilable(T::Array(String, Symbol))')
       # @example Create a block parameter.
-      #   Parlour::RbiGenerator::Parameter.new(name: '&blk', type: 'T.proc.void')
+      #   Parlour::RbiGenerator::Parameter.new('&blk', type: 'T.proc.void')
       # @example Create a parameter with a default value.
-      #   Parlour::RbiGenerator::Parameter.new(name: 'name', type: 'String', default: 'Parlour')
+      #   Parlour::RbiGenerator::Parameter.new('name', type: 'String', default: 'Parlour')
       #
       # @param name [String] The name of this parameter. This may start with +*+, +**+,
       #   or +&+, or end with +:+, which will infer the {kind} of this
@@ -33,7 +33,7 @@ module Parlour
       #   as +"\"\""+ (or +'""'+). The default value of the decimal +3.14+
       #   would be +"3.14"+.
       # @return [void]
-      def initialize(name: nil, type: nil, default: nil)
+      def initialize(name, type: nil, default: nil)
         name = T.must(name)
         @name = name
 

--- a/lib/parlour/rbi_generator/rbi_object.rb
+++ b/lib/parlour/rbi_generator/rbi_object.rb
@@ -52,12 +52,12 @@ module Parlour
       # the definition for this object, not in the definition's body.
       #
       # @example Creating a module with a comment.
-      #   namespace.create_module(name: 'M') do |m|
+      #   namespace.create_module('M') do |m|
       #     m.add_comment('This is a module')
       #   end
       #
       # @example Creating a class with a multi-line comment.
-      #   namespace.create_class(name: 'C') do |c|
+      #   namespace.create_class('C') do |c|
       #     c.add_comment(['This is a multi-line comment!', 'It can be as long as you want!'])
       #   end
       #

--- a/plugin_examples/foobar_plugin.rb
+++ b/plugin_examples/foobar_plugin.rb
@@ -3,10 +3,10 @@ require 'parlour'
 module FooBar
   class Plugin < Parlour::Plugin
     def generate(root)
-      root.create_module(name: 'Foo') do |foo|
+      root.create_module('Foo') do |foo|
         foo.add_comment('This is an example plugin!')
-        foo.create_module(name: 'Bar')
-        foo.create_module(name: 'Bar', interface: true)
+        foo.create_module('Bar')
+        foo.create_module('Bar', interface: true)
       end
     end
   end

--- a/spec/conflict_resolver_spec.rb
+++ b/spec/conflict_resolver_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Parlour::ConflictResolver do
   end
 
   it 'does not merge different kinds of definition' do
-    m = gen.root.create_module(name: 'M') do |m|
-      m.create_module(name: 'A')
-      m.create_class(name: 'A')
+    m = gen.root.create_module('M') do |m|
+      m.create_module('A')
+      m.create_class('A')
     end
 
     expect(m.children.length).to be 2
@@ -24,9 +24,9 @@ RSpec.describe Parlour::ConflictResolver do
 
   context 'when resolving conflicts on methods' do
     it 'merges multiple of the same method definition' do
-      a = gen.root.create_class(name: 'A') do |a|
-        a.create_method(name: 'foo', parameters: [pa(name: 'a', type: 'String')])
-        a.create_method(name: 'foo', parameters: [pa(name: 'a', type: 'String')])
+      a = gen.root.create_class('A') do |a|
+        a.create_method('foo', parameters: [pa('a', type: 'String')])
+        a.create_method('foo', parameters: [pa('a', type: 'String')])
       end
 
       expect(a.children.length).to be 2
@@ -37,9 +37,9 @@ RSpec.describe Parlour::ConflictResolver do
     end
 
     it 'will not merge methods with different names' do
-      a = gen.root.create_class(name: 'A') do |a|
-        a.create_method(name: 'foo')
-        a.create_method(name: 'bar')
+      a = gen.root.create_class('A') do |a|
+        a.create_method('foo')
+        a.create_method('bar')
       end
 
       expect(a.children.length).to be 2
@@ -50,9 +50,9 @@ RSpec.describe Parlour::ConflictResolver do
     end
 
     it 'will not attempt to automatically merge conflicting methods' do
-      a = gen.root.create_class(name: 'A') do |a|
-        a.create_method(name: 'foo', parameters: [pa(name: 'a', type: 'String')])
-        a.create_method(name: 'foo', parameters: [pa(name: 'a', type: 'Integer')])
+      a = gen.root.create_class('A') do |a|
+        a.create_method('foo', parameters: [pa('a', type: 'String')])
+        a.create_method('foo', parameters: [pa('a', type: 'Integer')])
       end
 
       expect(a.children.length).to be 2
@@ -67,9 +67,9 @@ RSpec.describe Parlour::ConflictResolver do
 
   context 'when resolving conflicts on classes' do
     it 'merges identical empty classes' do
-      m = gen.root.create_module(name: 'M') do |m|
-        m.create_class(name: 'A')
-        m.create_class(name: 'A')
+      m = gen.root.create_module('M') do |m|
+        m.create_class('A')
+        m.create_class('A')
       end
 
       expect(m.children.length).to be 2
@@ -81,9 +81,9 @@ RSpec.describe Parlour::ConflictResolver do
     end
 
     it 'does not merge empty classes with conflicting signatures' do
-      m = gen.root.create_module(name: 'M') do |m|
-        m.create_class(name: 'A', abstract: true)
-        m.create_class(name: 'A')
+      m = gen.root.create_module('M') do |m|
+        m.create_class('A', abstract: true)
+        m.create_class('A')
       end
 
       expect(m.children.length).to be 2
@@ -96,16 +96,16 @@ RSpec.describe Parlour::ConflictResolver do
     end
 
     it 'merges definitions inside compatible classes' do
-      m = gen.root.create_module(name: 'M') do |m|
-        m.create_class(name: 'A') do |a|
-          a.create_extend(name: 'E1')
-          a.create_include(name: 'I1')
-          a.create_method(name: 'foo')
+      m = gen.root.create_module('M') do |m|
+        m.create_class('A') do |a|
+          a.create_extend('E1')
+          a.create_include('I1')
+          a.create_method('foo')
         end
-        m.create_class(name: 'A') do |a|
-          a.create_extend(name: 'E2')
-          a.create_include(name: 'I2')
-          a.create_method(name: 'bar')
+        m.create_class('A') do |a|
+          a.create_extend('E2')
+          a.create_include('I2')
+          a.create_method('bar')
         end
       end
 
@@ -121,10 +121,10 @@ RSpec.describe Parlour::ConflictResolver do
     end
 
     it 'merges compatible superclasses' do
-      m = gen.root.create_module(name: 'M') do |m|
-        m.create_class(name: 'A', superclass: 'X')
-        m.create_class(name: 'A')
-        m.create_class(name: 'A', superclass: 'X')
+      m = gen.root.create_module('M') do |m|
+        m.create_class('A', superclass: 'X')
+        m.create_class('A')
+        m.create_class('A', superclass: 'X')
       end
 
       expect(m.children.length).to be 3
@@ -137,10 +137,10 @@ RSpec.describe Parlour::ConflictResolver do
     end
 
     it 'does not merge incompatible superclasses' do
-      m = gen.root.create_module(name: 'M') do |m|
-        m.create_class(name: 'A', superclass: 'X')
-        m.create_class(name: 'A')
-        m.create_class(name: 'A', superclass: 'Y')
+      m = gen.root.create_module('M') do |m|
+        m.create_class('A', superclass: 'X')
+        m.create_class('A')
+        m.create_class('A', superclass: 'Y')
       end
 
       expect(m.children.length).to be 3
@@ -155,9 +155,9 @@ RSpec.describe Parlour::ConflictResolver do
 
   context 'when resolving conflicts on modules' do
     it 'merges identical empty modules' do
-      m = gen.root.create_module(name: 'M') do |m|
-        m.create_module(name: 'A')
-        m.create_module(name: 'A')
+      m = gen.root.create_module('M') do |m|
+        m.create_module('A')
+        m.create_module('A')
       end
 
       expect(m.children.length).to be 2
@@ -169,9 +169,9 @@ RSpec.describe Parlour::ConflictResolver do
     end
 
     it 'does not merge empty modules with conflicting signatures' do
-      m = gen.root.create_module(name: 'M') do |m|
-        m.create_module(name: 'A', interface: true)
-        m.create_module(name: 'A')
+      m = gen.root.create_module('M') do |m|
+        m.create_module('A', interface: true)
+        m.create_module('A')
       end
 
       expect(m.children.length).to be 2
@@ -184,16 +184,16 @@ RSpec.describe Parlour::ConflictResolver do
     end
 
     it 'merges definitions inside compatible modules' do
-      m = gen.root.create_module(name: 'M') do |m|
-        m.create_module(name: 'A') do |a|
-          a.create_extend(name: 'E1')
-          a.create_include(name: 'I1')
-          a.create_method(name: 'foo')
+      m = gen.root.create_module('M') do |m|
+        m.create_module('A') do |a|
+          a.create_extend('E1')
+          a.create_include('I1')
+          a.create_method('foo')
         end
-        m.create_module(name: 'A') do |a|
-          a.create_extend(name: 'E2')
-          a.create_include(name: 'I2')
-          a.create_method(name: 'bar')
+        m.create_module('A') do |a|
+          a.create_extend('E2')
+          a.create_include('I2')
+          a.create_method('bar')
         end
       end
 
@@ -210,12 +210,12 @@ RSpec.describe Parlour::ConflictResolver do
   end
 
   it 'handles nested conflicts' do
-    m = gen.root.create_module(name: 'M') do |m|
-      m.create_module(name: 'A') do |a|
-        a.create_method(name: 'foo')
+    m = gen.root.create_module('M') do |m|
+      m.create_module('A') do |a|
+        a.create_method('foo')
       end
-      m.create_module(name: 'A') do |a|
-        a.create_method(name: 'foo')
+      m.create_module('A') do |a|
+        a.create_method('foo')
       end
     end
 

--- a/spec/parameter_spec.rb
+++ b/spec/parameter_spec.rb
@@ -4,52 +4,52 @@ RSpec.describe Parlour::RbiGenerator::Parameter do
   end
 
   it 'determines kinds properly' do
-    expect(pa(name: 'foo').kind).to eq :normal
-    expect(pa(name: '*foo').kind).to eq :splat
-    expect(pa(name: '**foo').kind).to eq :double_splat
-    expect(pa(name: '&foo').kind).to eq :block
-    expect(pa(name: 'foo:').kind).to eq :keyword
+    expect(pa('foo').kind).to eq :normal
+    expect(pa('*foo').kind).to eq :splat
+    expect(pa('**foo').kind).to eq :double_splat
+    expect(pa('&foo').kind).to eq :block
+    expect(pa('foo:').kind).to eq :keyword
   end
 
   it 'determines #name_without_kind properly' do
-    expect(pa(name: 'foo').name_without_kind).to eq 'foo'
-    expect(pa(name: '*foo').name_without_kind).to eq 'foo'
-    expect(pa(name: '**foo').name_without_kind).to eq 'foo'
-    expect(pa(name: '&foo').name_without_kind).to eq 'foo'
-    expect(pa(name: 'foo:').name_without_kind).to eq 'foo'
+    expect(pa('foo').name_without_kind).to eq 'foo'
+    expect(pa('*foo').name_without_kind).to eq 'foo'
+    expect(pa('**foo').name_without_kind).to eq 'foo'
+    expect(pa('&foo').name_without_kind).to eq 'foo'
+    expect(pa('foo:').name_without_kind).to eq 'foo'
   end
 
   it 'can generate definitions' do
-    expect(pa(name: 'foo').to_def_param).to eq 'foo'
-    expect(pa(name: '*foo').to_def_param).to eq '*foo'
-    expect(pa(name: '**foo').to_def_param).to eq '**foo'
-    expect(pa(name: '&foo').to_def_param).to eq '&foo'
-    expect(pa(name: 'foo:').to_def_param).to eq 'foo:'
+    expect(pa('foo').to_def_param).to eq 'foo'
+    expect(pa('*foo').to_def_param).to eq '*foo'
+    expect(pa('**foo').to_def_param).to eq '**foo'
+    expect(pa('&foo').to_def_param).to eq '&foo'
+    expect(pa('foo:').to_def_param).to eq 'foo:'
 
-    expect(pa(name: 'foo', default: '3').to_def_param).to eq 'foo = 3'
-    expect(pa(name: 'foo:', default: '3').to_def_param).to eq 'foo: 3'
+    expect(pa('foo', default: '3').to_def_param).to eq 'foo = 3'
+    expect(pa('foo:', default: '3').to_def_param).to eq 'foo: 3'
   end
 
   it 'can generate signatures' do
-    expect(pa(name: 'foo').to_sig_param).to eq 'foo: T.untyped'
-    expect(pa(name: '*foo').to_sig_param).to eq 'foo: T.untyped'
-    expect(pa(name: '**foo').to_sig_param).to eq 'foo: T.untyped'
-    expect(pa(name: '&foo').to_sig_param).to eq 'foo: T.untyped'
-    expect(pa(name: 'foo:').to_sig_param).to eq 'foo: T.untyped'
+    expect(pa('foo').to_sig_param).to eq 'foo: T.untyped'
+    expect(pa('*foo').to_sig_param).to eq 'foo: T.untyped'
+    expect(pa('**foo').to_sig_param).to eq 'foo: T.untyped'
+    expect(pa('&foo').to_sig_param).to eq 'foo: T.untyped'
+    expect(pa('foo:').to_sig_param).to eq 'foo: T.untyped'
 
-    expect(pa(name: 'foo', type: 'Integer', default: '3').to_sig_param).to eq 'foo: Integer'
+    expect(pa('foo', type: 'Integer', default: '3').to_sig_param).to eq 'foo: Integer'
   end
 
   it 'can generate various types of defaults' do
-    expect(pa(name: 'foo:', default: '5').to_def_param).to eq 'foo: 5'
-    expect(pa(name: 'foo:', default: "'bar'").to_def_param).to eq "foo: 'bar'"
-    expect(pa(name: 'foo:', default: '\'bar\'').to_def_param).to eq "foo: 'bar'"
-    expect(pa(name: 'foo:', default: ':bar').to_def_param).to eq "foo: :bar"
-    expect(pa(name: 'foo:', default: ":'bar'").to_def_param).to eq "foo: :'bar'"
-    expect(pa(name: 'foo:', default: 'nil').to_def_param).to eq "foo: nil"
-    expect(pa(name: 'foo:', default: '3.14159').to_def_param).to eq "foo: 3.14159"
-    expect(pa(name: 'foo:', default: 'true').to_def_param).to eq "foo: true"
-    expect(pa(name: 'foo:', default: '{ key: "value", key2: "value" }').to_def_param).to eq 'foo: { key: "value", key2: "value" }'
-    expect(pa(name: 'foo:', default: '[1, 2, 3]').to_def_param).to eq 'foo: [1, 2, 3]'
+    expect(pa('foo:', default: '5').to_def_param).to eq 'foo: 5'
+    expect(pa('foo:', default: "'bar'").to_def_param).to eq "foo: 'bar'"
+    expect(pa('foo:', default: '\'bar\'').to_def_param).to eq "foo: 'bar'"
+    expect(pa('foo:', default: ':bar').to_def_param).to eq "foo: :bar"
+    expect(pa('foo:', default: ":'bar'").to_def_param).to eq "foo: :'bar'"
+    expect(pa('foo:', default: 'nil').to_def_param).to eq "foo: nil"
+    expect(pa('foo:', default: '3.14159').to_def_param).to eq "foo: 3.14159"
+    expect(pa('foo:', default: 'true').to_def_param).to eq "foo: true"
+    expect(pa('foo:', default: '{ key: "value", key2: "value" }').to_def_param).to eq 'foo: { key: "value", key2: "value" }'
+    expect(pa('foo:', default: '[1, 2, 3]').to_def_param).to eq 'foo: [1, 2, 3]'
   end
 end

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Parlour::RbiGenerator do
 
   context 'module namespace' do
     it 'generates an empty module correctly' do
-      mod = subject.root.create_module(name: 'Foo')
+      mod = subject.root.create_module('Foo')
 
       expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
         module Foo
@@ -35,7 +35,7 @@ RSpec.describe Parlour::RbiGenerator do
 
   context 'class namespace' do
     it 'generates an empty class correctly' do
-      klass = subject.root.create_class(name: 'Foo')
+      klass = subject.root.create_class('Foo')
 
       expect(klass.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
         class Foo
@@ -44,16 +44,16 @@ RSpec.describe Parlour::RbiGenerator do
     end
 
     it 'nests classes correctly' do
-      klass = subject.root.create_class(name: 'Foo') do |foo|
-        foo.create_class(name: 'Bar') do |bar|
-          bar.create_class(name: 'A')
-          bar.create_class(name: 'B')
-          bar.create_class(name: 'C')
+      klass = subject.root.create_class('Foo') do |foo|
+        foo.create_class('Bar') do |bar|
+          bar.create_class('A')
+          bar.create_class('B')
+          bar.create_class('C')
         end
-        foo.create_class(name: 'Baz') do |baz|
-          baz.create_class(name: 'A')
-          baz.create_class(name: 'B')
-          baz.create_class(name: 'C')
+        foo.create_class('Baz') do |baz|
+          baz.create_class('A')
+          baz.create_class('B')
+          baz.create_class('C')
         end
       end
 
@@ -85,11 +85,11 @@ RSpec.describe Parlour::RbiGenerator do
     end
 
     it 'handles abstract' do
-      klass = subject.root.create_class(name: 'Foo') do |foo|
-        foo.create_class(name: 'Bar', abstract: true) do |bar|
-          bar.create_class(name: 'A')
-          bar.create_class(name: 'B')
-          bar.create_class(name: 'C')
+      klass = subject.root.create_class('Foo') do |foo|
+        foo.create_class('Bar', abstract: true) do |bar|
+          bar.create_class('A')
+          bar.create_class('B')
+          bar.create_class('C')
         end
       end
 
@@ -112,16 +112,16 @@ RSpec.describe Parlour::RbiGenerator do
     end
 
     it 'handles includes, extends and constants' do
-      klass = subject.root.create_class(name: 'Foo') do |foo|
-        foo.create_class(name: 'Bar', abstract: true) do |bar|
-          bar.create_extend(name:  'X')
-          bar.create_extend(name:  'Y')
-          bar.create_include(name:  'Z')
-          bar.create_constant(name: 'PI', value: '3.14')
-          bar.create_constant(name: 'Text', value: 'T.type_alias(T.any(String, Symbol))')
-          bar.create_class(name: 'A')
-          bar.create_class(name: 'B')
-          bar.create_class(name: 'C')
+      klass = subject.root.create_class('Foo') do |foo|
+        foo.create_class('Bar', abstract: true) do |bar|
+          bar.create_extend( 'X')
+          bar.create_extend( 'Y')
+          bar.create_include( 'Z')
+          bar.create_constant('PI', value: '3.14')
+          bar.create_constant('Text', value: 'T.type_alias(T.any(String, Symbol))')
+          bar.create_class('A')
+          bar.create_class('B')
+          bar.create_class('C')
         end
       end
 
@@ -150,7 +150,7 @@ RSpec.describe Parlour::RbiGenerator do
     end
 
     it 'handles multiple includes and extends' do
-      klass = subject.root.create_class(name: 'Foo') do |foo|
+      klass = subject.root.create_class('Foo') do |foo|
         foo.create_extends(['X', 'Y', 'Z'])
         foo.create_includes(['A', 'B', 'C'])
       end
@@ -170,24 +170,24 @@ RSpec.describe Parlour::RbiGenerator do
 
   context 'methods' do
     it 'have working equality' do
-      expect(subject.root.create_method(name: 'foo')).to eq \
-        subject.root.create_method(name: 'foo')
+      expect(subject.root.create_method('foo')).to eq \
+        subject.root.create_method('foo')
 
-      expect(subject.root.create_method(name: 'foo', parameters: [
-        pa(name: 'a', type: 'Integer', default: '4')
-      ], return_type: 'String')).to eq subject.root.create_method(name: 'foo', parameters: [
-        pa(name: 'a', type: 'Integer', default: '4')
+      expect(subject.root.create_method('foo', parameters: [
+        pa('a', type: 'Integer', default: '4')
+      ], return_type: 'String')).to eq subject.root.create_method('foo', parameters: [
+        pa('a', type: 'Integer', default: '4')
       ], return_type: 'String')
 
-      expect(subject.root.create_method(name: 'foo', parameters: [
-        pa(name: 'a', type: 'Integer', default: '4')
-      ], return_type: 'String')).not_to eq subject.root.create_method(name: 'foo', parameters: [
-        pa(name: 'a', type: 'Integer', default: '5')
+      expect(subject.root.create_method('foo', parameters: [
+        pa('a', type: 'Integer', default: '4')
+      ], return_type: 'String')).not_to eq subject.root.create_method('foo', parameters: [
+        pa('a', type: 'Integer', default: '5')
       ], return_type: 'String')
     end
 
     it 'can be created blank' do
-      meth = subject.root.create_method(name: 'foo')
+      meth = subject.root.create_method('foo')
 
       expect(meth.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
         sig { void }
@@ -196,7 +196,7 @@ RSpec.describe Parlour::RbiGenerator do
     end
 
     it 'can be created with return types' do
-      meth = subject.root.create_method(name: 'foo', return_type: 'String')
+      meth = subject.root.create_method('foo', return_type: 'String')
 
       expect(meth.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
         sig { returns(String) }
@@ -205,19 +205,19 @@ RSpec.describe Parlour::RbiGenerator do
     end
 
     it 'can accept keyword alias for return types' do
-      expect(subject.root.create_method(name: 'foo', returns: 'String')).to eq \
-        subject.root.create_method(name: 'foo', return_type: 'String')
+      expect(subject.root.create_method('foo', returns: 'String')).to eq \
+        subject.root.create_method('foo', return_type: 'String')
     end
 
     it 'cannot accept both returns: and return_type:' do
       expect do
-        subject.root.create_method(name: 'foo', returns: 'String', return_type: 'String')
+        subject.root.create_method('foo', returns: 'String', return_type: 'String')
       end.to raise_error
     end
  
     it 'can be created with parameters' do
-      meth = subject.root.create_method(name: 'foo', parameters: [
-        pa(name: 'a', type: 'Integer', default: '4')
+      meth = subject.root.create_method('foo', parameters: [
+        pa('a', type: 'Integer', default: '4')
       ], return_type: 'String')
 
       expect(meth.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
@@ -225,11 +225,11 @@ RSpec.describe Parlour::RbiGenerator do
         def foo(a = 4); end
       RUBY
 
-      meth = subject.root.create_method(name: 'bar', parameters: [
-        pa(name: 'a'),
-        pa(name: 'b', type: 'String'),
-        pa(name: 'c', default: '3'),
-        pa(name: 'd', type: 'Integer', default: '4')
+      meth = subject.root.create_method('bar', parameters: [
+        pa('a'),
+        pa('b', type: 'String'),
+        pa('c', default: '3'),
+        pa('d', type: 'Integer', default: '4')
       ], return_type: nil)
 
       expect(meth.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
@@ -246,8 +246,8 @@ RSpec.describe Parlour::RbiGenerator do
     end
 
     it 'can be created with qualifiers' do
-      meth = subject.root.create_method(name: 'foo', parameters: [
-        pa(name: 'a', type: 'Integer', default: '4')
+      meth = subject.root.create_method('foo', parameters: [
+        pa('a', type: 'Integer', default: '4')
       ], return_type: 'String', implementation: true, overridable: true)
 
       expect(meth.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
@@ -257,8 +257,8 @@ RSpec.describe Parlour::RbiGenerator do
     end
 
     it 'supports class methods' do
-      meth = subject.root.create_method(name: 'foo', parameters: [
-        pa(name: 'a', type: 'Integer', default: '4')
+      meth = subject.root.create_method('foo', parameters: [
+        pa('a', type: 'Integer', default: '4')
       ], return_type: 'String', class_method: true)
 
       expect(meth.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
@@ -270,10 +270,10 @@ RSpec.describe Parlour::RbiGenerator do
 
   context 'attributes' do
     it 'can be created using #create_attribute' do
-      mod = subject.root.create_module(name: 'M') do |m|
-        m.create_attribute(name: 'r', kind: :reader, type: 'String')
-        m.create_attribute(name: 'w', kind: :writer, type: 'Integer')
-        m.create_attr(name: 'a', kind: :accessor, type: 'T::Boolean') # test alias too
+      mod = subject.root.create_module('M') do |m|
+        m.create_attribute('r', kind: :reader, type: 'String')
+        m.create_attribute('w', kind: :writer, type: 'Integer')
+        m.create_attr('a', kind: :accessor, type: 'T::Boolean') # test alias too
       end
 
       expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
@@ -291,10 +291,10 @@ RSpec.describe Parlour::RbiGenerator do
     end
 
     it 'can be created using #create_attr_writer etc' do
-      mod = subject.root.create_module(name: 'M') do |m|
-        m.create_attr_reader(name: 'r', type: 'String')
-        m.create_attr_writer(name: 'w', type: 'Integer')
-        m.create_attr_accessor(name: 'a', type: 'T::Boolean')
+      mod = subject.root.create_module('M') do |m|
+        m.create_attr_reader('r', type: 'String')
+        m.create_attr_writer('w', type: 'Integer')
+        m.create_attr_accessor('a', type: 'T::Boolean')
       end
 
       expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
@@ -314,9 +314,9 @@ RSpec.describe Parlour::RbiGenerator do
 
   context 'arbitrary code' do
     it 'is generated correctly for single lines' do
-      mod = subject.root.create_module(name: 'M') do |m|
+      mod = subject.root.create_module('M') do |m|
         m.create_arbitrary(code: 'some_call')
-        m.create_method(name: 'foo')
+        m.create_method('foo')
       end
 
       expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
@@ -330,9 +330,9 @@ RSpec.describe Parlour::RbiGenerator do
     end
 
     it 'is generated correctly for multiple lines' do
-      mod = subject.root.create_module(name: 'M') do |m|
+      mod = subject.root.create_module('M') do |m|
         m.create_arbitrary(code: "foo\nbar\nbaz")
-        m.create_method(name: 'foo')
+        m.create_method('foo')
       end
 
       expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
@@ -349,11 +349,11 @@ RSpec.describe Parlour::RbiGenerator do
   end
 
   it 'supports comments' do
-    mod = subject.root.create_module(name: 'M') do |m|
+    mod = subject.root.create_module('M') do |m|
       m.add_comment('This is a module')
-      m.create_class(name: 'A') do |a|
+      m.create_class('A') do |a|
         a.add_comment('This is a class')
-        a.create_method(name: 'foo') do |foo|
+        a.create_method('foo') do |foo|
           foo.add_comment('This is a method')
         end
       end
@@ -373,7 +373,7 @@ RSpec.describe Parlour::RbiGenerator do
   end
 
   it 'supports multi-line comments' do
-    mod = subject.root.create_module(name: 'M') do |m|
+    mod = subject.root.create_module('M') do |m|
       m.add_comment(['This is a', 'multi-line', 'comment'])
     end
 
@@ -388,12 +388,12 @@ RSpec.describe Parlour::RbiGenerator do
 
   it 'supports comments on the next child' do
     subject.root.add_comment_to_next_child('This is a module')
-    mod = subject.root.create_module(name: 'M') do |m|
+    mod = subject.root.create_module('M') do |m|
       m.add_comment('This was added internally')
       m.add_comment_to_next_child('This is a class')
-      m.create_class(name: 'A') do |a|
+      m.create_class('A') do |a|
         a.add_comment_to_next_child('This is a method')
-        a.create_method(name: 'foo')
+        a.create_method('foo')
       end
     end
 
@@ -420,7 +420,7 @@ RSpec.describe Parlour::RbiGenerator do
 
     it 'generates correctly' do
       subject.root.path(::A::B::C) do |c|
-        c.create_method(name: 'foo')
+        c.create_method('foo')
       end
 
       expect(subject.root.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
@@ -436,7 +436,7 @@ RSpec.describe Parlour::RbiGenerator do
     end
 
     it 'throws on a non-root namespace' do
-      expect { subject.root.create_module(name: 'X').path(::A::B::C) { |*| } }.to raise_error(RuntimeError)
+      expect { subject.root.create_module('X').path(::A::B::C) { |*| } }.to raise_error(RuntimeError)
     end
   end
 end


### PR DESCRIPTION
This changes all methods which took a `name:` keyword argument to accept it as their first and only positional argument instead. (Fix #28.)

@connorshea / @manhhung741 - a quick review and/or your comments would be greatly appreciated!



