### PR TITLE
Implement strictness preference

### DIFF
--- a/exe/parlour
+++ b/exe/parlour
@@ -71,9 +71,32 @@ command :run do |c|
       choice = ask("?  ", Integer) { |q| q.in = 0..candidates.length }
       choice == 0 ? nil : candidates[choice - 1]
     end
+
+    # Figure out strictness levels
+    requested_strictness_levels = plugin_instances.map do |plugin|
+      s = plugin.strictness.to_s
+      puts "WARNING: Plugin #{plugin.class.name} requested an invalid strictness #{s}" \
+        unless %w[ignore false true strict strong].include?(s)
+      s
+    end.compact
+    unique_strictness_levels = requested_strictness_levels.uniq
+    if unique_strictness_levels.empty?
+      # If no requests were made, just use the default
+      strictness = 'strong' 
+    else
+      # Sort the strictnesses into "strictness order" and pick the weakest
+      strictness = unique_strictness_levels.min_by do |level|
+        %w[ignore false true strict strong].index(level) || Float::INFINITY
+      end
+      if unique_strictness_levels.one?
+        puts Rainbow('Note: ').yellow.bold + "All plugins specified the same strictness level, using it (#{strictness})"
+      else
+        puts Rainbow('Note: ').yellow.bold + "Plugins specified multiple strictness levels, chose the weakest (#{strictness})"
+      end
+    end
  
     # Write the final RBI
-    File.write(configuration[:output_file], gen.rbi)
+    File.write(configuration[:output_file], gen.rbi(strictness))
   end
 end
 

--- a/lib/parlour/plugin.rb
+++ b/lib/parlour/plugin.rb
@@ -60,5 +60,11 @@ module Parlour
     # @param root [RbiGenerator::Namespace] The root {RbiGenerator::Namespace}.
     # @return [void]
     def generate(root); end
+
+    sig { returns(String) }
+    # The strictness level which this plugin would prefer the generated RBI
+    # uses. There is no guarantee that this level will be used if other plugins
+    # request different strictness levels.
+    attr_accessor :strictness
   end
 end

--- a/lib/parlour/plugin.rb
+++ b/lib/parlour/plugin.rb
@@ -63,8 +63,9 @@ module Parlour
 
     sig { returns(String) }
     # The strictness level which this plugin would prefer the generated RBI
-    # uses. There is no guarantee that this level will be used if other plugins
-    # request different strictness levels.
+    # uses. If other plugins request different strictness levels, then the 
+    # lowest strictness will be used, meaning there is no guarantee that this
+    # level will be used.
     attr_accessor :strictness
   end
 end

--- a/lib/parlour/rbi_generator.rb
+++ b/lib/parlour/rbi_generator.rb
@@ -38,12 +38,12 @@ module Parlour
     # @return [Plugin, nil]
     attr_accessor :current_plugin
 
-    sig { returns(String) }
+    sig { params(strictness: String).returns(String) }
     # Returns the complete contents of the generated RBI file as a string.
     #
     # @return [String] The generated RBI file
-    def rbi
-      "# typed: strong\n" + root.generate_rbi(0, options).join("\n")
+    def rbi(strictness = 'strong')
+      "# typed: #{strictness}\n" + root.generate_rbi(0, options).join("\n")
     end
   end
 end

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -440,4 +440,9 @@ RSpec.describe Parlour::RbiGenerator do
       expect { subject.root.create_module('X').path(::A::B::C) { |*| } }.to raise_error(RuntimeError)
     end
   end
+
+  it 'allows a strictness level to be specified' do
+    expect(subject.rbi).to match /^\# typed: strong/
+    expect(subject.rbi('true')).to match /^\# typed: true/
+  end
 end


### PR DESCRIPTION
The `RbiGenerator#rbi` method now takes an optional strictness. Plugins can request a particular strictness, and the weakest strictness requested will be used for the entire RBI file.

Closes #21.

@connorshea / @manhhung741 - quick review would be greatly appreciated!

_(As an aside, why can't I use GitHub's "request reviewers" feature? Nobody appears in the list, even if I type usernames exactly...)_