### PR TITLE
Implement type parameter support

### DIFF
--- a/lib/parlour/rbi_generator/method.rb
+++ b/lib/parlour/rbi_generator/method.rb
@@ -16,6 +16,7 @@ module Parlour
           override: T::Boolean,
           overridable: T::Boolean,
           class_method: T::Boolean,
+          type_parameters: T.nilable(T::Array[Symbol]),
           block: T.nilable(T.proc.params(x: Method).void)
         ).void
       end
@@ -37,9 +38,10 @@ module Parlour
       # @param overridable [Boolean] Whether this method is overridable by subclasses.
       # @param class_method [Boolean] Whether this method is a class method; that is, it
       #   it is defined using +self.+.
+      # @param class_method [Array<Symbol>, nil] This method's type parameters.
       # @param block A block which the new instance yields itself to.
       # @return [void]
-      def initialize(generator, name, parameters, return_type = nil, abstract: false, implementation: false, override: false, overridable: false, class_method: false, &block)
+      def initialize(generator, name, parameters, return_type = nil, abstract: false, implementation: false, override: false, overridable: false, class_method: false, type_parameters: nil, &block)
         super(generator, name)
         @parameters = parameters
         @return_type = return_type
@@ -48,6 +50,7 @@ module Parlour
         @override = override
         @overridable = overridable
         @class_method = class_method
+        @type_parameters = type_parameters || []
         yield_self(&block) if block
       end
 
@@ -59,14 +62,15 @@ module Parlour
       # @return [Boolean]
       def ==(other)
         Method === other &&
-          name           == other.name && 
-          parameters     == other.parameters &&
-          return_type    == other.return_type &&
-          abstract       == other.abstract &&
-          implementation == other.implementation &&
-          override       == other.override &&
-          overridable    == other.overridable &&
-          class_method   == other.class_method
+          name            == other.name && 
+          parameters      == other.parameters &&
+          return_type     == other.return_type &&
+          abstract        == other.abstract &&
+          implementation  == other.implementation &&
+          override        == other.override &&
+          overridable     == other.overridable &&
+          class_method    == other.class_method &&
+          type_parameters == other.type_parameters
       end
 
       sig { returns(T::Array[Parameter]) }
@@ -105,6 +109,11 @@ module Parlour
       # +self.+.
       # @return [Boolean]
       attr_reader :class_method
+
+      sig { returns(T::Array[Symbol]) }
+      # This method's type parameters.
+      # @return [Array<Symbol>]
+      attr_reader :type_parameters
 
       sig do
         implementation.params(
@@ -231,6 +240,9 @@ module Parlour
         result += 'implementation.' if implementation
         result += 'override.' if override
         result += 'overridable.' if overridable
+        result += "type_parameters(#{
+          type_parameters.map { |t| ":#{t}" }.join(', ')
+        })." if type_parameters.any?
         result
       end
     end

--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -199,6 +199,7 @@ module Parlour
           override: T::Boolean,
           overridable: T::Boolean,
           class_method: T::Boolean,
+          type_parameters: T.nilable(T::Array[Symbol]),
           block: T.nilable(T.proc.params(x: Method).void)
         ).returns(Method)
       end
@@ -219,9 +220,10 @@ module Parlour
       # @param overridable [Boolean] Whether this method is overridable by subclasses.
       # @param class_method [Boolean] Whether this method is a class method; that is, it
       #   it is defined using +self.+.
+      # @param class_method [Array<Symbol>, nil] This method's type parameters.
       # @param block A block which the new instance yields itself to.
       # @return [Method]
-      def create_method(name, parameters: nil, return_type: nil, returns: nil, abstract: false, implementation: false, override: false, overridable: false, class_method: false, &block)
+      def create_method(name, parameters: nil, return_type: nil, returns: nil, abstract: false, implementation: false, override: false, overridable: false, class_method: false, type_parameters: nil, &block)
         parameters = parameters || []
         raise 'cannot specify both return_type: and returns:' if return_type && returns
         return_type ||= returns
@@ -235,6 +237,7 @@ module Parlour
           override: override,
           overridable: overridable,
           class_method: class_method,
+          type_parameters: type_parameters,
           &block
         )
         move_next_comments(new_method)

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -267,6 +267,17 @@ RSpec.describe Parlour::RbiGenerator do
         def self.foo(a = 4); end
       RUBY
     end
+
+    it 'supports type parameters' do
+      meth = subject.root.create_method('box', type_parameters: [:A], parameters: [
+        pa('a', type: 'T.type_parameter(:A)')
+      ], return_type: 'T::Array[T.type_parameter(:A)]')
+
+      expect(meth.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
+        sig { type_parameters(:A).params(a: T.type_parameter(:A)).returns(T::Array[T.type_parameter(:A)]) }
+        def box(a); end
+      RUBY
+    end
   end
 
   context 'attributes' do


### PR DESCRIPTION
This implements support for type parameters in methods, using the `type_parameters` modifier in a `sig` before `params`.

Closes #41.