### PR TITLE
Add class attributes

### DIFF
--- a/lib/parlour/conflict_resolver.rb
+++ b/lib/parlour/conflict_resolver.rb
@@ -50,6 +50,12 @@ module Parlour
             children.all? { |c| c.is_a?(RbiGenerator::Method) } &&
             children.count { |c| T.cast(c, RbiGenerator::Method).class_method } == 1
 
+          # Special case: do we have two attributes, one of which is a class 
+          # attribute and the other isn't? If so, do nothing - this is fine
+          next if children.length == 2 &&
+            children.all? { |c| c.is_a?(RbiGenerator::Attribute) } &&
+            children.count { |c| T.cast(c, RbiGenerator::Attribute).class_attribute } == 1
+
           # We found a conflict!
           # Start by removing all the conflicting items
           children.each do |c|

--- a/lib/parlour/rbi_generator/attribute.rb
+++ b/lib/parlour/rbi_generator/attribute.rb
@@ -9,6 +9,7 @@ module Parlour
           name: String,
           kind: Symbol,
           type: String,
+          class_attribute: T::Boolean,
           block: T.nilable(T.proc.params(x: Method).void)
         ).void
       end
@@ -21,15 +22,18 @@ module Parlour
       #   :accessor.
       # @param type [String] A Sorbet string of this attribute's type, such as
       #   +"String"+ or +"T.untyped"+.
+      # @param class_attribute [Boolean] Whether this attribute belongs to the
+      #   singleton class.
       # @param block A block which the new instance yields itself to.
       # @return [void]
-      def initialize(generator, name, kind, type, &block)
+      def initialize(generator, name, kind, type, class_attribute: false, &block)
         # According to this source: 
         #   https://github.com/sorbet/sorbet/blob/2275752e51604acfb79b30a0a96debc996c089d9/test/testdata/dsl/attr_multi.rb
         # attr_accessor and attr_reader should have: sig { returns(X) }
         # attr_writer :foo should have: sig { params(foo: X).returns(X) }
 
         @kind = kind
+        @class_attribute = class_attribute
         case kind
         when :accessor, :reader
           super(generator, name, [], type, &block)
@@ -46,6 +50,10 @@ module Parlour
       # The kind of attribute this is; one of +:writer+, +:reader+, or +:accessor+.
       # @return [Symbol]
       attr_reader :kind
+
+      sig { returns(T::Boolean) }
+      # Whether this attribute belongs to the singleton class.
+      attr_reader :class_attribute
 
       private
 

--- a/lib/parlour/rbi_generator/attribute.rb
+++ b/lib/parlour/rbi_generator/attribute.rb
@@ -55,6 +55,20 @@ module Parlour
       # Whether this attribute belongs to the singleton class.
       attr_reader :class_attribute
 
+      sig { override.params(other: Object).returns(T::Boolean) }
+      # Returns true if this instance is equal to another attribute.
+      #
+      # @param other [Object] The other instance. If this is not a {Attribute}
+      #   (or a subclass of it), this will always return false.
+      # @return [Boolean]
+      def ==(other)
+        T.must(
+          super(other) && Attribute === other &&
+            kind            == other.kind &&
+            class_attribute == other.class_attribute
+        )
+      end
+
       private
 
       sig do

--- a/lib/parlour/rbi_generator/attribute.rb
+++ b/lib/parlour/rbi_generator/attribute.rb
@@ -10,7 +10,7 @@ module Parlour
           kind: Symbol,
           type: String,
           class_attribute: T::Boolean,
-          block: T.nilable(T.proc.params(x: Method).void)
+          block: T.nilable(T.proc.params(x: Attribute).void)
         ).void
       end
       # Creates a new attribute.

--- a/lib/parlour/rbi_generator/method.rb
+++ b/lib/parlour/rbi_generator/method.rb
@@ -51,7 +51,7 @@ module Parlour
         yield_self(&block) if block
       end
 
-      sig { params(other: Object).returns(T::Boolean) }
+      sig { overridable.params(other: Object).returns(T::Boolean) }
       # Returns true if this instance is equal to another method.
       #
       # @param other [Object] The other instance. If this is not a {Method} (or a

--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -259,6 +259,13 @@ module Parlour
       #   # #=> sig { returns(T::Boolean) }
       #   #     attr_accessor :accessible
       #
+      # @example Create an +attr_accessor+ on the singleton class.
+      #   module.create_attribute('singleton_attr', kind: :accessor, type: 'T::Boolean')
+      #   # #=> class << self
+      #   #       sig { returns(T::Boolean) }
+      #   #       attr_accessor :singleton_attr
+      #   #     end
+      #
       # @param name [String] The name of this attribute.
       # @param kind [Symbol] The kind of attribute this is; one of +:writer+, +:reader+, or
       #   +:accessor+.

--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -264,14 +264,17 @@ module Parlour
       #   +:accessor+.
       # @param type [String] A Sorbet string of this attribute's type, such as
       #   +"String"+ or +"T.untyped"+.
+      # @param class_attribute [Boolean] Whether this attribute belongs to the
+      #   singleton class.
       # @param block A block which the new instance yields itself to.
       # @return [RbiGenerator::Attribute]
-      def create_attribute(name, kind:, type:, &block)
+      def create_attribute(name, kind:, type:, class_attribute: false, &block)
         new_attribute = RbiGenerator::Attribute.new(
           generator,
           name,
           kind,
           type,
+          class_attribute: class_attribute,
           &block
         )
         move_next_comments(new_attribute)
@@ -285,10 +288,12 @@ module Parlour
       # @param name [String] The name of this attribute.
       # @param type [String] A Sorbet string of this attribute's type, such as
       #   +"String"+ or +"T.untyped"+.
+      # @param class_attribute [Boolean] Whether this attribute belongs to the
+      #   singleton class.
       # @param block A block which the new instance yields itself to.
       # @return [RbiGenerator::Attribute]
-      def create_attr_reader(name, type:, &block)
-        create_attribute(name, kind: :reader, type: type, &block)
+      def create_attr_reader(name, type:, class_attribute: false, &block)
+        create_attribute(name, kind: :reader, type: type, class_attribute: class_attribute, &block)
       end
 
       # Creates a new write-only attribute (+attr_writer+).
@@ -296,10 +301,12 @@ module Parlour
       # @param name [String] The name of this attribute.
       # @param type [String] A Sorbet string of this attribute's type, such as
       #   +"String"+ or +"T.untyped"+.
+      # @param class_attribute [Boolean] Whether this attribute belongs to the
+      #   singleton class.
       # @param block A block which the new instance yields itself to.
       # @return [RbiGenerator::Attribute]
-      def create_attr_writer(name, type:, &block)
-        create_attribute(name, kind: :writer, type: type, &block)
+      def create_attr_writer(name, type:, class_attribute: false, &block)
+        create_attribute(name, kind: :writer, type: type, class_attribute: class_attribute, &block)
       end
 
       # Creates a new read and write attribute (+attr_accessor+).
@@ -307,10 +314,12 @@ module Parlour
       # @param name [String] The name of this attribute.
       # @param type [String] A Sorbet string of this attribute's type, such as
       #   +"String"+ or +"T.untyped"+.
+      # @param class_attribute [Boolean] Whether this attribute belongs to the
+      #   singleton class.
       # @param block A block which the new instance yields itself to.
       # @return [RbiGenerator::Attribute]
-      def create_attr_accessor(name, type:, &block)
-        create_attribute(name, kind: :accessor, type: type, &block)
+      def create_attr_accessor(name, type:, class_attribute: false, &block)
+        create_attribute(name, kind: :accessor, type: type, class_attribute: class_attribute, &block)
       end
 
       # Creates a new arbitrary code section.

--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -242,6 +242,15 @@ module Parlour
         new_method
       end
 
+      sig do
+        params(
+          name: String,
+          kind: Symbol,
+          type: String,
+          class_attribute: T::Boolean,
+          block: T.nilable(T.proc.params(x: Attribute).void)
+        ).returns(Attribute)
+      end
       # Creates a new attribute.
       #
       # @example Create an +attr_reader+.
@@ -290,6 +299,14 @@ module Parlour
       end
       alias_method :create_attr, :create_attribute
 
+      sig do
+        params(
+          name: String,
+          type: String,
+          class_attribute: T::Boolean,
+          block: T.nilable(T.proc.params(x: Attribute).void)
+        ).returns(Attribute)
+      end
       # Creates a new read-only attribute (+attr_reader+).
       #
       # @param name [String] The name of this attribute.
@@ -303,6 +320,14 @@ module Parlour
         create_attribute(name, kind: :reader, type: type, class_attribute: class_attribute, &block)
       end
 
+      sig do
+        params(
+          name: String,
+          type: String,
+          class_attribute: T::Boolean,
+          block: T.nilable(T.proc.params(x: Attribute).void)
+        ).returns(Attribute)
+      end
       # Creates a new write-only attribute (+attr_writer+).
       #
       # @param name [String] The name of this attribute.
@@ -316,6 +341,14 @@ module Parlour
         create_attribute(name, kind: :writer, type: type, class_attribute: class_attribute, &block)
       end
 
+      sig do
+        params(
+          name: String,
+          type: String,
+          class_attribute: T::Boolean,
+          block: T.nilable(T.proc.params(x: Attribute).void)
+        ).returns(Attribute)
+      end
       # Creates a new read and write attribute (+attr_accessor+).
       #
       # @param name [String] The name of this attribute.

--- a/spec/conflict_resolver_spec.rb
+++ b/spec/conflict_resolver_spec.rb
@@ -242,4 +242,17 @@ RSpec.describe Parlour::ConflictResolver do
     expect(m.children.first.children.length).to be 1
     expect(m.children.first.children.first.name).to eq 'foo'
   end
+
+  it 'does not conflict between instance attributes and class attributes' do
+    a = gen.root.create_class('A') do |a|
+      a.create_attr_accessor('foo', type: 'String', class_attribute: true)
+      a.create_attr_accessor('foo', type: 'String')
+    end
+
+    expect(a.children.length).to be 2
+
+    subject.resolve_conflicts(a) { |*| raise 'unable to resolve automatically' }
+
+    expect(a.children.length).to be 2
+  end
 end

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -311,6 +311,29 @@ RSpec.describe Parlour::RbiGenerator do
         end
       RUBY
     end
+
+    it 'supports class attributes' do
+      mod = subject.root.create_class('A') do |m|
+        m.create_attr_accessor('a', type: 'String', class_attribute: true)
+        m.create_attr_accessor('b', type: 'Integer')
+        m.create_attr_accessor('c', type: 'T::Boolean', class_attribute: true)
+      end
+
+      expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
+        class A
+          class << self
+            sig { returns(String) }
+            attr_accessor :a
+
+            sig { returns(T::Boolean) }
+            attr_accessor :c
+          end
+
+          sig { returns(Integer) }
+          attr_accessor :b
+        end
+      RUBY
+    end
   end
 
   context 'arbitrary code' do


### PR DESCRIPTION
This adds support for attributes wrapped in a `class << self` block, which closes #42.

(Also, my Git name was _still_ `=` - I think it's sorted now...)

This touches quite a few files, so review would be appreciated!