### PR TITLE
Disable typechecking for `Method#==` to improve performance.

### DIFF
--- a/lib/parlour/rbi_generator/method.rb
+++ b/lib/parlour/rbi_generator/method.rb
@@ -54,7 +54,7 @@ module Parlour
         yield_self(&block) if block
       end
 
-      sig { overridable.params(other: Object).returns(T::Boolean) }
+      sig { overridable.params(other: Object).returns(T::Boolean).checked(:never) }
       # Returns true if this instance is equal to another method.
       #
       # @param other [Object] The other instance. If this is not a {Method} (or a


### PR DESCRIPTION
On my Rails app it takes 2m4s to run `bundle exec rake rails_rbi:all` with typechecking enabled for `Parlour::RbiGenerator::Method#==`, and 1m4s without it. The reason I noticed this problem is because I added a bunch of metaprogramming-created methods to sorbet-rails, and it started to become annoyingly slow.

This is because once you add enough methods to a module/class, the number of comparisons that occurs grows (I think?) exponentially.

This makes Parlour spend a lot of time in the resolve conflicts stage. Based on profiling the rake task, there were >8.6 million calls to `Method#==`. Once you get to that many calls, I guess typechecking the method becomes a performance bottleneck.

See the docs for `checked`: https://sorbet.org/docs/runtime#checked-whether-to-check-in-the-first-place

I generated [a flamegraph](https://gist.github.com/connorshea/df666a1b5e788b90ba9bac29374bd8e2) from before I made this change, it took too long and I'm too lazy to generate a new one, but I did time how long it took to run the Rake task before/after and compared the difference.