### PR TITLE
Wrap rescue in a begin-end

### DIFF
--- a/lib/parlour/plugin.rb
+++ b/lib/parlour/plugin.rb
@@ -38,12 +38,14 @@ module Parlour
     # @return [void]
     def self.run_plugins(plugins, generator, allow_failure: true)
       plugins.each do |plugin|
-        puts "=== #{plugin.class.name}"
-        generator.current_plugin = plugin
-        plugin.generate(generator.root)
-      rescue Exception => e
-        raise e unless allow_failure
-        puts "!!! This plugin threw an exception: #{e}"
+        begin
+          puts "=== #{plugin.class.name}"
+          generator.current_plugin = plugin
+          plugin.generate(generator.root)
+        rescue Exception => e
+          raise e unless allow_failure
+          puts "!!! This plugin threw an exception: #{e}"
+        end
       end
     end
 


### PR DESCRIPTION
Sometimes the syntax below isn't accepted
```
plugins.each do |plugin|
rescue
end
```
See error below:
```
[dev@ip-10-0-0-61 v5.2 (model_rbi_plugins *)]$ bundle exec rake rails_rbi:models
rake aborted!
SyntaxError: /home/dev/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/parlour-0.5.1/lib/parlour/plugin.rb:42: syntax error, unexpected keyword_rescue, expecting keyword_end
      rescue Exception => e
            ^
/home/dev/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/parlour-0.5.1/lib/parlour/plugin.rb:59: syntax error, unexpected keyword_end, expecting end-of-input
```

That syntax is only a feature of Ruby 2.5
https://blog.bigbinary.com/2017/10/24/ruby-2.5-allows-rescue-inside-do-end-blocks.html