### PR TITLE
Adding missing depdency of Commander

### DIFF
--- a/parlour.gemspec
+++ b/parlour.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sorbet-runtime"
   spec.add_dependency "rainbow", "~> 3.0.0"
+  spec.add_dependency "commander", "~> 4.4.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The distributed exe/parlour requires the commander gem, but it is not listed in your gemspec. This means simply adding parlour to your `Gemfile` is insufficient to use the gem.

This PR adds the current minor version as a dependency.