### PR TITLE
Implement final methods

### DIFF
--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -199,6 +199,7 @@ module Parlour
           override: T::Boolean,
           overridable: T::Boolean,
           class_method: T::Boolean,
+          final: T::Boolean,
           block: T.nilable(T.proc.params(x: Method).void)
         ).returns(Method)
       end
@@ -219,9 +220,10 @@ module Parlour
       # @param overridable [Boolean] Whether this method is overridable by subclasses.
       # @param class_method [Boolean] Whether this method is a class method; that is, it
       #   it is defined using +self.+.
+      # @param final [Boolean] Whether this method is final.
       # @param block A block which the new instance yields itself to.
       # @return [Method]
-      def create_method(name, parameters: nil, return_type: nil, returns: nil, abstract: false, implementation: false, override: false, overridable: false, class_method: false, &block)
+      def create_method(name, parameters: nil, return_type: nil, returns: nil, abstract: false, implementation: false, override: false, overridable: false, class_method: false, final: false, &block)
         parameters = parameters || []
         raise 'cannot specify both return_type: and returns:' if return_type && returns
         return_type ||= returns
@@ -231,10 +233,11 @@ module Parlour
           parameters,
           return_type,
           abstract: abstract,
-          implementation: implementation, 
+          implementation: implementation,
           override: override,
           overridable: overridable,
           class_method: class_method,
+          final: final,
           &block
         )
         move_next_comments(new_method)

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -267,6 +267,17 @@ RSpec.describe Parlour::RbiGenerator do
         def self.foo(a = 4); end
       RUBY
     end
+
+    it 'can be final' do
+      meth = subject.root.create_method('foo', parameters: [
+        pa('a', type: 'Integer', default: '4')
+      ], return_type: 'String', final: true)
+
+      expect(meth.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
+        sig(:final) { params(a: Integer).returns(String) }
+        def foo(a = 4); end
+      RUBY
+    end
   end
 
   context 'attributes' do


### PR DESCRIPTION
Adds support for final methods using `sig(:final)`.

Closes #44.