### PR TITLE
Test against more versions of Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,14 @@ before_install:
   - gem install bundler
   - gem install yard
 rvm: 
+  - 2.3
+  - 2.4
+  - 2.5
   - 2.6
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
 after_success:
   - yard
 deploy:

--- a/lib/parlour.rb
+++ b/lib/parlour.rb
@@ -3,6 +3,8 @@ require 'sorbet-runtime'
 
 require 'parlour/version'
 
+require 'parlour/kernel_hack'
+
 require 'parlour/plugin'
 
 require 'parlour/rbi_generator/parameter'
@@ -20,4 +22,3 @@ require 'parlour/rbi_generator/class_namespace'
 require 'parlour/rbi_generator'
 
 require 'parlour/conflict_resolver'
-

--- a/lib/parlour/kernel_hack.rb
+++ b/lib/parlour/kernel_hack.rb
@@ -1,0 +1,6 @@
+module Kernel
+  def yield_self
+    return to_enum(__method__) { 1 } unless block_given?
+    yield self
+  end unless method_defined? :yield_self
+end

--- a/lib/parlour/plugin.rb
+++ b/lib/parlour/plugin.rb
@@ -28,7 +28,7 @@ module Parlour
       registered_plugins[T.must(new_plugin.name)] = new_plugin
     end
 
-    sig { params(plugins: T::Array[Plugin], generator: RbiGenerator).void }
+    sig { params(plugins: T::Array[Plugin], generator: RbiGenerator, allow_failure: T::Boolean).void }
     # Runs an array of plugins on a given generator instance.
     #
     # @param plugins [Array<Plugin>] An array of {Plugin} instances.

--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -525,7 +525,7 @@ module Parlour
       # @param object [RbiObject] The object to move the comments into.
       # @return [void]
       def move_next_comments(object)
-        object.comments.prepend(*@next_comments)
+        object.comments.unshift(*@next_comments)
         @next_comments.clear
       end
     end


### PR DESCRIPTION
I'd like to be able to use Parlour with more versions of Ruby. This change will run spec against different version of Ruby. It might fail on ruby v2.3 and v2.4. We'll fix it before merging this change.