### PR TITLE
Allow globs in relative require

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Parlour is an RBI generator and merger for Sorbet. It consists of two key parts:
     an intuitive DSL.
 
   - The plugin/build system, which allows multiple Parlour plugins to generate
-    RBIs for the same codebase. These are combined automatically as much as 
+    RBIs for the same codebase. These are combined automatically as much as
     possible, but any other conflicts can be resolved manually through prompts.
 
 ## Why should I use this?
@@ -64,7 +64,7 @@ end
 ```
 
 ### Writing a plugin
-Plugins are better than using the generator alone, as your plugin can be 
+Plugins are better than using the generator alone, as your plugin can be
 combined with others to produce larger RBIs without conflicts.
 
 We could write the above example as a plugin like this:
@@ -102,7 +102,8 @@ output_file: output.rbi
 
 relative_requires:
   - plugin.rb
-  
+  - app/models/*.rb
+
 plugins:
   MyPlugin: {}
 ```
@@ -125,7 +126,7 @@ output_file: output.rbi
 
 requires:
   - parlour-gem
-  
+
 plugins:
   MyPlugin: {}
 ```
@@ -139,7 +140,7 @@ requires:
   - gem1
   - gem2
   - gem3
-  
+
 plugins:
   Gem1::Plugin: {}
   Gem2::Plugin: {}

--- a/exe/parlour
+++ b/exe/parlour
@@ -36,7 +36,9 @@ command :run do |c|
 
     configuration[:requires].each { |source| require(source) }
     configuration[:relative_requires].each do |source|
-      require_relative(File.join(Dir.pwd, source))
+      Dir[File.join(Dir.pwd, source)].each do |file|
+        require_relative(file)
+      end
     end
 
     # Collect the instances of each plugin into an array

--- a/exe/parlour
+++ b/exe/parlour
@@ -84,7 +84,7 @@ command :run do |c|
     unique_strictness_levels = requested_strictness_levels.uniq
     if unique_strictness_levels.empty?
       # If no requests were made, just use the default
-      strictness = 'strong' 
+      strictness = 'strong'
     else
       # Sort the strictnesses into "strictness order" and pick the weakest
       strictness = unique_strictness_levels.min_by do |level|
@@ -96,7 +96,7 @@ command :run do |c|
         puts Rainbow('Note: ').yellow.bold + "Plugins specified multiple strictness levels, chose the weakest (#{strictness})"
       end
     end
- 
+
     # Write the final RBI
     File.write(configuration[:output_file], gen.rbi(strictness))
   end

--- a/sorbet/rbi/hidden-definitions/errors.txt
+++ b/sorbet/rbi/hidden-definitions/errors.txt
@@ -28,7 +28,14 @@
 # wrong constant name <RESERVED_114>
 # wrong constant name <RESERVED_115>
 # wrong constant name <RESERVED_116>
+# wrong constant name <RESERVED_117>
+# wrong constant name <RESERVED_118>
+# wrong constant name <RESERVED_119>
 # wrong constant name <RESERVED_11>
+# wrong constant name <RESERVED_120>
+# wrong constant name <RESERVED_121>
+# wrong constant name <RESERVED_122>
+# wrong constant name <RESERVED_123>
 # wrong constant name <RESERVED_12>
 # wrong constant name <RESERVED_13>
 # wrong constant name <RESERVED_14>
@@ -136,164 +143,465 @@
 # wrong constant name <todo sym>
 # uninitialized constant Abbrev
 # uninitialized constant Abbrev
-# undefined method `[]$2' for class `Array'
-# undefined method `[]=$2' for class `Array'
-# undefined method `concat$1' for class `Array'
-# undefined method `fetch$2' for class `Array'
-# undefined method `fill$2' for class `Array'
-# undefined method `flatten$1' for class `Array'
-# undefined method `index$2' for class `Array'
-# undefined method `initialize$2' for class `Array'
-# Did you mean?  initialize
-# undefined method `insert$1' for class `Array'
-# Did you mean?  inspect
-# undefined method `join$1' for class `Array'
-# undefined method `last$2' for class `Array'
-# undefined method `permutation$2' for class `Array'
-# undefined method `pop$2' for class `Array'
-# undefined method `rindex$2' for class `Array'
-# undefined method `rotate$1' for class `Array'
-# undefined method `rotate!$1' for class `Array'
-# undefined method `sample$2' for class `Array'
-# undefined method `shift$2' for class `Array'
-# undefined method `shuffle$1' for class `Array'
-# undefined method `shuffle!$1' for class `Array'
-# undefined method `slice$2' for class `Array'
-# undefined method `slice!$2' for class `Array'
-# wrong constant name []$2
-# wrong constant name []=$2
-# wrong constant name append
 # wrong constant name bsearch
 # wrong constant name bsearch_index
 # wrong constant name collect!
-# wrong constant name concat$1
-# wrong constant name difference
 # wrong constant name dig
-# wrong constant name fetch$2
-# wrong constant name fill$2
-# wrong constant name filter!
-# wrong constant name flatten$1
 # wrong constant name flatten!
-# wrong constant name index$2
-# wrong constant name initialize$2
-# wrong constant name insert$1
-# wrong constant name join$1
-# wrong constant name last$2
 # wrong constant name pack
-# wrong constant name permutation$2
-# wrong constant name pop$2
-# wrong constant name prepend
 # wrong constant name replace
-# wrong constant name rindex$2
-# wrong constant name rotate$1
-# wrong constant name rotate!$1
-# wrong constant name sample$2
 # wrong constant name shelljoin
-# wrong constant name shift$2
-# wrong constant name shuffle$1
-# wrong constant name shuffle!$1
-# wrong constant name slice$2
-# wrong constant name slice!$2
 # wrong constant name to_h
-# wrong constant name union
 # wrong constant name try_convert
 # uninitialized constant Base64
 # uninitialized constant Base64
+# wrong constant name as_null_object
+# wrong constant name initialize
+# wrong constant name null_object?
+# wrong constant name received_message?
+# wrong constant name should
+# wrong constant name should_not
+# wrong constant name should_not_receive
+# wrong constant name should_receive
+# wrong constant name stub
+# wrong constant name stub_chain
+# wrong constant name unstub
 # wrong constant name <Class:BasicObject>
-# uninitialized constant BasicSocket::APPEND
-# uninitialized constant BasicSocket::BINARY
-# uninitialized constant BasicSocket::CREAT
-# uninitialized constant BasicSocket::DIRECT
-# uninitialized constant BasicSocket::DSYNC
-# Did you mean?  BasicSocket::RSYNC
-#                BasicSocket::SYNC
-# uninitialized constant BasicSocket::EXCL
-# uninitialized constant BasicSocket::FNM_CASEFOLD
-# uninitialized constant BasicSocket::FNM_DOTMATCH
-# uninitialized constant BasicSocket::FNM_EXTGLOB
-# uninitialized constant BasicSocket::FNM_NOESCAPE
-# uninitialized constant BasicSocket::FNM_PATHNAME
-# uninitialized constant BasicSocket::FNM_SHORTNAME
-# uninitialized constant BasicSocket::FNM_SYSCASE
-# uninitialized constant BasicSocket::LOCK_EX
-# Did you mean?  BasicSocket::LOCK_NB
-#                BasicSocket::LOCK_UN
-#                BasicSocket::LOCK_SH
-# uninitialized constant BasicSocket::LOCK_NB
-# Did you mean?  BasicSocket::LOCK_UN
-#                BasicSocket::LOCK_EX
-#                BasicSocket::LOCK_SH
-# uninitialized constant BasicSocket::LOCK_SH
-# Did you mean?  BasicSocket::LOCK_NB
-#                BasicSocket::LOCK_UN
-#                BasicSocket::LOCK_EX
-# uninitialized constant BasicSocket::LOCK_UN
-# Did you mean?  BasicSocket::LOCK_NB
-#                BasicSocket::LOCK_EX
-#                BasicSocket::LOCK_SH
-# uninitialized constant BasicSocket::NOATIME
-# uninitialized constant BasicSocket::NOCTTY
-# uninitialized constant BasicSocket::NOFOLLOW
-# uninitialized constant BasicSocket::NONBLOCK
-# uninitialized constant BasicSocket::NULL
-# uninitialized constant BasicSocket::RDONLY
-# Did you mean?  BasicSocket::WRONLY
-# uninitialized constant BasicSocket::RDWR
-# uninitialized constant BasicSocket::RSYNC
-# Did you mean?  BasicSocket::DSYNC
-#                BasicSocket::SYNC
-# uninitialized constant BasicSocket::SEEK_CUR
-# uninitialized constant BasicSocket::SEEK_DATA
-# Did you mean?  BasicSocket::SEEK_SET
-# uninitialized constant BasicSocket::SEEK_END
-# uninitialized constant BasicSocket::SEEK_HOLE
-# uninitialized constant BasicSocket::SEEK_SET
-# uninitialized constant BasicSocket::SHARE_DELETE
-# uninitialized constant BasicSocket::SYNC
-# Did you mean?  BasicSocket::RSYNC
-#                BasicSocket::DSYNC
-# uninitialized constant BasicSocket::TMPFILE
-# Did you mean?  Tempfile
-# uninitialized constant BasicSocket::TRUNC
-# Did you mean?  TRUE
-# uninitialized constant BasicSocket::WRONLY
-# Did you mean?  BasicSocket::RDONLY
-# wrong constant name read_nonblock
 # uninitialized constant Benchmark
 # uninitialized constant Benchmark
-# undefined method `_dump$1' for class `BigDecimal'
-# undefined method `div$2' for class `BigDecimal'
-# undefined method `power$2' for class `BigDecimal'
-# undefined method `to_s$1' for class `BigDecimal'
-# Did you mean?  to_s
-# wrong constant name _dump$1
 # wrong constant name clone
-# wrong constant name div$2
-# wrong constant name power$2
-# wrong constant name to_s$1
-# undefined singleton method `limit$1' for `BigDecimal'
-# undefined singleton method `mode$1' for `BigDecimal'
-# wrong constant name limit$1
-# wrong constant name mode$1
-# wrong constant name new
+# wrong constant name ver
 # wrong constant name clone
 # wrong constant name irb
-# wrong constant name local_variable_defined?
-# wrong constant name local_variable_get
-# wrong constant name local_variable_set
-# wrong constant name receiver
-# wrong constant name source_location
+# wrong constant name <Class:APIResponseMismatchError>
+# wrong constant name <Class:BuildMetadata>
+# wrong constant name <Class:BundlerError>
+# wrong constant name <Class:CurrentRuby>
+# wrong constant name <Class:CyclicDependencyError>
+# wrong constant name <Class:Definition>
+# wrong constant name <Class:DepProxy>
+# wrong constant name <Class:Dependency>
+# wrong constant name <Class:DeprecatedError>
+# wrong constant name <Class:Dsl>
+# wrong constant name <Class:EndpointSpecification>
+# wrong constant name <Class:Env>
+# wrong constant name <Class:EnvironmentPreserver>
+# wrong constant name <Class:FeatureFlag>
+# wrong constant name <Class:Fetcher>
+# wrong constant name <Class:FileUtils>
+# wrong constant name <Class:GemHelper>
+# wrong constant name <Class:GemHelpers>
+# wrong constant name <Class:GemNotFound>
+# wrong constant name <Class:GemRemoteFetcher>
+# wrong constant name <Class:GemRequireError>
+# wrong constant name <Class:GemVersionPromoter>
+# wrong constant name <Class:GemfileError>
+# wrong constant name <Class:GemfileEvalError>
+# wrong constant name <Class:GemfileLockNotFound>
+# wrong constant name <Class:GemfileNotFound>
+# wrong constant name <Class:GemspecError>
+# wrong constant name <Class:GenericSystemCallError>
+# wrong constant name <Class:GitError>
+# wrong constant name <Class:Graph>
+# wrong constant name <Class:HTTPError>
+# wrong constant name <Class:Index>
+# wrong constant name <Class:Injector>
+# wrong constant name <Class:InstallError>
+# wrong constant name <Class:InstallHookError>
+# wrong constant name <Class:Installer>
+# wrong constant name <Class:InvalidOption>
+# wrong constant name <Class:LazySpecification>
+# wrong constant name <Class:LockfileError>
+# wrong constant name <Class:LockfileParser>
+# wrong constant name <Class:MarshalError>
+# wrong constant name <Class:MatchPlatform>
+# wrong constant name <Class:Molinillo>
+# wrong constant name <Class:NoSpaceOnDeviceError>
+# wrong constant name <Class:OperationNotSupportedError>
+# wrong constant name <Class:PathError>
+# wrong constant name <Class:PermissionError>
+# wrong constant name <Class:Plugin>
+# wrong constant name <Class:PluginError>
+# wrong constant name <Class:ProcessLock>
+# wrong constant name <Class:ProductionError>
+# wrong constant name <Class:RemoteSpecification>
+# wrong constant name <Class:Resolver>
+# wrong constant name <Class:Retry>
+# wrong constant name <Class:RubyDsl>
+# wrong constant name <Class:RubyGemsGemInstaller>
+# wrong constant name <Class:RubyVersion>
+# wrong constant name <Class:RubyVersionMismatch>
+# wrong constant name <Class:RubygemsIntegration>
+# wrong constant name <Class:Runtime>
+# wrong constant name <Class:SecurityError>
+# wrong constant name <Class:Settings>
+# wrong constant name <Class:SharedHelpers>
+# wrong constant name <Class:Source>
+# wrong constant name <Class:SourceList>
+# wrong constant name <Class:SpecSet>
+# wrong constant name <Class:StubSpecification>
+# wrong constant name <Class:SudoNotPermittedError>
+# wrong constant name <Class:TemporaryResourceError>
+# wrong constant name <Class:ThreadCreationError>
+# wrong constant name <Class:UI>
+# wrong constant name <Class:URICredentialsFilter>
+# wrong constant name <Class:VersionConflict>
+# wrong constant name <Class:VersionRanges>
+# wrong constant name <Class:VirtualProtocolError>
+# wrong constant name <Class:YAMLSerializer>
+# wrong constant name <Class:YamlSyntaxError>
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name built_at
+# wrong constant name git_commit_sha
+# wrong constant name release?
+# wrong constant name to_h
+# wrong constant name <static-init>
+# wrong constant name all_errors
+# wrong constant name status_code
+# wrong constant name jruby?
+# wrong constant name jruby_18?
+# wrong constant name jruby_19?
+# wrong constant name jruby_1?
+# wrong constant name jruby_20?
+# wrong constant name jruby_21?
+# wrong constant name jruby_22?
+# wrong constant name jruby_23?
+# wrong constant name jruby_24?
+# wrong constant name jruby_25?
+# wrong constant name jruby_26?
+# wrong constant name jruby_27?
+# wrong constant name jruby_2?
+# wrong constant name maglev?
+# wrong constant name maglev_18?
+# wrong constant name maglev_19?
+# wrong constant name maglev_1?
+# wrong constant name maglev_20?
+# wrong constant name maglev_21?
+# wrong constant name maglev_22?
+# wrong constant name maglev_23?
+# wrong constant name maglev_24?
+# wrong constant name maglev_25?
+# wrong constant name maglev_26?
+# wrong constant name maglev_27?
+# wrong constant name maglev_2?
+# wrong constant name mingw?
+# wrong constant name mingw_18?
+# wrong constant name mingw_19?
+# wrong constant name mingw_1?
+# wrong constant name mingw_20?
+# wrong constant name mingw_21?
+# wrong constant name mingw_22?
+# wrong constant name mingw_23?
+# wrong constant name mingw_24?
+# wrong constant name mingw_25?
+# wrong constant name mingw_26?
+# wrong constant name mingw_27?
+# wrong constant name mingw_2?
+# wrong constant name mri?
+# wrong constant name mri_18?
+# wrong constant name mri_19?
+# wrong constant name mri_1?
+# wrong constant name mri_20?
+# wrong constant name mri_21?
+# wrong constant name mri_22?
+# wrong constant name mri_23?
+# wrong constant name mri_24?
+# wrong constant name mri_25?
+# wrong constant name mri_26?
+# wrong constant name mri_27?
+# wrong constant name mri_2?
+# wrong constant name mswin64?
+# wrong constant name mswin64_18?
+# wrong constant name mswin64_19?
+# wrong constant name mswin64_1?
+# wrong constant name mswin64_20?
+# wrong constant name mswin64_21?
+# wrong constant name mswin64_22?
+# wrong constant name mswin64_23?
+# wrong constant name mswin64_24?
+# wrong constant name mswin64_25?
+# wrong constant name mswin64_26?
+# wrong constant name mswin64_27?
+# wrong constant name mswin64_2?
+# wrong constant name mswin?
+# wrong constant name mswin_18?
+# wrong constant name mswin_19?
+# wrong constant name mswin_1?
+# wrong constant name mswin_20?
+# wrong constant name mswin_21?
+# wrong constant name mswin_22?
+# wrong constant name mswin_23?
+# wrong constant name mswin_24?
+# wrong constant name mswin_25?
+# wrong constant name mswin_26?
+# wrong constant name mswin_27?
+# wrong constant name mswin_2?
+# wrong constant name on_18?
+# wrong constant name on_19?
+# wrong constant name on_1?
+# wrong constant name on_20?
+# wrong constant name on_21?
+# wrong constant name on_22?
+# wrong constant name on_23?
+# wrong constant name on_24?
+# wrong constant name on_25?
+# wrong constant name on_26?
+# wrong constant name on_27?
+# wrong constant name on_2?
+# wrong constant name rbx?
+# wrong constant name rbx_18?
+# wrong constant name rbx_19?
+# wrong constant name rbx_1?
+# wrong constant name rbx_20?
+# wrong constant name rbx_21?
+# wrong constant name rbx_22?
+# wrong constant name rbx_23?
+# wrong constant name rbx_24?
+# wrong constant name rbx_25?
+# wrong constant name rbx_26?
+# wrong constant name rbx_27?
+# wrong constant name rbx_2?
+# wrong constant name ruby?
+# wrong constant name ruby_18?
+# wrong constant name ruby_19?
+# wrong constant name ruby_1?
+# wrong constant name ruby_20?
+# wrong constant name ruby_21?
+# wrong constant name ruby_22?
+# wrong constant name ruby_23?
+# wrong constant name ruby_24?
+# wrong constant name ruby_25?
+# wrong constant name ruby_26?
+# wrong constant name ruby_27?
+# wrong constant name ruby_2?
+# wrong constant name truffleruby?
+# wrong constant name truffleruby_18?
+# wrong constant name truffleruby_19?
+# wrong constant name truffleruby_1?
+# wrong constant name truffleruby_20?
+# wrong constant name truffleruby_21?
+# wrong constant name truffleruby_22?
+# wrong constant name truffleruby_23?
+# wrong constant name truffleruby_24?
+# wrong constant name truffleruby_25?
+# wrong constant name truffleruby_26?
+# wrong constant name truffleruby_27?
+# wrong constant name truffleruby_2?
+# wrong constant name x64_mingw?
+# wrong constant name x64_mingw_18?
+# wrong constant name x64_mingw_19?
+# wrong constant name x64_mingw_1?
+# wrong constant name x64_mingw_20?
+# wrong constant name x64_mingw_21?
+# wrong constant name x64_mingw_22?
+# wrong constant name x64_mingw_23?
+# wrong constant name x64_mingw_24?
+# wrong constant name x64_mingw_25?
+# wrong constant name x64_mingw_26?
+# wrong constant name x64_mingw_27?
+# wrong constant name x64_mingw_2?
+# wrong constant name <static-init>
+# wrong constant name status_code
+# wrong constant name <static-init>
+# uninitialized constant Bundler::Definition::GENERICS
+# Did you mean?  Bundler::Definition::GENERICS
+# uninitialized constant Bundler::Definition::GENERIC_CACHE
+# Did you mean?  Bundler::Definition::GENERIC_CACHE
+# wrong constant name add_current_platform
+# wrong constant name add_platform
+# wrong constant name current_dependencies
+# wrong constant name dependencies
+# wrong constant name ensure_equivalent_gemfile_and_lockfile
+# wrong constant name find_indexed_specs
+# wrong constant name find_resolved_spec
+# wrong constant name gem_version_promoter
+# wrong constant name gemfiles
+# wrong constant name groups
+# wrong constant name has_local_dependencies?
+# wrong constant name has_rubygems_remotes?
+# wrong constant name index
+# wrong constant name initialize
+# wrong constant name lock
+# wrong constant name locked_bundler_version
+# wrong constant name locked_deps
+# wrong constant name locked_gems
+# wrong constant name locked_ruby_version
+# wrong constant name locked_ruby_version_object
+# wrong constant name lockfile
+# wrong constant name missing_specs
+# wrong constant name missing_specs?
+# wrong constant name new_platform?
+# wrong constant name new_specs
+# wrong constant name nothing_changed?
+# wrong constant name platforms
+# wrong constant name remove_platform
+# wrong constant name removed_specs
+# wrong constant name requested_specs
+# wrong constant name requires
+# wrong constant name resolve
+# wrong constant name resolve_remotely!
+# wrong constant name resolve_with_cache!
+# wrong constant name ruby_version
+# wrong constant name spec_git_paths
+# wrong constant name specs
+# wrong constant name specs_for
+# wrong constant name to_lock
+# wrong constant name unlocking?
+# wrong constant name validate_platforms!
+# wrong constant name validate_ruby!
+# wrong constant name validate_runtime!
+# wrong constant name <static-init>
+# wrong constant name build
+# wrong constant name ==
+# wrong constant name __platform
+# wrong constant name dep
+# wrong constant name eql?
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name requirement
+# wrong constant name type
+# wrong constant name <static-init>
+# uninitialized constant Bundler::Dependency::TYPES
+# Did you mean?  Bundler::Dependency::TYPES
+# wrong constant name autorequire
+# wrong constant name current_env?
+# wrong constant name current_platform?
+# wrong constant name gem_platforms
+# wrong constant name gemfile
+# wrong constant name initialize
+# wrong constant name platforms
+# wrong constant name should_include?
+# wrong constant name <static-init>
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name <Class:DSLError>
+# wrong constant name dependencies
+# wrong constant name dependencies=
+# wrong constant name env
+# wrong constant name eval_gemfile
+# wrong constant name gem
+# wrong constant name gemspec
+# wrong constant name gemspecs
+# wrong constant name git
+# wrong constant name git_source
+# wrong constant name github
+# wrong constant name group
+# wrong constant name install_if
+# wrong constant name method_missing
+# wrong constant name path
+# wrong constant name platform
+# wrong constant name platforms
+# wrong constant name plugin
+# wrong constant name source
+# wrong constant name to_definition
+# wrong constant name contents
+# wrong constant name description
+# wrong constant name dsl_path
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name evaluate
+# uninitialized constant Bundler::EndpointSpecification::CURRENT_SPECIFICATION_VERSION
+# Did you mean?  Bundler::EndpointSpecification::CURRENT_SPECIFICATION_VERSION
+# uninitialized constant Bundler::EndpointSpecification::DateLike
+# Did you mean?  Bundler::EndpointSpecification::DateLike
+#                DateTime
+# uninitialized constant Bundler::EndpointSpecification::DateTimeFormat
+# Did you mean?  Bundler::EndpointSpecification::DateTimeFormat
+# uninitialized constant Bundler::EndpointSpecification::EMPTY
+# Did you mean?  Bundler::EndpointSpecification::EMPTY
+# uninitialized constant Bundler::EndpointSpecification::GENERICS
+# Did you mean?  Bundler::EndpointSpecification::GENERICS
+# uninitialized constant Bundler::EndpointSpecification::GENERIC_CACHE
+# Did you mean?  Bundler::EndpointSpecification::GENERIC_CACHE
+# uninitialized constant Bundler::EndpointSpecification::INITIALIZE_CODE_FOR_DEFAULTS
+# Did you mean?  Bundler::EndpointSpecification::INITIALIZE_CODE_FOR_DEFAULTS
+# uninitialized constant Bundler::EndpointSpecification::MARSHAL_FIELDS
+# Did you mean?  Bundler::EndpointSpecification::MARSHAL_FIELDS
+# uninitialized constant Bundler::EndpointSpecification::NONEXISTENT_SPECIFICATION_VERSION
+# Did you mean?  Bundler::EndpointSpecification::NONEXISTENT_SPECIFICATION_VERSION
+# uninitialized constant Bundler::EndpointSpecification::NOT_FOUND
+# Did you mean?  Bundler::EndpointSpecification::NOT_FOUND
+# uninitialized constant Bundler::EndpointSpecification::SPECIFICATION_VERSION_HISTORY
+# Did you mean?  Bundler::EndpointSpecification::SPECIFICATION_VERSION_HISTORY
+# uninitialized constant Bundler::EndpointSpecification::TODAY
+# Did you mean?  Bundler::EndpointSpecification::TODAY
+# uninitialized constant Bundler::EndpointSpecification::VALID_NAME_PATTERN
+# Did you mean?  Bundler::EndpointSpecification::VALID_NAME_PATTERN
+# wrong constant name __swap__
+# wrong constant name _local_specification
+# wrong constant name checksum
+# wrong constant name dependencies=
+# wrong constant name fetch_platform
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant Bundler::EndpointSpecification::Elem
 # wrong constant name <static-init>
 # wrong constant name environment
 # wrong constant name report
 # wrong constant name write
+# wrong constant name backup
+# wrong constant name initialize
+# wrong constant name restore
+# wrong constant name <static-init>
+# wrong constant name allow_bundler_dependency_conflicts?
+# wrong constant name allow_offline_install?
+# wrong constant name auto_clean_without_path?
+# wrong constant name auto_config_jobs?
+# wrong constant name bundler_10_mode?
+# wrong constant name bundler_1_mode?
+# wrong constant name bundler_2_mode?
+# wrong constant name bundler_3_mode?
+# wrong constant name bundler_4_mode?
+# wrong constant name bundler_5_mode?
+# wrong constant name bundler_6_mode?
+# wrong constant name bundler_7_mode?
+# wrong constant name bundler_8_mode?
+# wrong constant name bundler_9_mode?
+# wrong constant name cache_all?
+# wrong constant name cache_command_is_package?
+# wrong constant name console_command?
+# wrong constant name default_cli_command
+# wrong constant name default_install_uses_path?
+# wrong constant name deployment_means_frozen?
+# wrong constant name disable_multisource?
+# wrong constant name error_on_stderr?
+# wrong constant name forget_cli_options?
 # wrong constant name github_https?
+# wrong constant name global_gem_cache?
+# wrong constant name global_path_appends_ruby_scope?
+# wrong constant name init_gems_rb?
+# wrong constant name initialize
+# wrong constant name list_command?
 # wrong constant name lockfile_upgrade_warning?
+# wrong constant name lockfile_uses_separate_rubygems_sources?
+# wrong constant name only_update_to_newer_versions?
+# wrong constant name path_relative_to_cwd?
+# wrong constant name plugins?
+# wrong constant name prefer_gems_rb?
+# wrong constant name print_only_version_number?
+# wrong constant name setup_makes_kernel_gem_public?
+# wrong constant name skip_default_git_sources?
+# wrong constant name specific_platform?
+# wrong constant name suppress_install_using_messages?
+# wrong constant name unlock_source_unlocks_spec?
+# wrong constant name update_requires_all_flag?
+# wrong constant name use_gem_version_promoter_for_major_updates?
+# wrong constant name viz_command?
+# wrong constant name <static-init>
+# wrong constant name <Class:AuthenticationRequiredError>
+# wrong constant name <Class:BadAuthenticationError>
 # wrong constant name <Class:Base>
+# wrong constant name <Class:CertificateFailureError>
 # wrong constant name <Class:CompactIndex>
 # wrong constant name <Class:Dependency>
 # wrong constant name <Class:Downloader>
+# wrong constant name <Class:FallbackError>
 # wrong constant name <Class:Index>
+# wrong constant name <Class:NetworkDownError>
+# wrong constant name <Class:SSLError>
 # wrong constant name fetch_spec
 # wrong constant name fetchers
 # wrong constant name http_proxy
@@ -304,7 +612,9 @@
 # wrong constant name use_api
 # wrong constant name user_agent
 # wrong constant name initialize
+# wrong constant name <static-init>
 # wrong constant name initialize
+# wrong constant name <static-init>
 # wrong constant name api_fetcher?
 # wrong constant name available?
 # wrong constant name display_uri
@@ -315,6 +625,7 @@
 # wrong constant name remote_uri
 # wrong constant name <static-init>
 # wrong constant name initialize
+# wrong constant name <static-init>
 # wrong constant name <Class:ClientFetcher>
 # wrong constant name available?
 # wrong constant name fetch_spec
@@ -343,10 +654,13 @@
 # wrong constant name redirect_limit
 # wrong constant name request
 # wrong constant name <static-init>
+# wrong constant name <static-init>
 # wrong constant name fetch_spec
 # wrong constant name specs
 # wrong constant name <static-init>
+# wrong constant name <static-init>
 # wrong constant name initialize
+# wrong constant name <static-init>
 # wrong constant name <static-init>
 # wrong constant name api_timeout
 # wrong constant name api_timeout=
@@ -356,19 +670,154 @@
 # wrong constant name max_retries=
 # wrong constant name redirect_limit
 # wrong constant name redirect_limit=
+# wrong constant name <Class:DryRun>
+# wrong constant name <Class:Entry_>
+# wrong constant name <Class:LowMethods>
+# wrong constant name <Class:NoWrite>
+# wrong constant name <Class:StreamUtils_>
+# wrong constant name <Class:Verbose>
+# uninitialized constant Bundler::FileUtils::DryRun::LOW_METHODS
+# Did you mean?  Bundler::FileUtils::DryRun::LowMethods
+#                Bundler::FileUtils::LowMethods
+#                Bundler::FileUtils::DryRun::LOW_METHODS
+#                Bundler::FileUtils::LOW_METHODS
+# uninitialized constant Bundler::FileUtils::DryRun::METHODS
+# Did you mean?  Method
+#                Bundler::FileUtils::DryRun::METHODS
+#                Bundler::FileUtils::METHODS
+# uninitialized constant Bundler::FileUtils::DryRun::OPT_TABLE
+# Did you mean?  Bundler::FileUtils::DryRun::OPT_TABLE
+#                Bundler::FileUtils::OPT_TABLE
+# wrong constant name <static-init>
+# wrong constant name blockdev?
+# wrong constant name chardev?
+# wrong constant name chmod
+# wrong constant name chown
+# wrong constant name copy
+# wrong constant name copy_file
+# wrong constant name copy_metadata
+# wrong constant name dereference?
+# wrong constant name directory?
+# wrong constant name door?
+# wrong constant name entries
+# wrong constant name exist?
+# wrong constant name file?
+# wrong constant name initialize
+# wrong constant name lstat
+# wrong constant name lstat!
+# wrong constant name path
+# wrong constant name pipe?
+# wrong constant name platform_support
+# wrong constant name postorder_traverse
+# wrong constant name prefix
+# wrong constant name preorder_traverse
+# wrong constant name rel
+# wrong constant name remove
+# wrong constant name remove_dir1
+# wrong constant name remove_file
+# wrong constant name socket?
+# wrong constant name stat
+# wrong constant name stat!
+# wrong constant name symlink?
+# wrong constant name traverse
+# wrong constant name wrap_traverse
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# uninitialized constant Bundler::FileUtils::NoWrite::LOW_METHODS
+# Did you mean?  Bundler::FileUtils::NoWrite::LowMethods
+#                Bundler::FileUtils::LowMethods
+#                Bundler::FileUtils::NoWrite::LOW_METHODS
+#                Bundler::FileUtils::LOW_METHODS
+# uninitialized constant Bundler::FileUtils::NoWrite::METHODS
+# Did you mean?  Method
+#                Bundler::FileUtils::NoWrite::METHODS
+#                Bundler::FileUtils::METHODS
+# uninitialized constant Bundler::FileUtils::NoWrite::OPT_TABLE
+# Did you mean?  Bundler::FileUtils::NoWrite::OPT_TABLE
+#                Bundler::FileUtils::OPT_TABLE
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# uninitialized constant Bundler::FileUtils::Verbose::LOW_METHODS
+# Did you mean?  Bundler::FileUtils::Verbose::LowMethods
+#                Bundler::FileUtils::LowMethods
+#                Bundler::FileUtils::Verbose::LOW_METHODS
+#                Bundler::FileUtils::LOW_METHODS
+# uninitialized constant Bundler::FileUtils::Verbose::METHODS
+# Did you mean?  Method
+#                Bundler::FileUtils::Verbose::METHODS
+#                Bundler::FileUtils::METHODS
+# uninitialized constant Bundler::FileUtils::Verbose::OPT_TABLE
+# Did you mean?  Bundler::FileUtils::Verbose::OPT_TABLE
+#                Bundler::FileUtils::OPT_TABLE
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name cd
+# wrong constant name chdir
+# wrong constant name chmod
+# wrong constant name chmod_R
+# wrong constant name chown
+# wrong constant name chown_R
+# wrong constant name cmp
+# wrong constant name collect_method
+# wrong constant name commands
+# wrong constant name compare_file
+# wrong constant name compare_stream
+# wrong constant name copy
+# wrong constant name copy_entry
+# wrong constant name copy_file
+# wrong constant name copy_stream
+# wrong constant name cp
+# wrong constant name cp_r
+# wrong constant name getwd
+# wrong constant name have_option?
+# wrong constant name identical?
+# wrong constant name install
 # wrong constant name link
-# wrong constant name cp_lr
-# wrong constant name link_entry
+# wrong constant name ln
+# wrong constant name ln_s
+# wrong constant name ln_sf
+# wrong constant name makedirs
+# wrong constant name mkdir
+# wrong constant name mkdir_p
+# wrong constant name mkpath
+# wrong constant name move
+# wrong constant name mv
+# wrong constant name options
+# wrong constant name options_of
+# wrong constant name private_module_function
+# wrong constant name pwd
+# wrong constant name remove
+# wrong constant name remove_dir
+# wrong constant name remove_entry
+# wrong constant name remove_entry_secure
+# wrong constant name remove_file
+# wrong constant name rm
+# wrong constant name rm_f
+# wrong constant name rm_r
+# wrong constant name rm_rf
+# wrong constant name rmdir
+# wrong constant name rmtree
+# wrong constant name safe_unlink
+# wrong constant name symlink
+# wrong constant name touch
+# wrong constant name uptodate?
 # uninitialized constant Bundler::GemHelper::DEFAULT
+# Did you mean?  Bundler::GemHelper::DEFAULT
 # uninitialized constant Bundler::GemHelper::LN_SUPPORTED
+# Did you mean?  Bundler::GemHelper::LN_SUPPORTED
 # uninitialized constant Bundler::GemHelper::LOW_METHODS
 # Did you mean?  Bundler::GemHelper::LowMethods
+#                Bundler::GemHelper::LOW_METHODS
 # uninitialized constant Bundler::GemHelper::METHODS
 # Did you mean?  Method
+#                Bundler::GemHelper::METHODS
 # uninitialized constant Bundler::GemHelper::OPT_TABLE
+# Did you mean?  Bundler::GemHelper::OPT_TABLE
 # uninitialized constant Bundler::GemHelper::RUBY
+# Did you mean?  Bundler::GemHelper::RUBY
 # uninitialized constant Bundler::GemHelper::VERSION
-# Did you mean?  Bundler::VERSION
+# Did you mean?  Bundler::GemHelper::VERSION
+#                Bundler::VERSION
 # wrong constant name allowed_push_host
 # wrong constant name already_tagged?
 # wrong constant name base
@@ -389,8 +838,7 @@
 # wrong constant name perform_git_push
 # wrong constant name rubygem_push
 # wrong constant name sh
-# wrong constant name sh_with_input
-# wrong constant name sh_with_status
+# wrong constant name sh_with_code
 # wrong constant name spec_path
 # wrong constant name tag_version
 # wrong constant name version
@@ -400,7 +848,34 @@
 # wrong constant name install_tasks
 # wrong constant name instance
 # wrong constant name instance=
+# wrong constant name <Class:PlatformMatch>
+# wrong constant name <=>
+# uninitialized constant Bundler::GemHelpers::PlatformMatch::Elem
+# wrong constant name cpu_match
+# wrong constant name cpu_match=
+# wrong constant name os_match
+# wrong constant name os_match=
+# wrong constant name platform_version_match
+# wrong constant name platform_version_match=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name cpu_match
+# wrong constant name members
+# wrong constant name os_match
+# wrong constant name platform_version_match
+# wrong constant name <static-init>
+# wrong constant name generic
+# wrong constant name generic_local_platform
+# wrong constant name platform_specificity_match
+# wrong constant name select_best_platform_match
+# wrong constant name status_code
+# wrong constant name <static-init>
 # uninitialized constant Bundler::GemRemoteFetcher::BASE64_URI_TRANSLATE
+# Did you mean?  Bundler::GemRemoteFetcher::BASE64_URI_TRANSLATE
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name orig_exception
+# wrong constant name status_code
 # wrong constant name <static-init>
 # wrong constant name initialize
 # wrong constant name level
@@ -414,6 +889,21 @@
 # wrong constant name strict
 # wrong constant name strict=
 # wrong constant name unlock_gems
+# wrong constant name <static-init>
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name status_code
+# wrong constant name underlying_error
+# wrong constant name <static-init>
+# wrong constant name status_code
 # wrong constant name <static-init>
 # wrong constant name <Class:GraphVizClient>
 # wrong constant name edge_options
@@ -429,13 +919,43 @@
 # wrong constant name run
 # wrong constant name <static-init>
 # wrong constant name <static-init>
+# wrong constant name filter_uri
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name <<
+# wrong constant name ==
 # uninitialized constant Bundler::Index::Elem
+# wrong constant name []
+# wrong constant name add_source
+# wrong constant name all_specs
+# wrong constant name dependencies_eql?
+# wrong constant name dependency_names
+# wrong constant name each
+# wrong constant name empty?
+# wrong constant name local_search
+# wrong constant name search
+# wrong constant name search_all
+# wrong constant name size
+# wrong constant name sort_specs
+# wrong constant name sources
+# wrong constant name spec_names
+# wrong constant name specs
+# wrong constant name unmet_dependency_names
+# wrong constant name unsorted_search
+# wrong constant name use
+# wrong constant name <static-init>
+# wrong constant name build
+# wrong constant name sort_specs
 # wrong constant name initialize
 # wrong constant name inject
 # wrong constant name remove
 # wrong constant name <static-init>
 # wrong constant name inject
 # wrong constant name remove
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name status_code
+# wrong constant name <static-init>
 # wrong constant name generate_bundler_executable_stubs
 # wrong constant name generate_standalone_bundler_executable_stubs
 # wrong constant name initialize
@@ -445,8 +965,370 @@
 # wrong constant name ambiguous_gems
 # wrong constant name ambiguous_gems=
 # wrong constant name install
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name ==
+# uninitialized constant Bundler::LazySpecification::GENERICS
+# Did you mean?  Bundler::LazySpecification::GENERICS
+# uninitialized constant Bundler::LazySpecification::GENERIC_CACHE
+# Did you mean?  Bundler::LazySpecification::GENERIC_CACHE
+# wrong constant name <Class:Identifier>
+# wrong constant name __materialize__
+# wrong constant name dependencies
+# wrong constant name full_name
+# wrong constant name git_version
+# wrong constant name identifier
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name platform
+# wrong constant name remote
+# wrong constant name remote=
+# wrong constant name respond_to?
+# wrong constant name satisfies?
+# wrong constant name source
+# wrong constant name source=
+# wrong constant name to_lock
+# wrong constant name version
+# wrong constant name <=>
+# uninitialized constant Bundler::LazySpecification::Identifier::Elem
+# wrong constant name dependencies
+# wrong constant name dependencies=
+# wrong constant name name
+# wrong constant name name=
+# wrong constant name platform
+# wrong constant name platform=
+# wrong constant name platform_string
+# wrong constant name source
+# wrong constant name source=
+# wrong constant name version
+# wrong constant name version=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# wrong constant name <static-init>
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name bundler_version
+# wrong constant name dependencies
+# wrong constant name initialize
+# wrong constant name platforms
+# wrong constant name ruby_version
+# wrong constant name sources
+# wrong constant name specs
+# wrong constant name warn_for_outdated_bundler_version
+# wrong constant name <static-init>
+# wrong constant name sections_in_lockfile
+# wrong constant name sections_to_ignore
+# wrong constant name unknown_sections_in_lockfile
+# wrong constant name <static-init>
+# uninitialized constant Bundler::MatchPlatform::GENERICS
+# Did you mean?  Bundler::MatchPlatform::GENERICS
+# uninitialized constant Bundler::MatchPlatform::GENERIC_CACHE
+# Did you mean?  Bundler::MatchPlatform::GENERIC_CACHE
+# wrong constant name match_platform
+# wrong constant name <static-init>
+# wrong constant name platforms_match?
+# wrong constant name <Class:CircularDependencyError>
+# wrong constant name <Class:Compatibility>
+# wrong constant name <Class:Delegates>
+# wrong constant name <Class:DependencyGraph>
+# wrong constant name <Class:DependencyState>
+# wrong constant name <Class:NoSuchDependencyError>
+# wrong constant name <Class:PossibilityState>
+# wrong constant name <Class:ResolutionState>
+# wrong constant name <Class:Resolver>
+# wrong constant name <Class:ResolverError>
+# wrong constant name <Class:SpecificationProvider>
+# wrong constant name <Class:UI>
+# wrong constant name <Class:VersionConflict>
+# wrong constant name dependencies
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name flat_map
+# wrong constant name <Class:ResolutionState>
+# wrong constant name <Class:SpecificationProvider>
+# wrong constant name activated
+# wrong constant name conflicts
+# wrong constant name depth
+# wrong constant name name
+# wrong constant name possibilities
+# wrong constant name requirement
+# wrong constant name requirements
+# wrong constant name unused_unwind_options
+# wrong constant name <static-init>
+# wrong constant name allow_missing?
+# wrong constant name dependencies_for
+# wrong constant name name_for
+# wrong constant name name_for_explicit_dependency_source
+# wrong constant name name_for_locking_dependency_source
+# wrong constant name requirement_satisfied_by?
+# wrong constant name search_for
+# wrong constant name sort_dependencies
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name <Class:Action>
+# wrong constant name <Class:AddEdgeNoCircular>
+# wrong constant name <Class:AddVertex>
+# wrong constant name <Class:DeleteEdge>
+# wrong constant name <Class:DetachVertexNamed>
+# wrong constant name <Class:Edge>
 # uninitialized constant Bundler::Molinillo::DependencyGraph::Elem
+# wrong constant name <Class:Log>
+# wrong constant name <Class:SetPayload>
+# wrong constant name <Class:Tag>
+# wrong constant name <Class:Vertex>
+# wrong constant name add_child_vertex
+# wrong constant name add_edge
+# wrong constant name add_vertex
+# wrong constant name delete_edge
+# wrong constant name detach_vertex_named
+# wrong constant name each
+# wrong constant name log
+# wrong constant name rewind_to
+# wrong constant name root_vertex_named
+# wrong constant name set_payload
+# wrong constant name tag
+# wrong constant name to_dot
+# wrong constant name tsort_each_child
+# wrong constant name vertex_named
+# wrong constant name vertices
+# wrong constant name down
+# wrong constant name next
+# wrong constant name next=
+# wrong constant name previous
+# wrong constant name previous=
+# wrong constant name up
+# wrong constant name <static-init>
+# wrong constant name action_name
+# wrong constant name destination
+# wrong constant name initialize
+# wrong constant name make_edge
+# wrong constant name origin
+# wrong constant name requirement
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name payload
+# wrong constant name root
+# wrong constant name <static-init>
+# wrong constant name destination_name
+# wrong constant name initialize
+# wrong constant name make_edge
+# wrong constant name origin_name
+# wrong constant name requirement
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name <static-init>
+# uninitialized constant Bundler::Molinillo::DependencyGraph::Edge::Elem
+# wrong constant name destination
+# wrong constant name destination=
+# wrong constant name origin
+# wrong constant name origin=
+# wrong constant name requirement
+# wrong constant name requirement=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# wrong constant name add_edge_no_circular
+# wrong constant name add_vertex
+# wrong constant name delete_edge
+# wrong constant name detach_vertex_named
+# wrong constant name each
+# wrong constant name pop!
+# wrong constant name reverse_each
+# wrong constant name rewind_to
+# wrong constant name set_payload
+# wrong constant name tag
+# wrong constant name <static-init>
 # uninitialized constant Bundler::Molinillo::DependencyGraph::Log::Elem
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name payload
+# wrong constant name <static-init>
+# wrong constant name down
+# wrong constant name initialize
+# wrong constant name tag
+# wrong constant name up
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name _path_to?
+# wrong constant name ancestor?
+# wrong constant name descendent?
+# wrong constant name eql?
+# wrong constant name explicit_requirements
+# wrong constant name incoming_edges
+# wrong constant name incoming_edges=
+# wrong constant name initialize
+# wrong constant name is_reachable_from?
+# wrong constant name name
+# wrong constant name name=
+# wrong constant name outgoing_edges
+# wrong constant name outgoing_edges=
+# wrong constant name path_to?
+# wrong constant name payload
+# wrong constant name payload=
+# wrong constant name predecessors
+# wrong constant name recursive_predecessors
+# wrong constant name recursive_successors
+# wrong constant name requirements
+# wrong constant name root
+# wrong constant name root=
+# wrong constant name root?
+# wrong constant name shallow_eql?
+# wrong constant name successors
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name tsort
+# uninitialized constant Bundler::Molinillo::DependencyState::Elem
+# wrong constant name pop_possibility_state
+# wrong constant name <static-init>
+# wrong constant name dependency
+# wrong constant name dependency=
+# wrong constant name initialize
+# wrong constant name required_by
+# wrong constant name required_by=
+# wrong constant name <static-init>
+# uninitialized constant Bundler::Molinillo::PossibilityState::Elem
+# wrong constant name <static-init>
+# uninitialized constant Bundler::Molinillo::ResolutionState::Elem
+# wrong constant name activated
+# wrong constant name activated=
+# wrong constant name conflicts
+# wrong constant name conflicts=
+# wrong constant name depth
+# wrong constant name depth=
+# wrong constant name name
+# wrong constant name name=
+# wrong constant name possibilities
+# wrong constant name possibilities=
+# wrong constant name requirement
+# wrong constant name requirement=
+# wrong constant name requirements
+# wrong constant name requirements=
+# wrong constant name unused_unwind_options
+# wrong constant name unused_unwind_options=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name empty
+# wrong constant name members
+# wrong constant name <Class:Resolution>
+# wrong constant name initialize
+# wrong constant name resolve
+# wrong constant name resolver_ui
+# wrong constant name specification_provider
+# wrong constant name <Class:Conflict>
+# wrong constant name <Class:PossibilitySet>
+# wrong constant name <Class:UnwindDetails>
+# wrong constant name base
+# wrong constant name initialize
+# wrong constant name iteration_rate=
+# wrong constant name original_requested
+# wrong constant name resolve
+# wrong constant name resolver_ui
+# wrong constant name specification_provider
+# wrong constant name started_at=
+# wrong constant name states=
+# uninitialized constant Bundler::Molinillo::Resolver::Resolution::Conflict::Elem
+# wrong constant name activated_by_name
+# wrong constant name activated_by_name=
+# wrong constant name existing
+# wrong constant name existing=
+# wrong constant name locked_requirement
+# wrong constant name locked_requirement=
+# wrong constant name possibility
+# wrong constant name possibility_set
+# wrong constant name possibility_set=
+# wrong constant name requirement
+# wrong constant name requirement=
+# wrong constant name requirement_trees
+# wrong constant name requirement_trees=
+# wrong constant name requirements
+# wrong constant name requirements=
+# wrong constant name underlying_error
+# wrong constant name underlying_error=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# uninitialized constant Bundler::Molinillo::Resolver::Resolution::PossibilitySet::Elem
+# wrong constant name dependencies
+# wrong constant name dependencies=
+# wrong constant name latest_version
+# wrong constant name possibilities
+# wrong constant name possibilities=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# wrong constant name <=>
+# uninitialized constant Bundler::Molinillo::Resolver::Resolution::UnwindDetails::Elem
+# wrong constant name all_requirements
+# wrong constant name conflicting_requirements
+# wrong constant name conflicting_requirements=
+# wrong constant name requirement_tree
+# wrong constant name requirement_tree=
+# wrong constant name requirement_trees
+# wrong constant name requirement_trees=
+# wrong constant name requirements_unwound_to_instead
+# wrong constant name requirements_unwound_to_instead=
+# wrong constant name reversed_requirement_tree_index
+# wrong constant name state_index
+# wrong constant name state_index=
+# wrong constant name state_requirement
+# wrong constant name state_requirement=
+# wrong constant name sub_dependencies_to_avoid
+# wrong constant name unwinding_to_primary_requirement?
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name allow_missing?
+# wrong constant name dependencies_for
+# wrong constant name name_for
+# wrong constant name name_for_explicit_dependency_source
+# wrong constant name name_for_locking_dependency_source
+# wrong constant name requirement_satisfied_by?
+# wrong constant name search_for
+# wrong constant name sort_dependencies
+# wrong constant name <static-init>
+# wrong constant name after_resolution
+# wrong constant name before_resolution
+# wrong constant name debug
+# wrong constant name debug?
+# wrong constant name indicate_progress
+# wrong constant name output
+# wrong constant name progress_rate
+# wrong constant name <static-init>
+# wrong constant name conflicts
+# wrong constant name initialize
+# wrong constant name message_with_trees
+# wrong constant name specification_provider
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name action
+# wrong constant name initialize
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name <Class:API>
+# wrong constant name <Class:DSL>
+# wrong constant name <Class:Events>
+# wrong constant name <Class:Index>
+# wrong constant name <Class:Installer>
+# wrong constant name <Class:MalformattedPlugin>
+# wrong constant name <Class:SourceList>
+# wrong constant name <Class:UndefinedCommandError>
+# wrong constant name <Class:UnknownSourceError>
+# wrong constant name <Class:Source>
+# wrong constant name cache_dir
+# wrong constant name method_missing
+# wrong constant name tmp
 # wrong constant name ==
 # wrong constant name app_cache_dirname
 # wrong constant name app_cache_path
@@ -480,26 +1362,137 @@
 # wrong constant name uri
 # wrong constant name uri_hash
 # wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name command
+# wrong constant name hook
+# wrong constant name source
+# wrong constant name <Class:PluginGemfileError>
+# uninitialized constant Bundler::Plugin::DSL::VALID_KEYS
+# Did you mean?  Bundler::Plugin::DSL::VALID_KEYS
+# uninitialized constant Bundler::Plugin::DSL::VALID_PLATFORMS
+# Did you mean?  Bundler::Plugin::DSL::VALID_PLATFORMS
+# wrong constant name _gem
+# wrong constant name inferred_plugins
+# wrong constant name plugin
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name defined_event?
+# wrong constant name <Class:CommandConflict>
+# wrong constant name <Class:SourceConflict>
+# wrong constant name command_plugin
+# wrong constant name commands
+# wrong constant name global_index_file
+# wrong constant name hook_plugins
+# wrong constant name index_file
+# wrong constant name installed?
+# wrong constant name load_paths
+# wrong constant name local_index_file
+# wrong constant name plugin_path
+# wrong constant name register_plugin
+# wrong constant name source?
+# wrong constant name source_plugin
 # wrong constant name initialize
 # wrong constant name <static-init>
 # wrong constant name initialize
+# wrong constant name <static-init>
 # wrong constant name <static-init>
 # wrong constant name <Class:Git>
 # wrong constant name <Class:Rubygems>
 # wrong constant name install
 # wrong constant name install_definition
 # uninitialized constant Bundler::Plugin::Installer::Git::DEFAULT_GLOB
+# Did you mean?  Bundler::Plugin::Installer::Git::DEFAULT_GLOB
 # wrong constant name generate_bin
 # wrong constant name <static-init>
 # uninitialized constant Bundler::Plugin::Installer::Rubygems::API_REQUEST_LIMIT
 # Did you mean?  Bundler::Plugin::Installer::Rubygems::API_REQUEST_SIZE
+#                Bundler::Plugin::Installer::Rubygems::API_REQUEST_LIMIT
 # uninitialized constant Bundler::Plugin::Installer::Rubygems::API_REQUEST_SIZE
-# Did you mean?  Bundler::Plugin::Installer::Rubygems::API_REQUEST_LIMIT
+# Did you mean?  Bundler::Plugin::Installer::Rubygems::API_REQUEST_SIZE
+#                Bundler::Plugin::Installer::Rubygems::API_REQUEST_LIMIT
 # wrong constant name <static-init>
 # wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name add_command
+# wrong constant name add_hook
+# wrong constant name add_source
+# wrong constant name cache
+# wrong constant name command?
+# wrong constant name exec_command
+# wrong constant name gemfile_install
+# wrong constant name global_root
+# wrong constant name hook
+# wrong constant name index
+# wrong constant name install
+# wrong constant name installed?
+# wrong constant name local_root
+# wrong constant name reset!
+# wrong constant name root
+# wrong constant name source
+# wrong constant name source?
+# wrong constant name source_from_lock
+# wrong constant name status_code
 # wrong constant name <static-init>
 # wrong constant name <static-init>
 # wrong constant name lock
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name <=>
+# uninitialized constant Bundler::RemoteSpecification::GENERICS
+# Did you mean?  Bundler::RemoteSpecification::GENERICS
+# uninitialized constant Bundler::RemoteSpecification::GENERIC_CACHE
+# Did you mean?  Bundler::RemoteSpecification::GENERIC_CACHE
+# wrong constant name __swap__
+# wrong constant name dependencies
+# wrong constant name dependencies=
+# wrong constant name fetch_platform
+# wrong constant name full_name
+# wrong constant name git_version
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name platform
+# wrong constant name remote
+# wrong constant name remote=
+# wrong constant name respond_to?
+# wrong constant name sort_obj
+# wrong constant name source
+# wrong constant name source=
+# wrong constant name version
+# wrong constant name <static-init>
+# wrong constant name <Class:SpecGroup>
+# wrong constant name index_for
+# wrong constant name initialize
+# wrong constant name relevant_sources_for_vertex
+# wrong constant name start
+# wrong constant name ==
+# uninitialized constant Bundler::Resolver::SpecGroup::GENERICS
+# Did you mean?  Bundler::Resolver::SpecGroup::GENERICS
+# uninitialized constant Bundler::Resolver::SpecGroup::GENERIC_CACHE
+# Did you mean?  Bundler::Resolver::SpecGroup::GENERIC_CACHE
+# wrong constant name activate_platform!
+# wrong constant name dependencies_for_activated_platforms
+# wrong constant name eql?
+# wrong constant name for?
+# wrong constant name ignores_bundler_dependencies
+# wrong constant name ignores_bundler_dependencies=
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name name=
+# wrong constant name source
+# wrong constant name source=
+# wrong constant name to_specs
+# wrong constant name version
+# wrong constant name version=
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name platform_sort_key
+# wrong constant name resolve
+# wrong constant name sort_platforms
 # wrong constant name attempt
 # wrong constant name attempts
 # wrong constant name current_run
@@ -513,11 +1506,198 @@
 # wrong constant name attempts
 # wrong constant name default_attempts
 # wrong constant name default_retries
+# wrong constant name ruby
+# wrong constant name <static-init>
 # uninitialized constant Bundler::RubyGemsGemInstaller::ENV_PATHS
+# Did you mean?  Bundler::RubyGemsGemInstaller::ENV_PATHS
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name diff
+# wrong constant name engine
+# wrong constant name engine_gem_version
+# wrong constant name engine_versions
+# wrong constant name exact?
+# wrong constant name gem_version
+# wrong constant name host
+# wrong constant name initialize
+# wrong constant name patchlevel
+# wrong constant name single_version_string
+# wrong constant name to_gem_version_with_patchlevel
+# wrong constant name to_s
+# wrong constant name versions
+# wrong constant name versions_string
+# wrong constant name <static-init>
+# wrong constant name from_string
+# wrong constant name system
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name <Class:AlmostModern>
+# wrong constant name <Class:Ancient>
+# wrong constant name <Class:Future>
+# wrong constant name <Class:Legacy>
+# wrong constant name <Class:Modern>
+# wrong constant name <Class:MoreFuture>
+# wrong constant name <Class:MoreModern>
+# wrong constant name <Class:Transitional>
+# wrong constant name backport_base_dir
+# wrong constant name backport_cache_file
+# wrong constant name backport_segment_generation
+# wrong constant name backport_spec_file
+# wrong constant name backport_yaml_initialize
+# wrong constant name bin_path
+# wrong constant name binstubs_call_gem?
+# wrong constant name build
+# wrong constant name build_args
+# wrong constant name build_args=
+# wrong constant name build_gem
+# wrong constant name clear_paths
+# wrong constant name config_map
+# wrong constant name configuration
+# wrong constant name download_gem
+# wrong constant name ext_lock
+# wrong constant name fetch_all_remote_specs
+# wrong constant name fetch_prerelease_specs
+# wrong constant name fetch_specs
+# wrong constant name gem_bindir
+# wrong constant name gem_cache
+# wrong constant name gem_dir
+# wrong constant name gem_from_path
+# wrong constant name gem_path
+# wrong constant name inflate
+# wrong constant name install_with_build_args
+# wrong constant name load_path_insert_index
+# wrong constant name load_plugin_files
+# wrong constant name load_plugins
+# wrong constant name loaded_gem_paths
+# wrong constant name loaded_specs
+# wrong constant name mark_loaded
+# wrong constant name marshal_spec_dir
+# wrong constant name method_visibility
+# wrong constant name path
+# wrong constant name path_separator
+# wrong constant name platforms
+# wrong constant name post_reset_hooks
+# wrong constant name preserve_paths
+# wrong constant name provides?
+# wrong constant name read_binary
+# wrong constant name redefine_method
+# wrong constant name replace_bin_path
+# wrong constant name replace_entrypoints
+# wrong constant name replace_gem
+# wrong constant name replace_refresh
+# wrong constant name repository_subdirectories
+# wrong constant name reset
+# wrong constant name reverse_rubygems_kernel_mixin
+# wrong constant name ruby_engine
+# wrong constant name security_policies
+# wrong constant name security_policy_keys
+# wrong constant name set_installed_by_version
+# wrong constant name sources
+# wrong constant name sources=
+# wrong constant name spec_cache_dirs
+# wrong constant name spec_default_gem?
+# wrong constant name spec_extension_dir
+# wrong constant name spec_from_gem
+# wrong constant name spec_matches_for_glob
+# wrong constant name spec_missing_extensions?
+# wrong constant name stub_set_spec
+# wrong constant name stub_source_index
+# wrong constant name stubs_provide_full_functionality?
+# wrong constant name suffix_pattern
+# wrong constant name ui=
+# wrong constant name undo_replacements
+# wrong constant name user_home
+# wrong constant name validate
+# wrong constant name version
+# wrong constant name with_build_args
+# uninitialized constant Bundler::RubygemsIntegration::AlmostModern::EXT_LOCK
+# Did you mean?  Bundler::RubygemsIntegration::AlmostModern::EXT_LOCK
+#                Bundler::RubygemsIntegration::EXT_LOCK
+# wrong constant name <static-init>
+# uninitialized constant Bundler::RubygemsIntegration::Ancient::EXT_LOCK
+# Did you mean?  Bundler::RubygemsIntegration::Ancient::EXT_LOCK
+#                Bundler::RubygemsIntegration::EXT_LOCK
+# wrong constant name <static-init>
+# uninitialized constant Bundler::RubygemsIntegration::Future::EXT_LOCK
+# Did you mean?  Bundler::RubygemsIntegration::Future::EXT_LOCK
+#                Bundler::RubygemsIntegration::EXT_LOCK
+# wrong constant name all_specs
+# wrong constant name fetch_specs
+# wrong constant name find_name
+# wrong constant name gem_remote_fetcher
+# wrong constant name stub_rubygems
+# wrong constant name <static-init>
+# uninitialized constant Bundler::RubygemsIntegration::Legacy::EXT_LOCK
+# Did you mean?  Bundler::RubygemsIntegration::Legacy::EXT_LOCK
+#                Bundler::RubygemsIntegration::EXT_LOCK
+# wrong constant name all_specs
+# wrong constant name find_name
+# wrong constant name stub_rubygems
+# wrong constant name <static-init>
+# uninitialized constant Bundler::RubygemsIntegration::Modern::EXT_LOCK
+# Did you mean?  Bundler::RubygemsIntegration::Modern::EXT_LOCK
+#                Bundler::RubygemsIntegration::EXT_LOCK
+# wrong constant name all_specs
+# wrong constant name find_name
+# wrong constant name stub_rubygems
 # wrong constant name <static-init>
 # uninitialized constant Bundler::RubygemsIntegration::MoreFuture::EXT_LOCK
-# Did you mean?  Bundler::RubygemsIntegration::EXT_LOCK
-# wrong constant name default_stubs
+# Did you mean?  Bundler::RubygemsIntegration::MoreFuture::EXT_LOCK
+#                Bundler::RubygemsIntegration::EXT_LOCK
+# wrong constant name backport_ext_builder_monitor
+# wrong constant name use_gemdeps
+# wrong constant name <static-init>
+# uninitialized constant Bundler::RubygemsIntegration::MoreModern::EXT_LOCK
+# Did you mean?  Bundler::RubygemsIntegration::MoreModern::EXT_LOCK
+#                Bundler::RubygemsIntegration::EXT_LOCK
+# wrong constant name <static-init>
+# uninitialized constant Bundler::RubygemsIntegration::Transitional::EXT_LOCK
+# Did you mean?  Bundler::RubygemsIntegration::Transitional::EXT_LOCK
+#                Bundler::RubygemsIntegration::EXT_LOCK
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name provides?
+# wrong constant name version
+# wrong constant name cache
+# wrong constant name clean
+# wrong constant name current_dependencies
+# wrong constant name dependencies
+# wrong constant name gems
+# wrong constant name initialize
+# wrong constant name lock
+# wrong constant name prune_cache
+# wrong constant name requested_specs
+# wrong constant name require
+# wrong constant name requires
+# wrong constant name setup
+# wrong constant name specs
+# wrong constant name <static-init>
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name <Class:Mirror>
+# wrong constant name <Class:Mirrors>
+# wrong constant name <Class:Path>
+# wrong constant name <Class:Validator>
+# wrong constant name []
+# wrong constant name all
+# wrong constant name allow_sudo?
+# wrong constant name app_cache_path
+# wrong constant name credentials_for
+# wrong constant name gem_mirrors
+# wrong constant name ignore_config?
+# wrong constant name initialize
+# wrong constant name key_for
+# wrong constant name local_overrides
+# wrong constant name locations
+# wrong constant name mirror_for
+# wrong constant name path
+# wrong constant name pretty_values_for
+# wrong constant name set_command_option
+# wrong constant name set_command_option_if_given
+# wrong constant name set_global
+# wrong constant name set_local
+# wrong constant name temporary
+# wrong constant name validate!
 # wrong constant name ==
 # wrong constant name fallback_timeout
 # wrong constant name fallback_timeout=
@@ -532,6 +1712,23 @@
 # wrong constant name initialize
 # wrong constant name parse
 # wrong constant name <static-init>
+# uninitialized constant Bundler::Settings::Path::Elem
+# wrong constant name append_ruby_scope
+# wrong constant name append_ruby_scope=
+# wrong constant name base_path
+# wrong constant name base_path_relative_to_pwd
+# wrong constant name default_install_uses_path
+# wrong constant name default_install_uses_path=
+# wrong constant name explicit_path
+# wrong constant name explicit_path=
+# wrong constant name path
+# wrong constant name system_path
+# wrong constant name system_path=
+# wrong constant name use_system_gems?
+# wrong constant name validate!
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
 # wrong constant name <Class:Rule>
 # wrong constant name description
 # wrong constant name fail!
@@ -542,7 +1739,212 @@
 # wrong constant name <static-init>
 # wrong constant name <static-init>
 # wrong constant name validate!
+# wrong constant name <static-init>
+# wrong constant name normalize_uri
+# wrong constant name chdir
+# wrong constant name const_get_safely
+# wrong constant name default_bundle_dir
+# wrong constant name default_gemfile
+# wrong constant name default_lockfile
+# wrong constant name digest
+# wrong constant name ensure_same_dependencies
+# wrong constant name filesystem_access
+# wrong constant name in_bundle?
+# wrong constant name major_deprecation
+# wrong constant name md5_available?
+# wrong constant name pretty_dependency
+# wrong constant name print_major_deprecations!
+# wrong constant name pwd
+# wrong constant name root
+# wrong constant name set_bundle_environment
+# wrong constant name set_env
+# wrong constant name trap
+# wrong constant name with_clean_git_env
+# wrong constant name write_to_gemfile
+# wrong constant name <static-init>
+# wrong constant name <Class:Gemspec>
+# wrong constant name <Class:Git>
+# wrong constant name <Class:Metadata>
+# wrong constant name <Class:Path>
+# wrong constant name <Class:Rubygems>
+# wrong constant name can_lock?
+# wrong constant name dependency_names
+# wrong constant name dependency_names=
+# wrong constant name dependency_names_to_double_check
+# wrong constant name double_check_for
+# wrong constant name extension_cache_path
+# wrong constant name include?
+# wrong constant name path?
+# wrong constant name unmet_deps
+# wrong constant name version_message
+# uninitialized constant Bundler::Source::Gemspec::DEFAULT_GLOB
+# Did you mean?  Bundler::Source::Gemspec::DEFAULT_GLOB
+# wrong constant name as_path_source
+# wrong constant name gemspec
+# wrong constant name <static-init>
+# uninitialized constant Bundler::Source::Git::DEFAULT_GLOB
+# Did you mean?  Bundler::Source::Git::DEFAULT_GLOB
+# wrong constant name allow_git_ops?
+# wrong constant name branch
+# wrong constant name cache_path
+# wrong constant name extension_dir_name
+# wrong constant name install_path
+# wrong constant name local_override!
+# wrong constant name ref
+# wrong constant name revision
+# wrong constant name specs
+# wrong constant name submodules
+# wrong constant name unlock!
+# wrong constant name uri
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name cached!
+# wrong constant name eql?
+# wrong constant name install
+# wrong constant name options
+# wrong constant name remote!
+# wrong constant name specs
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name app_cache_dirname
+# wrong constant name cache
+# wrong constant name cached!
+# wrong constant name eql?
+# wrong constant name expanded_original_path
+# wrong constant name initialize
+# wrong constant name install
+# wrong constant name local_specs
+# wrong constant name name
+# wrong constant name name=
+# wrong constant name options
+# wrong constant name original_path
+# wrong constant name path
+# wrong constant name remote!
+# wrong constant name root
+# wrong constant name root_path
+# wrong constant name specs
+# wrong constant name to_lock
+# wrong constant name version
+# wrong constant name version=
+# wrong constant name <static-init>
+# wrong constant name from_lock
+# wrong constant name ==
+# wrong constant name add_remote
+# wrong constant name api_fetchers
+# wrong constant name builtin_gem?
+# wrong constant name cache
+# wrong constant name cache_path
+# wrong constant name cached!
+# wrong constant name cached_built_in_gem
+# wrong constant name cached_gem
+# wrong constant name cached_path
+# wrong constant name cached_specs
+# wrong constant name caches
+# wrong constant name credless_remotes
+# wrong constant name double_check_for
+# wrong constant name eql?
+# wrong constant name equivalent_remotes?
+# wrong constant name fetch_gem
+# wrong constant name fetch_names
+# wrong constant name fetchers
+# wrong constant name include?
+# wrong constant name initialize
+# wrong constant name install
+# wrong constant name installed?
+# wrong constant name installed_specs
+# wrong constant name loaded_from
+# wrong constant name name
+# wrong constant name normalize_uri
+# wrong constant name options
+# wrong constant name remote!
+# wrong constant name remote_specs
+# wrong constant name remotes
+# wrong constant name remotes_for_spec
+# wrong constant name remove_auth
+# wrong constant name replace_remotes
+# wrong constant name requires_sudo?
+# wrong constant name rubygems_dir
+# wrong constant name specs
+# wrong constant name suppress_configured_credentials
+# wrong constant name to_lock
+# wrong constant name <static-init>
+# wrong constant name from_lock
+# wrong constant name <static-init>
+# wrong constant name add_git_source
+# wrong constant name add_path_source
+# wrong constant name add_plugin_source
+# wrong constant name add_rubygems_remote
+# wrong constant name add_rubygems_source
+# wrong constant name all_sources
+# wrong constant name cached!
+# wrong constant name default_source
+# wrong constant name get
+# wrong constant name git_sources
+# wrong constant name global_rubygems_source
+# wrong constant name global_rubygems_source=
+# wrong constant name lock_sources
+# wrong constant name metadata_source
+# wrong constant name path_sources
+# wrong constant name plugin_sources
+# wrong constant name remote!
+# wrong constant name replace_sources!
+# wrong constant name rubygems_primary_remotes
+# wrong constant name rubygems_remotes
+# wrong constant name rubygems_sources
+# wrong constant name <static-init>
+# wrong constant name <<
 # uninitialized constant Bundler::SpecSet::Elem
+# wrong constant name []
+# wrong constant name []=
+# wrong constant name each
+# wrong constant name empty?
+# wrong constant name find_by_name_and_platform
+# wrong constant name for
+# wrong constant name initialize
+# wrong constant name length
+# wrong constant name materialize
+# wrong constant name materialized_for_all_platforms
+# wrong constant name merge
+# wrong constant name size
+# wrong constant name sort!
+# wrong constant name to_a
+# wrong constant name to_hash
+# wrong constant name valid_for?
+# wrong constant name what_required
+# wrong constant name <static-init>
+# uninitialized constant Bundler::StubSpecification::GENERICS
+# Did you mean?  Bundler::StubSpecification::GENERICS
+# uninitialized constant Bundler::StubSpecification::GENERIC_CACHE
+# Did you mean?  Bundler::StubSpecification::GENERIC_CACHE
+# wrong constant name activated
+# wrong constant name activated=
+# wrong constant name default_gem
+# wrong constant name full_gem_path
+# wrong constant name full_require_paths
+# wrong constant name ignored
+# wrong constant name ignored=
+# wrong constant name load_paths
+# wrong constant name loaded_from
+# wrong constant name matches_for_glob
+# wrong constant name missing_extensions?
+# wrong constant name raw_require_paths
+# wrong constant name source=
+# wrong constant name stub
+# wrong constant name stub=
+# wrong constant name to_yaml
+# wrong constant name <static-init>
+# wrong constant name from_stub
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name <Class:RGProxy>
+# wrong constant name <Class:Shell>
+# wrong constant name <Class:Silent>
+# wrong constant name initialize
+# wrong constant name say
+# wrong constant name <static-init>
 # wrong constant name add_color
 # wrong constant name ask
 # wrong constant name confirm
@@ -561,6 +1963,32 @@
 # wrong constant name unprinted_warnings
 # wrong constant name warn
 # wrong constant name yes?
+# wrong constant name <static-init>
+# wrong constant name add_color
+# wrong constant name ask
+# wrong constant name confirm
+# wrong constant name debug
+# wrong constant name debug?
+# wrong constant name error
+# wrong constant name info
+# wrong constant name level
+# wrong constant name level=
+# wrong constant name no?
+# wrong constant name quiet?
+# wrong constant name shell=
+# wrong constant name silence
+# wrong constant name trace
+# wrong constant name unprinted_warnings
+# wrong constant name warn
+# wrong constant name yes?
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name credential_filtered_string
+# wrong constant name credential_filtered_uri
+# wrong constant name conflicts
+# wrong constant name initialize
+# wrong constant name status_code
 # wrong constant name <static-init>
 # wrong constant name <Class:NEq>
 # wrong constant name <Class:ReqR>
@@ -594,6 +2022,71 @@
 # wrong constant name empty?
 # wrong constant name for
 # wrong constant name for_many
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name dump
+# wrong constant name load
+# wrong constant name initialize
+# wrong constant name orig_exception
+# wrong constant name status_code
+# wrong constant name <static-init>
+# wrong constant name app_cache
+# wrong constant name app_config_path
+# wrong constant name bin_path
+# wrong constant name bundle_path
+# wrong constant name bundler_major_version
+# wrong constant name clean_env
+# wrong constant name clean_exec
+# wrong constant name clean_system
+# wrong constant name clear_gemspec_cache
+# wrong constant name configure
+# wrong constant name configured_bundle_path
+# wrong constant name current_ruby
+# wrong constant name default_bundle_dir
+# wrong constant name default_gemfile
+# wrong constant name default_lockfile
+# wrong constant name definition
+# wrong constant name environment
+# wrong constant name feature_flag
+# wrong constant name frozen_bundle?
+# wrong constant name git_present?
+# wrong constant name home
+# wrong constant name install_path
+# wrong constant name load_gemspec
+# wrong constant name load_gemspec_uncached
+# wrong constant name load_marshal
+# wrong constant name local_platform
+# wrong constant name locked_gems
+# wrong constant name mkdir_p
+# wrong constant name original_env
+# wrong constant name read_file
+# wrong constant name require
+# wrong constant name require_thor_actions
+# wrong constant name requires_sudo?
+# wrong constant name reset!
+# wrong constant name reset_paths!
+# wrong constant name reset_rubygems!
+# wrong constant name rm_rf
+# wrong constant name root
+# wrong constant name ruby_scope
+# wrong constant name rubygems
+# wrong constant name settings
+# wrong constant name setup
+# wrong constant name specs_path
+# wrong constant name sudo
+# wrong constant name system_bindir
+# wrong constant name tmp
+# wrong constant name tmp_home_path
+# wrong constant name ui
+# wrong constant name ui=
+# wrong constant name use_system_gems?
+# wrong constant name user_bundle_path
+# wrong constant name user_cache
+# wrong constant name user_home
+# wrong constant name which
+# wrong constant name with_clean_env
+# wrong constant name with_original_env
 # wrong constant name a
 # wrong constant name base
 # wrong constant name blockquote
@@ -621,22 +2114,15 @@
 # uninitialized constant CSV
 # uninitialized constant Chalk
 # uninitialized constant Chalk
-# undefined method `initialize$2' for class `Class'
-# Did you mean?  initialize
-# wrong constant name initialize$2
+# wrong constant name any_instance
 # wrong constant name json_creatable?
 # wrong constant name polar
 # wrong constant name rect
 # wrong constant name rectangular
 # uninitialized constant Configatron
 # uninitialized constant Configatron
-# undefined singleton method `result$1' for `Coverage'
-# undefined singleton method `start$1' for `Coverage'
-# wrong constant name line_stub
 # wrong constant name peek_result
-# wrong constant name result$1
 # wrong constant name running?
-# wrong constant name start$1
 # wrong constant name initialize
 # wrong constant name !=
 # wrong constant name ==
@@ -662,6 +2148,10 @@
 # wrong constant name original_message
 # wrong constant name spell_checker
 # wrong constant name to_s
+# wrong constant name +
+# wrong constant name <<
+# uninitialized constant DidYouMean::DeprecatedIgnoredCallers::Elem
+# wrong constant name <static-init>
 # uninitialized constant DidYouMean::Formatter
 # uninitialized constant DidYouMean::Formatter
 # wrong constant name distance
@@ -676,8 +2166,6 @@
 # wrong constant name method_name
 # wrong constant name method_names
 # wrong constant name receiver
-# wrong constant name NameErrorCheckers$1
-# wrong constant name NameErrorCheckers$1
 # wrong constant name corrections
 # wrong constant name initialize
 # wrong constant name message_for
@@ -693,37 +2181,13 @@
 # wrong constant name name
 # wrong constant name formatter
 # wrong constant name formatter=
-# undefined method `initialize$1' for class `Dir'
-# Did you mean?  initialize
-# wrong constant name children
-# wrong constant name each_child
-# wrong constant name initialize$1
-# undefined singleton method `[]$2' for `Dir'
-# undefined singleton method `chdir$2' for `Dir'
-# undefined singleton method `entries$1' for `Dir'
-# undefined singleton method `foreach$2' for `Dir'
-# undefined singleton method `glob$2' for `Dir'
-# undefined singleton method `home$1' for `Dir'
-# undefined singleton method `mkdir$1' for `Dir'
-# undefined singleton method `mktmpdir$2' for `Dir'
-# wrong constant name []$2
-# wrong constant name chdir$2
 # wrong constant name children
 # wrong constant name each_child
 # wrong constant name empty?
-# wrong constant name entries$1
 # wrong constant name exists?
-# wrong constant name foreach$2
-# wrong constant name glob$2
-# wrong constant name home$1
-# wrong constant name mkdir$1
-# wrong constant name mktmpdir$2
 # wrong constant name tmpdir
-# undefined method `initialize$1' for class `ERB'
-# Did you mean?  initialize
 # wrong constant name def_method
 # wrong constant name def_module
-# wrong constant name initialize$1
 # wrong constant name result_with_hash
 # wrong constant name _dump
 # wrong constant name convert
@@ -755,82 +2219,18 @@
 # wrong constant name source_encoding_name
 # wrong constant name _load
 # wrong constant name locale_charmap
-# undefined method `all?$2' for module `Enumerable'
-# undefined method `any?$2' for module `Enumerable'
-# undefined method `count$2' for module `Enumerable'
-# undefined method `cycle$2' for module `Enumerable'
-# undefined method `detect$2' for module `Enumerable'
-# undefined method `each_with_index$2' for module `Enumerable'
-# undefined method `entries$1' for module `Enumerable'
-# undefined method `find$2' for module `Enumerable'
-# undefined method `find_index$2' for module `Enumerable'
-# undefined method `first$2' for module `Enumerable'
-# undefined method `inject$2' for module `Enumerable'
-# undefined method `max$2' for module `Enumerable'
-# undefined method `max_by$2' for module `Enumerable'
-# undefined method `min$2' for module `Enumerable'
-# undefined method `min_by$2' for module `Enumerable'
-# undefined method `none?$2' for module `Enumerable'
-# undefined method `one?$2' for module `Enumerable'
-# undefined method `reduce$2' for module `Enumerable'
-# undefined method `reverse_each$2' for module `Enumerable'
-# undefined method `to_a$1' for module `Enumerable'
-# undefined method `to_h$1' for module `Enumerable'
-# wrong constant name all?$2
-# wrong constant name any?$2
-# wrong constant name chain
 # wrong constant name chunk
 # wrong constant name chunk_while
-# wrong constant name count$2
-# wrong constant name cycle$2
-# wrong constant name detect$2
 # wrong constant name each_entry
-# wrong constant name each_with_index$2
-# wrong constant name entries$1
-# wrong constant name filter
-# wrong constant name find$2
-# wrong constant name find_index$2
-# wrong constant name first$2
 # wrong constant name grep_v
-# wrong constant name inject$2
-# wrong constant name max$2
-# wrong constant name max_by$2
-# wrong constant name min$2
-# wrong constant name min_by$2
-# wrong constant name none?$2
-# wrong constant name one?$2
-# wrong constant name reduce$2
-# wrong constant name reverse_each$2
 # wrong constant name slice_after
 # wrong constant name slice_before
 # wrong constant name slice_when
 # wrong constant name sum
-# wrong constant name to_a$1
-# wrong constant name to_h$1
 # wrong constant name to_set
 # wrong constant name uniq
 # wrong constant name zip
-# undefined method `each$2' for class `Enumerator'
-# undefined method `initialize$1' for class `Enumerator'
-# Did you mean?  initialize
-# undefined method `with_index$2' for class `Enumerator'
-# wrong constant name +
-# wrong constant name <Class:ArithmeticSequence>
-# wrong constant name <Class:Chain>
-# wrong constant name each$2
 # wrong constant name each_with_index
-# wrong constant name initialize$1
-# wrong constant name with_index$2
-# uninitialized constant Enumerator::ArithmeticSequence::Elem
-# wrong constant name begin
-# wrong constant name each
-# wrong constant name end
-# wrong constant name exclude_end?
-# wrong constant name last
-# wrong constant name step
-# wrong constant name <static-init>
-# uninitialized constant Enumerator::Chain::Elem
-# wrong constant name <static-init>
 # wrong constant name each
 # wrong constant name initialize
 # wrong constant name chunk
@@ -838,10 +2238,16 @@
 # wrong constant name force
 # wrong constant name slice_when
 # wrong constant name <static-init>
-# wrong constant name EOPNOTSUPP$1
-# wrong constant name EOPNOTSUPP$1
-# wrong constant name EWOULDBLOCK$1
-# wrong constant name EWOULDBLOCK$1
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
 # wrong constant name gid
 # wrong constant name gid=
 # wrong constant name mem
@@ -854,8 +2260,12 @@
 # wrong constant name []
 # wrong constant name each
 # wrong constant name members
+# wrong constant name change
+# wrong constant name change=
 # wrong constant name dir
 # wrong constant name dir=
+# wrong constant name expire
+# wrong constant name expire=
 # wrong constant name gecos
 # wrong constant name gecos=
 # wrong constant name gid
@@ -866,211 +2276,53 @@
 # wrong constant name passwd=
 # wrong constant name shell
 # wrong constant name shell=
+# wrong constant name uclass
+# wrong constant name uclass=
 # wrong constant name uid
 # wrong constant name uid=
 # uninitialized constant Etc::Passwd::Elem
 # wrong constant name []
 # wrong constant name each
 # wrong constant name members
-# wrong constant name confstr
-# wrong constant name endgrent
-# wrong constant name endpwent
-# wrong constant name getgrent
-# wrong constant name getgrgid
-# wrong constant name getgrnam
-# wrong constant name getlogin
-# wrong constant name getpwent
-# wrong constant name getpwnam
-# wrong constant name getpwuid
-# wrong constant name group
-# wrong constant name nprocessors
-# wrong constant name passwd
-# wrong constant name setgrent
-# wrong constant name setpwent
-# wrong constant name sysconf
-# wrong constant name sysconfdir
-# wrong constant name systmpdir
-# wrong constant name uname
-# undefined method `exception$1' for class `Exception'
-# Did you mean?  exception
-# undefined method `initialize$1' for class `Exception'
-# Did you mean?  initialize
-# wrong constant name exception$1
 # wrong constant name full_message
-# wrong constant name initialize$1
 # wrong constant name exception
-# wrong constant name to_tty?
 # uninitialized constant Exception2MessageMapper
 # uninitialized constant Exception2MessageMapper
 # wrong constant name <static-init>
 # wrong constant name resume
 # wrong constant name yield
 # wrong constant name size?
-# undefined singleton method `absolute_path$1' for `File'
-# undefined singleton method `basename$1' for `File'
-# undefined singleton method `birthtime$1' for `File'
-# undefined singleton method `chmod$1' for `File'
-# undefined singleton method `chown$1' for `File'
-# undefined singleton method `expand_path$1' for `File'
-# undefined singleton method `fnmatch$1' for `File'
-# undefined singleton method `fnmatch?$1' for `File'
-# undefined singleton method `lchmod$1' for `File'
-# undefined singleton method `lchown$1' for `File'
-# undefined singleton method `realdirpath$1' for `File'
-# undefined singleton method `realpath$1' for `File'
-# undefined singleton method `umask$1' for `File'
-# undefined singleton method `utime$1' for `File'
-# wrong constant name absolute_path$1
-# wrong constant name basename$1
-# wrong constant name birthtime$1
-# wrong constant name chmod$1
-# wrong constant name chown$1
 # wrong constant name empty?
 # wrong constant name exists?
-# wrong constant name expand_path$1
-# wrong constant name fnmatch$1
-# wrong constant name fnmatch?$1
-# wrong constant name lchmod$1
-# wrong constant name lchown$1
 # wrong constant name lutime
 # wrong constant name mkfifo
-# wrong constant name realdirpath$1
-# wrong constant name realpath$1
-# wrong constant name umask$1
-# wrong constant name utime$1
-# wrong constant name blockdev?
-# wrong constant name chardev?
-# wrong constant name directory?
-# wrong constant name empty?
-# wrong constant name executable?
-# wrong constant name executable_real?
-# wrong constant name exist?
-# wrong constant name exists?
-# wrong constant name file?
-# wrong constant name grpowned?
-# wrong constant name identical?
-# wrong constant name owned?
-# wrong constant name pipe?
-# wrong constant name readable?
-# wrong constant name readable_real?
-# wrong constant name setgid?
-# wrong constant name setuid?
-# wrong constant name size
-# wrong constant name size?
-# wrong constant name socket?
-# wrong constant name sticky?
-# wrong constant name symlink?
-# wrong constant name world_readable?
-# wrong constant name world_writable?
-# wrong constant name writable?
-# wrong constant name writable_real?
-# wrong constant name zero?
 # uninitialized constant FileUtils::DryRun::LN_SUPPORTED
-# Did you mean?  FileUtils::LN_SUPPORTED
+# Did you mean?  FileUtils::DryRun::LN_SUPPORTED
+#                FileUtils::LN_SUPPORTED
 # uninitialized constant FileUtils::DryRun::RUBY
 # Did you mean?  FileUtils::RUBY
+#                FileUtils::DryRun::RUBY
 # uninitialized constant FileUtils::DryRun::VERSION
-# Did you mean?  FileUtils::VERSION
-# wrong constant name blockdev?
-# wrong constant name chardev?
-# wrong constant name chmod
-# wrong constant name chown
-# wrong constant name copy
-# wrong constant name copy_file
-# wrong constant name copy_metadata
-# wrong constant name dereference?
-# wrong constant name directory?
-# wrong constant name door?
-# wrong constant name entries
-# wrong constant name exist?
-# wrong constant name file?
-# wrong constant name initialize
-# wrong constant name link
-# wrong constant name lstat
-# wrong constant name lstat!
-# wrong constant name path
-# wrong constant name pipe?
-# wrong constant name platform_support
-# wrong constant name postorder_traverse
-# wrong constant name prefix
-# wrong constant name preorder_traverse
-# wrong constant name rel
-# wrong constant name remove
-# wrong constant name remove_dir1
-# wrong constant name remove_file
-# wrong constant name socket?
-# wrong constant name stat
-# wrong constant name stat!
-# wrong constant name symlink?
-# wrong constant name traverse
-# wrong constant name wrap_traverse
+# Did you mean?  FileUtils::DryRun::VERSION
+#                FileUtils::VERSION
 # uninitialized constant FileUtils::NoWrite::LN_SUPPORTED
-# Did you mean?  FileUtils::LN_SUPPORTED
+# Did you mean?  FileUtils::NoWrite::LN_SUPPORTED
+#                FileUtils::LN_SUPPORTED
 # uninitialized constant FileUtils::NoWrite::RUBY
 # Did you mean?  FileUtils::RUBY
+#                FileUtils::NoWrite::RUBY
 # uninitialized constant FileUtils::NoWrite::VERSION
-# Did you mean?  FileUtils::VERSION
+# Did you mean?  FileUtils::NoWrite::VERSION
+#                FileUtils::VERSION
 # uninitialized constant FileUtils::Verbose::LN_SUPPORTED
-# Did you mean?  FileUtils::LN_SUPPORTED
+# Did you mean?  FileUtils::Verbose::LN_SUPPORTED
+#                FileUtils::LN_SUPPORTED
 # uninitialized constant FileUtils::Verbose::RUBY
 # Did you mean?  FileUtils::RUBY
+#                FileUtils::Verbose::RUBY
 # uninitialized constant FileUtils::Verbose::VERSION
-# Did you mean?  FileUtils::VERSION
-# undefined singleton method `cp_r$1' for `FileUtils'
-# undefined singleton method `mkdir_p$1' for `FileUtils'
-# wrong constant name cd
-# wrong constant name chdir
-# wrong constant name chmod
-# wrong constant name chmod_R
-# wrong constant name chown
-# wrong constant name chown_R
-# wrong constant name cmp
-# wrong constant name collect_method
-# wrong constant name commands
-# wrong constant name compare_file
-# wrong constant name compare_stream
-# wrong constant name copy
-# wrong constant name copy_entry
-# wrong constant name copy_file
-# wrong constant name copy_stream
-# wrong constant name cp
-# wrong constant name cp_lr
-# wrong constant name cp_r$1
-# wrong constant name getwd
-# wrong constant name have_option?
-# wrong constant name identical?
-# wrong constant name install
-# wrong constant name link
-# wrong constant name link_entry
-# wrong constant name ln
-# wrong constant name ln_s
-# wrong constant name ln_sf
-# wrong constant name makedirs
-# wrong constant name mkdir
-# wrong constant name mkdir_p$1
-# wrong constant name mkpath
-# wrong constant name move
-# wrong constant name mv
-# wrong constant name options
-# wrong constant name options_of
-# wrong constant name private_module_function
-# wrong constant name pwd
-# wrong constant name remove
-# wrong constant name remove_dir
-# wrong constant name remove_entry
-# wrong constant name remove_entry_secure
-# wrong constant name remove_file
-# wrong constant name rm
-# wrong constant name rm_f
-# wrong constant name rm_rf
-# wrong constant name rmdir
-# wrong constant name rmtree
-# wrong constant name safe_unlink
-# wrong constant name symlink
-# wrong constant name uptodate?
-# undefined method `rationalize$2' for class `Float'
-# Did you mean?  Rational
-# wrong constant name rationalize$2
+# Did you mean?  FileUtils::Verbose::VERSION
+#                FileUtils::VERSION
 # wrong constant name def_delegator
 # wrong constant name def_delegators
 # wrong constant name def_instance_delegator
@@ -1084,36 +2336,1866 @@
 # wrong constant name debug=
 # wrong constant name <static-init>
 # wrong constant name garbage_collect
-# undefined singleton method `start$1' for `GC'
-# undefined singleton method `stat$2' for `GC'
 # wrong constant name latest_gc_info
-# wrong constant name start$1
-# wrong constant name stat$2
 # wrong constant name stress=
 # wrong constant name verify_internal_consistency
-# wrong constant name verify_transient_heap_internal_consistency
+# wrong constant name <Class:AvailableSet>
+# wrong constant name <Class:BundlerVersionFinder>
+# wrong constant name <Class:Command>
+# wrong constant name <Class:Commands>
+# wrong constant name <Class:ConfigFile>
+# wrong constant name <Class:ConsoleUI>
+# wrong constant name <Class:DefaultUserInteraction>
+# wrong constant name <Class:DependencyInstaller>
+# wrong constant name <Class:DependencyList>
+# wrong constant name <Class:Ext>
+# wrong constant name <Class:Installer>
+# wrong constant name <Class:Licenses>
+# wrong constant name <Class:NameTuple>
+# wrong constant name <Class:Package>
+# wrong constant name <Class:RemoteFetcher>
+# wrong constant name <Class:Request>
+# wrong constant name <Class:RequestSet>
+# wrong constant name <Class:Resolver>
+# wrong constant name <Class:RuntimeRequirementNotMetError>
+# wrong constant name <Class:Security>
+# wrong constant name <Class:SilentUI>
+# wrong constant name <Class:Source>
+# wrong constant name <Class:SourceList>
+# wrong constant name <Class:SpecFetcher>
+# wrong constant name <Class:StreamUI>
+# wrong constant name <Class:Text>
+# wrong constant name <Class:UriFormatter>
+# wrong constant name <Class:UserInteraction>
+# wrong constant name <Class:Util>
+# wrong constant name <<
+# uninitialized constant Gem::AvailableSet::Elem
+# wrong constant name <Class:Tuple>
+# wrong constant name add
+# wrong constant name all_specs
+# wrong constant name each
+# wrong constant name each_spec
+# wrong constant name empty?
+# wrong constant name find_all
+# wrong constant name inject_into_list
+# wrong constant name match_platform!
+# wrong constant name pick_best!
+# wrong constant name prefetch
+# wrong constant name remote
+# wrong constant name remote=
+# wrong constant name remove_installed!
+# wrong constant name set
+# wrong constant name size
+# wrong constant name sorted
+# wrong constant name source_for
+# wrong constant name to_request_set
+# uninitialized constant Gem::AvailableSet::Tuple::Elem
+# wrong constant name source
+# wrong constant name source=
+# wrong constant name spec
+# wrong constant name spec=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# wrong constant name <static-init>
+# wrong constant name activated?
+# wrong constant name base_dir
+# wrong constant name base_dir=
+# wrong constant name contains_requirable_file?
+# wrong constant name datadir
+# wrong constant name default_gem?
+# wrong constant name extension_dir
+# wrong constant name extension_dir=
+# wrong constant name extensions_dir
+# wrong constant name full_gem_path
+# wrong constant name full_gem_path=
+# wrong constant name full_name
+# wrong constant name full_require_paths
+# wrong constant name gem_build_complete_path
+# wrong constant name gem_dir
+# wrong constant name gems_dir
+# wrong constant name ignored=
+# wrong constant name internal_init
+# wrong constant name lib_dirs_glob
+# wrong constant name loaded_from
+# wrong constant name loaded_from=
+# wrong constant name matches_for_glob
+# wrong constant name name
+# wrong constant name platform
+# wrong constant name raw_require_paths
+# wrong constant name require_paths
+# wrong constant name source_paths
+# wrong constant name stubbed?
+# wrong constant name this
+# wrong constant name to_fullpath
+# wrong constant name to_spec
+# wrong constant name version
+# wrong constant name default_specifications_dir
+# wrong constant name <static-init>
+# wrong constant name bundler_version
+# wrong constant name bundler_version_with_reason
+# wrong constant name compatible?
+# wrong constant name filter!
+# wrong constant name missing_version_message
+# wrong constant name without_filtering
+# wrong constant name add_extra_args
+# wrong constant name add_option
+# wrong constant name arguments
+# wrong constant name begins?
+# wrong constant name command
+# wrong constant name defaults
+# wrong constant name defaults=
+# wrong constant name defaults_str
+# wrong constant name description
+# wrong constant name execute
+# wrong constant name get_all_gem_names
+# wrong constant name get_all_gem_names_and_versions
+# wrong constant name get_one_gem_name
+# wrong constant name get_one_optional_argument
+# wrong constant name handle_options
+# wrong constant name handles?
+# wrong constant name initialize
+# wrong constant name invoke
+# wrong constant name invoke_with_build_args
+# wrong constant name merge_options
+# wrong constant name options
+# wrong constant name program_name
+# wrong constant name program_name=
+# wrong constant name remove_option
+# wrong constant name show_help
+# wrong constant name show_lookup_failure
+# wrong constant name summary
+# wrong constant name summary=
+# wrong constant name usage
+# wrong constant name when_invoked
+# wrong constant name <static-init>
+# wrong constant name add_common_option
+# wrong constant name add_specific_extra_args
+# wrong constant name build_args
+# wrong constant name build_args=
+# wrong constant name common_options
+# wrong constant name extra_args
+# wrong constant name extra_args=
+# wrong constant name specific_extra_args
+# wrong constant name specific_extra_args_hash
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name []
+# wrong constant name []=
+# wrong constant name api_keys
+# wrong constant name args
+# wrong constant name backtrace
+# wrong constant name backtrace=
+# wrong constant name bulk_threshold
+# wrong constant name bulk_threshold=
+# wrong constant name check_credentials_permissions
+# wrong constant name config_file_name
+# wrong constant name credentials_path
+# wrong constant name disable_default_gem_server
+# wrong constant name disable_default_gem_server=
+# wrong constant name each
+# wrong constant name handle_arguments
+# wrong constant name home
+# wrong constant name home=
+# wrong constant name initialize
+# wrong constant name load_api_keys
+# wrong constant name load_file
+# wrong constant name path
+# wrong constant name path=
+# wrong constant name really_verbose
+# wrong constant name rubygems_api_key
+# wrong constant name rubygems_api_key=
+# wrong constant name set_api_key
+# wrong constant name sources
+# wrong constant name sources=
+# wrong constant name ssl_ca_cert
+# wrong constant name ssl_ca_cert=
+# wrong constant name ssl_client_cert
+# wrong constant name ssl_verify_mode
+# wrong constant name to_yaml
+# wrong constant name unset_api_key!
+# wrong constant name update_sources
+# wrong constant name update_sources=
+# wrong constant name verbose
+# wrong constant name verbose=
+# wrong constant name write
+# wrong constant name <static-init>
+# wrong constant name conflicts
+# wrong constant name initialize
+# wrong constant name target
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name ui
+# wrong constant name ui=
+# wrong constant name use_ui
+# wrong constant name <static-init>
+# wrong constant name ui
+# wrong constant name ui=
+# wrong constant name use_ui
+# wrong constant name <=>
+# wrong constant name ==
+# wrong constant name ===
+# wrong constant name =~
+# wrong constant name all_sources
+# wrong constant name all_sources=
+# wrong constant name encode_with
+# wrong constant name eql?
+# wrong constant name groups
+# wrong constant name groups=
+# wrong constant name initialize
+# wrong constant name latest_version?
+# wrong constant name match?
+# wrong constant name matches_spec?
+# wrong constant name matching_specs
+# wrong constant name merge
+# wrong constant name name
+# wrong constant name name=
+# wrong constant name prerelease=
+# wrong constant name prerelease?
+# wrong constant name requirement
+# wrong constant name requirements_list
+# wrong constant name runtime?
+# wrong constant name source
+# wrong constant name source=
+# wrong constant name specific?
+# wrong constant name to_lock
+# wrong constant name to_spec
+# wrong constant name to_specs
+# wrong constant name to_yaml_properties
+# wrong constant name type
+# wrong constant name _deprecated_gems_to_install
+# wrong constant name add_found_dependencies
+# wrong constant name available_set_for
+# wrong constant name consider_local?
+# wrong constant name consider_remote?
+# wrong constant name document
+# wrong constant name errors
+# wrong constant name find_gems_with_sources
+# wrong constant name find_spec_by_name_and_version
+# wrong constant name gather_dependencies
+# wrong constant name gems_to_install
+# wrong constant name in_background
+# wrong constant name initialize
+# wrong constant name install
+# wrong constant name install_development_deps
+# wrong constant name installed_gems
+# wrong constant name resolve_dependencies
+# wrong constant name <static-init>
+# uninitialized constant Gem::DependencyList::Elem
+# wrong constant name add
+# wrong constant name clear
+# wrong constant name dependency_order
+# wrong constant name development
+# wrong constant name development=
+# wrong constant name each
+# wrong constant name find_name
+# wrong constant name initialize
+# wrong constant name ok?
+# wrong constant name ok_to_remove?
+# wrong constant name remove_by_name
+# wrong constant name remove_specs_unsatisfied_by
+# wrong constant name spec_predecessors
+# wrong constant name specs
+# wrong constant name tsort_each_node
+# wrong constant name why_not_ok?
+# wrong constant name <static-init>
+# wrong constant name from_specs
+# wrong constant name conflict
+# wrong constant name conflicting_dependencies
+# wrong constant name initialize
+# wrong constant name deprecate
+# wrong constant name skip
+# wrong constant name skip=
+# wrong constant name skip_during
+# wrong constant name source_exception
+# wrong constant name source_exception=
+# wrong constant name <Class:BuildError>
+# wrong constant name <Class:Builder>
+# wrong constant name <Class:CmakeBuilder>
+# wrong constant name <Class:ConfigureBuilder>
+# wrong constant name <Class:ExtConfBuilder>
+# wrong constant name <Class:RakeBuilder>
+# wrong constant name <static-init>
+# wrong constant name build_args
+# wrong constant name build_args=
+# wrong constant name build_error
+# wrong constant name build_extension
+# wrong constant name build_extensions
+# wrong constant name builder_for
+# wrong constant name initialize
+# wrong constant name write_gem_make_out
+# wrong constant name <static-init>
+# wrong constant name class_name
+# wrong constant name make
+# wrong constant name redirector
+# wrong constant name run
+# uninitialized constant Gem::Ext::CmakeBuilder::CHDIR_MONITOR
+# Did you mean?  Gem::Ext::CmakeBuilder::CHDIR_MONITOR
+# uninitialized constant Gem::Ext::CmakeBuilder::CHDIR_MUTEX
+# Did you mean?  Gem::Ext::CmakeBuilder::CHDIR_MUTEX
+# wrong constant name <static-init>
+# wrong constant name build
+# uninitialized constant Gem::Ext::ConfigureBuilder::CHDIR_MONITOR
+# Did you mean?  Gem::Ext::ConfigureBuilder::CHDIR_MONITOR
+# uninitialized constant Gem::Ext::ConfigureBuilder::CHDIR_MUTEX
+# Did you mean?  Gem::Ext::ConfigureBuilder::CHDIR_MUTEX
+# wrong constant name <static-init>
+# wrong constant name build
+# uninitialized constant Gem::Ext::ExtConfBuilder::CHDIR_MONITOR
+# Did you mean?  Gem::Ext::ExtConfBuilder::CHDIR_MONITOR
+# uninitialized constant Gem::Ext::ExtConfBuilder::CHDIR_MUTEX
+# Did you mean?  Gem::Ext::ExtConfBuilder::CHDIR_MUTEX
+# wrong constant name <static-init>
+# wrong constant name build
+# wrong constant name get_relative_path
+# uninitialized constant Gem::Ext::RakeBuilder::CHDIR_MONITOR
+# Did you mean?  Gem::Ext::RakeBuilder::CHDIR_MONITOR
+# uninitialized constant Gem::Ext::RakeBuilder::CHDIR_MUTEX
+# Did you mean?  Gem::Ext::RakeBuilder::CHDIR_MUTEX
+# wrong constant name <static-init>
+# wrong constant name build
+# wrong constant name <static-init>
+# wrong constant name directory
+# wrong constant name initialize
+# wrong constant name file_path
+# wrong constant name file_path=
+# wrong constant name spec
+# wrong constant name spec=
+# wrong constant name build_message
+# wrong constant name conflicts
+# wrong constant name dependency
+# wrong constant name initialize
+# wrong constant name request
+# wrong constant name app_script_text
+# wrong constant name bin_dir
+# wrong constant name build_extensions
+# wrong constant name build_root
+# wrong constant name check_executable_overwrite
+# wrong constant name check_that_user_bin_dir_is_in_path
+# wrong constant name default_spec_file
+# wrong constant name dir
+# wrong constant name ensure_dependencies_met
+# wrong constant name ensure_dependency
+# wrong constant name ensure_loadable_spec
+# wrong constant name ensure_required_ruby_version_met
+# wrong constant name ensure_required_rubygems_version_met
+# wrong constant name extension_build_error
+# wrong constant name extract_bin
+# wrong constant name extract_files
+# wrong constant name formatted_program_filename
+# wrong constant name gem
+# wrong constant name gem_dir
+# wrong constant name gem_home
+# wrong constant name generate_bin
+# wrong constant name generate_bin_script
+# wrong constant name generate_bin_symlink
+# wrong constant name generate_windows_script
+# wrong constant name initialize
+# wrong constant name install
+# wrong constant name installation_satisfies_dependency?
+# wrong constant name installed_specs
+# wrong constant name options
+# wrong constant name pre_install_checks
+# wrong constant name process_options
+# wrong constant name run_post_build_hooks
+# wrong constant name run_post_install_hooks
+# wrong constant name run_pre_install_hooks
+# wrong constant name shebang
+# wrong constant name spec
+# wrong constant name spec_file
+# wrong constant name unpack
+# wrong constant name verify_gem_home
+# wrong constant name verify_spec_name
+# wrong constant name windows_stub_script
+# wrong constant name write_build_info_file
+# wrong constant name write_cache_file
+# wrong constant name write_default_spec
+# wrong constant name write_spec
+# wrong constant name <static-init>
+# wrong constant name at
+# wrong constant name exec_format
+# wrong constant name exec_format=
+# wrong constant name for_spec
+# wrong constant name install_lock
+# wrong constant name path_warning
+# wrong constant name path_warning=
+# wrong constant name <static-init>
+# wrong constant name match?
+# wrong constant name suggestions
+# wrong constant name each
+# wrong constant name initialize
+# wrong constant name prepend
+# wrong constant name tail
+# wrong constant name tail=
+# wrong constant name to_a
+# wrong constant name value
+# wrong constant name value=
+# wrong constant name prepend
+# wrong constant name name
+# wrong constant name name=
+# wrong constant name requirement
+# wrong constant name requirement=
+# wrong constant name initialize
+# wrong constant name initialize
+# wrong constant name specs
+# wrong constant name <=>
+# wrong constant name ==
+# wrong constant name eql?
+# wrong constant name full_name
+# wrong constant name initialize
+# wrong constant name match_platform?
+# wrong constant name name
+# wrong constant name platform
+# wrong constant name prerelease?
+# wrong constant name spec_name
+# wrong constant name to_a
+# wrong constant name version
+# wrong constant name <static-init>
+# wrong constant name from_list
+# wrong constant name null
+# wrong constant name to_basic
+# wrong constant name <Class:DigestIO>
+# wrong constant name <Class:Error>
+# wrong constant name <Class:FileSource>
+# wrong constant name <Class:FormatError>
+# wrong constant name <Class:IOSource>
+# wrong constant name <Class:NonSeekableIO>
+# wrong constant name <Class:Old>
+# wrong constant name <Class:PathError>
+# wrong constant name <Class:Source>
+# wrong constant name <Class:TarHeader>
+# wrong constant name <Class:TarInvalidError>
+# wrong constant name <Class:TarReader>
+# wrong constant name <Class:TarWriter>
+# wrong constant name <Class:TooLongFileName>
+# wrong constant name add_checksums
+# wrong constant name add_contents
+# wrong constant name add_files
+# wrong constant name add_metadata
+# wrong constant name build
+# wrong constant name build_time
+# wrong constant name build_time=
+# wrong constant name checksums
+# wrong constant name contents
+# wrong constant name copy_to
+# wrong constant name digest
+# wrong constant name extract_files
+# wrong constant name extract_tar_gz
+# wrong constant name files
+# wrong constant name gzip_to
+# wrong constant name initialize
+# wrong constant name install_location
+# wrong constant name load_spec
+# wrong constant name open_tar_gz
+# wrong constant name read_checksums
+# wrong constant name security_policy
+# wrong constant name security_policy=
+# wrong constant name setup_signer
+# wrong constant name spec
+# wrong constant name spec=
+# wrong constant name verify
+# wrong constant name verify_checksums
+# wrong constant name verify_entry
+# wrong constant name verify_files
+# wrong constant name verify_gz
+# wrong constant name digests
+# wrong constant name initialize
+# wrong constant name write
+# wrong constant name <static-init>
+# wrong constant name wrap
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name path
+# wrong constant name present?
+# wrong constant name start
+# wrong constant name with_read_io
+# wrong constant name with_write_io
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name path
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name io
+# wrong constant name path
+# wrong constant name present?
+# wrong constant name start
+# wrong constant name with_read_io
+# wrong constant name with_write_io
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name extract_files
+# wrong constant name file_list
+# wrong constant name read_until_dashes
+# wrong constant name skip_ruby
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name checksum
+# wrong constant name devmajor
+# wrong constant name devminor
+# wrong constant name empty?
+# wrong constant name gid
+# wrong constant name gname
+# wrong constant name initialize
+# wrong constant name linkname
+# wrong constant name magic
+# wrong constant name mode
+# wrong constant name mtime
+# wrong constant name name
+# wrong constant name prefix
+# wrong constant name size
+# wrong constant name typeflag
+# wrong constant name uid
+# wrong constant name uname
+# wrong constant name update_checksum
+# wrong constant name version
+# wrong constant name <static-init>
+# wrong constant name from
+# wrong constant name <static-init>
+# uninitialized constant Gem::Package::TarReader::Elem
+# wrong constant name <Class:Entry>
+# wrong constant name <Class:UnexpectedEOF>
+# wrong constant name close
+# wrong constant name each
+# wrong constant name each_entry
+# wrong constant name initialize
+# wrong constant name rewind
+# wrong constant name seek
+# wrong constant name bytes_read
+# wrong constant name check_closed
+# wrong constant name close
+# wrong constant name closed?
+# wrong constant name directory?
+# wrong constant name eof?
+# wrong constant name file?
+# wrong constant name full_name
+# wrong constant name getc
+# wrong constant name header
+# wrong constant name initialize
+# wrong constant name pos
+# wrong constant name read
+# wrong constant name readpartial
+# wrong constant name rewind
+# wrong constant name symlink?
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name new
+# wrong constant name <Class:BoundedStream>
+# wrong constant name <Class:FileOverflow>
+# wrong constant name <Class:RestrictedStream>
+# wrong constant name add_file
+# wrong constant name add_file_digest
+# wrong constant name add_file_signed
+# wrong constant name add_file_simple
+# wrong constant name add_symlink
+# wrong constant name check_closed
+# wrong constant name close
+# wrong constant name closed?
+# wrong constant name flush
+# wrong constant name initialize
+# wrong constant name mkdir
+# wrong constant name split_name
+# wrong constant name initialize
+# wrong constant name limit
+# wrong constant name write
+# wrong constant name written
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name write
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name new
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name build
+# wrong constant name new
+# wrong constant name home
+# wrong constant name initialize
+# wrong constant name path
+# wrong constant name spec_cache_dir
+# wrong constant name ==
+# wrong constant name ===
+# wrong constant name =~
+# wrong constant name cpu
+# wrong constant name cpu=
+# wrong constant name eql?
+# wrong constant name initialize
+# wrong constant name os
+# wrong constant name os=
+# wrong constant name to_a
+# wrong constant name version
+# wrong constant name version=
+# wrong constant name installable?
+# wrong constant name local
+# wrong constant name match
+# wrong constant name new
+# wrong constant name add_platform
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name platforms
+# wrong constant name version
+# wrong constant name wordy
+# wrong constant name api_endpoint
+# wrong constant name cache_update_path
+# wrong constant name close_all
+# wrong constant name correct_for_windows_path
+# wrong constant name download
+# wrong constant name download_to_cache
+# wrong constant name fetch_file
+# wrong constant name fetch_http
+# wrong constant name fetch_https
+# wrong constant name fetch_path
+# wrong constant name fetch_s3
+# wrong constant name fetch_size
+# wrong constant name headers
+# wrong constant name headers=
+# wrong constant name https?
+# wrong constant name initialize
+# wrong constant name request
+# wrong constant name s3_expiration
+# wrong constant name sign_s3_url
+# wrong constant name <static-init>
+# wrong constant name fetcher
+# wrong constant name <Class:ConnectionPools>
+# wrong constant name <Class:HTTPPool>
+# wrong constant name <Class:HTTPSPool>
+# wrong constant name cert_files
+# wrong constant name connection_for
+# wrong constant name fetch
+# wrong constant name initialize
+# wrong constant name perform_request
+# wrong constant name proxy_uri
+# wrong constant name reset
+# wrong constant name user_agent
+# wrong constant name close_all
+# wrong constant name initialize
+# wrong constant name pool_for
+# wrong constant name <static-init>
+# wrong constant name client
+# wrong constant name client=
+# wrong constant name cert_files
+# wrong constant name checkin
+# wrong constant name checkout
+# wrong constant name close_all
+# wrong constant name initialize
+# wrong constant name proxy_uri
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name configure_connection_for_https
+# wrong constant name create_with_proxy
+# wrong constant name get_cert_files
+# wrong constant name get_proxy_from_env
+# wrong constant name proxy_uri
+# wrong constant name verify_certificate
+# wrong constant name verify_certificate_message
+# wrong constant name <Class:GemDependencyAPI>
+# wrong constant name <Class:Lockfile>
+# wrong constant name always_install
+# wrong constant name always_install=
+# wrong constant name dependencies
+# wrong constant name development
+# wrong constant name development=
+# wrong constant name development_shallow
+# wrong constant name development_shallow=
+# wrong constant name errors
+# wrong constant name gem
+# wrong constant name git_set
+# wrong constant name ignore_dependencies
+# wrong constant name ignore_dependencies=
+# wrong constant name import
+# wrong constant name initialize
+# wrong constant name install
+# wrong constant name install_dir
+# wrong constant name install_from_gemdeps
+# wrong constant name install_into
+# wrong constant name load_gemdeps
+# wrong constant name prerelease
+# wrong constant name prerelease=
+# wrong constant name remote
+# wrong constant name remote=
+# wrong constant name resolve
+# wrong constant name resolve_current
+# wrong constant name resolver
+# wrong constant name sets
+# wrong constant name soft_missing
+# wrong constant name soft_missing=
+# wrong constant name sorted_requests
+# wrong constant name source_set
+# wrong constant name specs
+# wrong constant name specs_in
+# wrong constant name tsort_each_node
+# wrong constant name vendor_set
+# wrong constant name dependencies
+# wrong constant name find_gemspec
+# wrong constant name gem
+# wrong constant name gem_deps_file
+# wrong constant name gem_git_reference
+# wrong constant name gemspec
+# wrong constant name git
+# wrong constant name git_set
+# wrong constant name git_source
+# wrong constant name group
+# wrong constant name initialize
+# wrong constant name installing=
+# wrong constant name load
+# wrong constant name platform
+# wrong constant name platforms
+# wrong constant name requires
+# wrong constant name ruby
+# wrong constant name source
+# wrong constant name vendor_set
+# wrong constant name without_groups
+# wrong constant name without_groups=
+# wrong constant name <static-init>
+# wrong constant name <Class:ParseError>
+# wrong constant name <Class:Parser>
+# wrong constant name <Class:Tokenizer>
+# wrong constant name add_DEPENDENCIES
+# wrong constant name add_GEM
+# wrong constant name add_GIT
+# wrong constant name add_PATH
+# wrong constant name add_PLATFORMS
+# wrong constant name initialize
+# wrong constant name platforms
+# wrong constant name relative_path_from
+# wrong constant name spec_groups
+# wrong constant name write
+# wrong constant name column
+# wrong constant name initialize
+# wrong constant name line
+# wrong constant name path
+# wrong constant name <static-init>
+# wrong constant name get
+# wrong constant name initialize
+# wrong constant name parse
+# wrong constant name parse_DEPENDENCIES
+# wrong constant name parse_GEM
+# wrong constant name parse_GIT
+# wrong constant name parse_PATH
+# wrong constant name parse_PLATFORMS
+# wrong constant name parse_dependency
+# wrong constant name <static-init>
+# wrong constant name <Class:Token>
+# wrong constant name empty?
+# wrong constant name initialize
+# wrong constant name make_parser
+# wrong constant name next_token
+# wrong constant name peek
+# wrong constant name shift
+# wrong constant name skip
+# wrong constant name to_a
+# wrong constant name token_pos
+# wrong constant name unshift
+# uninitialized constant Gem::RequestSet::Lockfile::Tokenizer::Token::Elem
+# wrong constant name column
+# wrong constant name column=
+# wrong constant name line
+# wrong constant name line=
+# wrong constant name type
+# wrong constant name type=
+# wrong constant name value
+# wrong constant name value=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# wrong constant name <static-init>
+# wrong constant name from_file
+# wrong constant name <static-init>
+# wrong constant name build
+# wrong constant name requests_to_deps
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name ===
+# wrong constant name =~
+# wrong constant name as_list
+# wrong constant name concat
+# wrong constant name encode_with
+# wrong constant name exact?
+# wrong constant name for_lockfile
+# wrong constant name init_with
+# wrong constant name initialize
+# wrong constant name marshal_dump
+# wrong constant name marshal_load
+# wrong constant name none?
+# wrong constant name prerelease?
+# wrong constant name requirements
+# wrong constant name satisfied_by?
+# wrong constant name specific?
+# wrong constant name to_yaml_properties
+# wrong constant name yaml_initialize
+# wrong constant name create
+# wrong constant name default
+# wrong constant name parse
+# wrong constant name source_set
+# wrong constant name <Class:APISet>
+# wrong constant name <Class:APISpecification>
+# wrong constant name <Class:ActivationRequest>
+# wrong constant name <Class:BestSet>
+# wrong constant name <Class:ComposedSet>
+# wrong constant name <Class:Conflict>
+# wrong constant name <Class:CurrentSet>
+# wrong constant name <Class:DependencyRequest>
+# wrong constant name <Class:GitSet>
+# wrong constant name <Class:GitSpecification>
+# wrong constant name <Class:IndexSet>
+# wrong constant name <Class:IndexSpecification>
+# wrong constant name <Class:InstalledSpecification>
+# wrong constant name <Class:InstallerSet>
+# wrong constant name <Class:LocalSpecification>
+# wrong constant name <Class:LockSet>
+# wrong constant name <Class:LockSpecification>
+# wrong constant name <Class:Molinillo>
+# wrong constant name <Class:RequirementList>
+# wrong constant name <Class:Set>
+# wrong constant name <Class:SourceSet>
+# wrong constant name <Class:SpecSpecification>
+# wrong constant name <Class:Specification>
+# wrong constant name <Class:Stats>
+# wrong constant name <Class:VendorSet>
+# wrong constant name <Class:VendorSpecification>
+# wrong constant name activation_request
+# wrong constant name development
+# wrong constant name development=
+# wrong constant name development_shallow
+# wrong constant name development_shallow=
+# wrong constant name explain
+# wrong constant name explain_list
+# wrong constant name find_possible
+# wrong constant name ignore_dependencies
+# wrong constant name ignore_dependencies=
+# wrong constant name initialize
+# wrong constant name missing
+# wrong constant name requests
+# wrong constant name resolve
+# wrong constant name select_local_platforms
+# wrong constant name skip_gems
+# wrong constant name skip_gems=
+# wrong constant name soft_missing
+# wrong constant name soft_missing=
+# wrong constant name stats
+# wrong constant name dep_uri
+# wrong constant name initialize
+# wrong constant name prefetch_now
+# wrong constant name source
+# wrong constant name uri
+# wrong constant name versions
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name development?
+# wrong constant name download
+# wrong constant name full_name
+# wrong constant name full_spec
+# wrong constant name initialize
+# wrong constant name installed?
+# wrong constant name name
+# wrong constant name others_possible?
+# wrong constant name parent
+# wrong constant name request
+# wrong constant name spec
+# wrong constant name version
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name pick_sets
+# wrong constant name replace_failed_api_set
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name prerelease=
+# wrong constant name remote=
+# wrong constant name sets
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name activated
+# wrong constant name conflicting_dependencies
+# wrong constant name dependency
+# wrong constant name explain
+# wrong constant name explanation
+# wrong constant name failed_dep
+# wrong constant name for_spec?
+# wrong constant name initialize
+# wrong constant name request_path
+# wrong constant name requester
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name dependency
+# wrong constant name development?
+# wrong constant name explicit?
+# wrong constant name implicit?
+# wrong constant name initialize
+# wrong constant name match?
+# wrong constant name matches_spec?
+# wrong constant name name
+# wrong constant name request_context
+# wrong constant name requester
+# wrong constant name requirement
+# wrong constant name type
+# wrong constant name <static-init>
+# wrong constant name add_git_gem
+# wrong constant name add_git_spec
+# wrong constant name need_submodules
+# wrong constant name repositories
+# wrong constant name root_dir
+# wrong constant name root_dir=
+# wrong constant name specs
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name add_dependency
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name <static-init>
+# wrong constant name add_always_install
+# wrong constant name add_local
+# wrong constant name always_install
+# wrong constant name consider_local?
+# wrong constant name consider_remote?
+# wrong constant name ignore_dependencies
+# wrong constant name ignore_dependencies=
+# wrong constant name ignore_installed
+# wrong constant name ignore_installed=
+# wrong constant name initialize
+# wrong constant name load_spec
+# wrong constant name local?
+# wrong constant name prerelease=
+# wrong constant name remote=
+# wrong constant name remote_set
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name add
+# wrong constant name initialize
+# wrong constant name load_spec
+# wrong constant name specs
+# wrong constant name <static-init>
+# wrong constant name add_dependency
+# wrong constant name initialize
+# wrong constant name sources
+# wrong constant name <static-init>
+# wrong constant name <Class:CircularDependencyError>
+# wrong constant name <Class:Delegates>
+# wrong constant name <Class:DependencyGraph>
+# wrong constant name <Class:DependencyState>
+# wrong constant name <Class:NoSuchDependencyError>
+# wrong constant name <Class:PossibilityState>
+# wrong constant name <Class:ResolutionState>
+# wrong constant name <Class:Resolver>
+# wrong constant name <Class:ResolverError>
+# wrong constant name <Class:SpecificationProvider>
+# wrong constant name <Class:UI>
+# wrong constant name <Class:VersionConflict>
+# wrong constant name dependencies
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <Class:ResolutionState>
+# wrong constant name <Class:SpecificationProvider>
+# wrong constant name activated
+# wrong constant name conflicts
+# wrong constant name depth
+# wrong constant name name
+# wrong constant name possibilities
+# wrong constant name requirement
+# wrong constant name requirements
+# wrong constant name <static-init>
+# wrong constant name allow_missing?
+# wrong constant name dependencies_for
+# wrong constant name name_for
+# wrong constant name name_for_explicit_dependency_source
+# wrong constant name name_for_locking_dependency_source
+# wrong constant name requirement_satisfied_by?
+# wrong constant name search_for
+# wrong constant name sort_dependencies
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name <Class:Action>
+# wrong constant name <Class:AddEdgeNoCircular>
+# wrong constant name <Class:AddVertex>
+# wrong constant name <Class:DeleteEdge>
+# wrong constant name <Class:DetachVertexNamed>
+# wrong constant name <Class:Edge>
+# uninitialized constant Gem::Resolver::Molinillo::DependencyGraph::Elem
+# wrong constant name <Class:Log>
+# wrong constant name <Class:SetPayload>
+# wrong constant name <Class:Tag>
+# wrong constant name <Class:Vertex>
+# wrong constant name add_child_vertex
+# wrong constant name add_edge
+# wrong constant name add_vertex
+# wrong constant name delete_edge
+# wrong constant name detach_vertex_named
+# wrong constant name each
+# wrong constant name log
+# wrong constant name rewind_to
+# wrong constant name root_vertex_named
+# wrong constant name set_payload
+# wrong constant name tag
+# wrong constant name to_dot
+# wrong constant name tsort_each_child
+# wrong constant name vertex_named
+# wrong constant name vertices
+# wrong constant name down
+# wrong constant name next
+# wrong constant name next=
+# wrong constant name previous
+# wrong constant name previous=
+# wrong constant name up
+# wrong constant name <static-init>
+# wrong constant name action_name
+# wrong constant name destination
+# wrong constant name initialize
+# wrong constant name make_edge
+# wrong constant name origin
+# wrong constant name requirement
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name payload
+# wrong constant name root
+# wrong constant name <static-init>
+# wrong constant name destination_name
+# wrong constant name initialize
+# wrong constant name make_edge
+# wrong constant name origin_name
+# wrong constant name requirement
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name <static-init>
+# uninitialized constant Gem::Resolver::Molinillo::DependencyGraph::Edge::Elem
+# wrong constant name destination
+# wrong constant name destination=
+# wrong constant name origin
+# wrong constant name origin=
+# wrong constant name requirement
+# wrong constant name requirement=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# wrong constant name add_edge_no_circular
+# wrong constant name add_vertex
+# wrong constant name delete_edge
+# wrong constant name detach_vertex_named
+# wrong constant name each
+# wrong constant name pop!
+# wrong constant name reverse_each
+# wrong constant name rewind_to
+# wrong constant name set_payload
+# wrong constant name tag
+# wrong constant name <static-init>
 # uninitialized constant Gem::Resolver::Molinillo::DependencyGraph::Log::Elem
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name payload
+# wrong constant name <static-init>
+# wrong constant name down
+# wrong constant name initialize
+# wrong constant name tag
+# wrong constant name up
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name ancestor?
+# wrong constant name descendent?
+# wrong constant name eql?
+# wrong constant name explicit_requirements
+# wrong constant name incoming_edges
+# wrong constant name incoming_edges=
+# wrong constant name initialize
+# wrong constant name is_reachable_from?
+# wrong constant name name
+# wrong constant name name=
+# wrong constant name outgoing_edges
+# wrong constant name outgoing_edges=
+# wrong constant name path_to?
+# wrong constant name payload
+# wrong constant name payload=
+# wrong constant name predecessors
+# wrong constant name recursive_predecessors
+# wrong constant name recursive_successors
+# wrong constant name requirements
+# wrong constant name root
+# wrong constant name root=
+# wrong constant name root?
+# wrong constant name shallow_eql?
+# wrong constant name successors
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name tsort
+# uninitialized constant Gem::Resolver::Molinillo::DependencyState::Elem
+# wrong constant name pop_possibility_state
+# wrong constant name <static-init>
+# wrong constant name dependency
+# wrong constant name dependency=
+# wrong constant name initialize
+# wrong constant name required_by
+# wrong constant name required_by=
+# wrong constant name <static-init>
+# uninitialized constant Gem::Resolver::Molinillo::PossibilityState::Elem
+# wrong constant name <static-init>
+# uninitialized constant Gem::Resolver::Molinillo::ResolutionState::Elem
+# wrong constant name activated
+# wrong constant name activated=
+# wrong constant name conflicts
+# wrong constant name conflicts=
+# wrong constant name depth
+# wrong constant name depth=
+# wrong constant name name
+# wrong constant name name=
+# wrong constant name possibilities
+# wrong constant name possibilities=
+# wrong constant name requirement
+# wrong constant name requirement=
+# wrong constant name requirements
+# wrong constant name requirements=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name empty
+# wrong constant name members
+# wrong constant name <Class:Resolution>
+# wrong constant name initialize
+# wrong constant name resolve
+# wrong constant name resolver_ui
+# wrong constant name specification_provider
+# wrong constant name <Class:Conflict>
+# wrong constant name base
+# wrong constant name initialize
+# wrong constant name iteration_rate=
+# wrong constant name original_requested
+# wrong constant name resolve
+# wrong constant name resolver_ui
+# wrong constant name specification_provider
+# wrong constant name started_at=
+# wrong constant name states=
+# uninitialized constant Gem::Resolver::Molinillo::Resolver::Resolution::Conflict::Elem
+# wrong constant name activated_by_name
+# wrong constant name activated_by_name=
+# wrong constant name existing
+# wrong constant name existing=
+# wrong constant name locked_requirement
+# wrong constant name locked_requirement=
+# wrong constant name possibility
+# wrong constant name possibility=
+# wrong constant name requirement
+# wrong constant name requirement=
+# wrong constant name requirement_trees
+# wrong constant name requirement_trees=
+# wrong constant name requirements
+# wrong constant name requirements=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name allow_missing?
+# wrong constant name dependencies_for
+# wrong constant name name_for
+# wrong constant name name_for_explicit_dependency_source
+# wrong constant name name_for_locking_dependency_source
+# wrong constant name requirement_satisfied_by?
+# wrong constant name search_for
+# wrong constant name sort_dependencies
+# wrong constant name <static-init>
+# wrong constant name after_resolution
+# wrong constant name before_resolution
+# wrong constant name debug
+# wrong constant name debug?
+# wrong constant name indicate_progress
+# wrong constant name output
+# wrong constant name progress_rate
+# wrong constant name <static-init>
+# wrong constant name conflicts
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# uninitialized constant Gem::Resolver::RequirementList::Elem
+# wrong constant name add
+# wrong constant name each
+# wrong constant name empty?
+# wrong constant name next5
+# wrong constant name remove
+# wrong constant name size
+# wrong constant name <static-init>
+# wrong constant name errors
+# wrong constant name errors=
+# wrong constant name find_all
+# wrong constant name prefetch
+# wrong constant name prerelease
+# wrong constant name prerelease=
+# wrong constant name remote
+# wrong constant name remote=
+# wrong constant name remote?
+# wrong constant name <static-init>
+# wrong constant name add_source_gem
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name dependencies
+# wrong constant name fetch_development_dependencies
+# wrong constant name full_name
+# wrong constant name install
+# wrong constant name installable_platform?
+# wrong constant name local?
+# wrong constant name name
+# wrong constant name platform
+# wrong constant name set
+# wrong constant name source
+# wrong constant name spec
+# wrong constant name version
+# wrong constant name <static-init>
+# wrong constant name backtracking!
+# wrong constant name display
+# wrong constant name iteration!
+# wrong constant name record_depth
+# wrong constant name record_requirements
+# wrong constant name requirement!
+# wrong constant name <static-init>
+# wrong constant name add_vendor_gem
+# wrong constant name load_spec
+# wrong constant name specs
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name compose_sets
+# wrong constant name for_current_gems
+# wrong constant name suggestion
+# wrong constant name suggestion=
+# wrong constant name <static-init>
+# wrong constant name <Class:DIGEST_ALGORITHM>
+# wrong constant name <Class:Exception>
+# wrong constant name <Class:KEY_ALGORITHM>
+# wrong constant name <Class:Policy>
+# wrong constant name <Class:Signer>
+# wrong constant name <Class:TrustDir>
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name digest
+# wrong constant name hexdigest
+# wrong constant name <static-init>
+# wrong constant name d
+# wrong constant name d=
+# wrong constant name dmp1
+# wrong constant name dmp1=
+# wrong constant name dmq1
+# wrong constant name dmq1=
+# wrong constant name e
+# wrong constant name e=
+# wrong constant name export
+# wrong constant name initialize
+# wrong constant name iqmp
+# wrong constant name iqmp=
+# wrong constant name n
+# wrong constant name n=
+# wrong constant name p
+# wrong constant name p=
+# wrong constant name params
+# wrong constant name private?
+# wrong constant name private_decrypt
+# wrong constant name private_encrypt
+# wrong constant name public?
+# wrong constant name public_decrypt
+# wrong constant name public_encrypt
+# wrong constant name public_key
+# wrong constant name q
+# wrong constant name q=
+# wrong constant name set_crt_params
+# wrong constant name set_factors
+# wrong constant name set_key
+# wrong constant name sign_pss
+# wrong constant name to_der
+# wrong constant name to_pem
+# wrong constant name to_s
+# wrong constant name to_text
+# wrong constant name verify_pss
+# wrong constant name <static-init>
+# wrong constant name generate
+# wrong constant name check_cert
+# wrong constant name check_chain
+# wrong constant name check_data
+# wrong constant name check_key
+# wrong constant name check_root
+# wrong constant name check_trust
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name only_signed
+# wrong constant name only_signed=
+# wrong constant name only_trusted
+# wrong constant name only_trusted=
+# wrong constant name subject
+# wrong constant name verify
+# wrong constant name verify_chain
+# wrong constant name verify_chain=
+# wrong constant name verify_data
+# wrong constant name verify_data=
+# wrong constant name verify_root
+# wrong constant name verify_root=
+# wrong constant name verify_signatures
+# wrong constant name verify_signer
+# wrong constant name verify_signer=
+# wrong constant name <static-init>
+# wrong constant name cert_chain
+# wrong constant name cert_chain=
+# wrong constant name digest_algorithm
+# wrong constant name digest_name
+# wrong constant name extract_name
+# wrong constant name initialize
+# wrong constant name key
+# wrong constant name key=
+# wrong constant name load_cert_chain
+# wrong constant name re_sign_key
+# wrong constant name sign
+# wrong constant name <static-init>
+# wrong constant name cert_path
+# wrong constant name dir
+# wrong constant name each_certificate
+# wrong constant name initialize
+# wrong constant name issuer_of
+# wrong constant name load_certificate
+# wrong constant name name_path
+# wrong constant name trust_cert
+# wrong constant name verify
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name alt_name_or_x509_entry
+# wrong constant name create_cert
+# wrong constant name create_cert_email
+# wrong constant name create_cert_self_signed
+# wrong constant name create_key
+# wrong constant name email_to_name
+# wrong constant name re_sign
+# wrong constant name reset
+# wrong constant name sign
+# wrong constant name trust_dir
+# wrong constant name trusted_certificates
+# wrong constant name write
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <=>
+# wrong constant name ==
+# wrong constant name <Class:Git>
+# wrong constant name <Class:Installed>
+# wrong constant name <Class:Local>
+# wrong constant name <Class:Lock>
+# wrong constant name <Class:SpecificFile>
+# wrong constant name <Class:Vendor>
+# wrong constant name api_uri
+# wrong constant name cache_dir
+# wrong constant name dependency_resolver_set
+# wrong constant name download
+# wrong constant name eql?
+# wrong constant name fetch_spec
+# wrong constant name initialize
+# wrong constant name load_specs
+# wrong constant name update_cache?
+# wrong constant name uri
+# uninitialized constant Gem::Source::Git::FILES
+# Did you mean?  File
+#                Gem::Source::Git::FILES
+#                Gem::Source::FILES
+# wrong constant name base_dir
+# wrong constant name cache
+# wrong constant name checkout
+# wrong constant name dir_shortref
+# wrong constant name download
+# wrong constant name initialize
+# wrong constant name install_dir
+# wrong constant name name
+# wrong constant name need_submodules
+# wrong constant name reference
+# wrong constant name remote
+# wrong constant name remote=
+# wrong constant name repo_cache_dir
+# wrong constant name repository
+# wrong constant name rev_parse
+# wrong constant name root_dir
+# wrong constant name root_dir=
+# wrong constant name specs
+# wrong constant name uri_hash
+# wrong constant name <static-init>
+# uninitialized constant Gem::Source::Installed::FILES
+# Did you mean?  File
+#                Gem::Source::Installed::FILES
+#                Gem::Source::FILES
+# wrong constant name download
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant Gem::Source::Local::FILES
+# Did you mean?  File
+#                Gem::Source::Local::FILES
+#                Gem::Source::FILES
+# wrong constant name download
+# wrong constant name fetch_spec
+# wrong constant name find_gem
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant Gem::Source::Lock::FILES
+# Did you mean?  File
+#                Gem::Source::Lock::FILES
+#                Gem::Source::FILES
+# wrong constant name initialize
+# wrong constant name wrapped
+# wrong constant name <static-init>
+# uninitialized constant Gem::Source::SpecificFile::FILES
+# Did you mean?  File
+#                Gem::Source::SpecificFile::FILES
+#                Gem::Source::FILES
+# wrong constant name fetch_spec
+# wrong constant name initialize
+# wrong constant name load_specs
+# wrong constant name path
+# wrong constant name spec
+# wrong constant name <static-init>
+# uninitialized constant Gem::Source::Vendor::FILES
+# Did you mean?  File
+#                Gem::Source::Vendor::FILES
+#                Gem::Source::FILES
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name error
+# wrong constant name exception
+# wrong constant name initialize
+# wrong constant name source
+# wrong constant name wordy
+# wrong constant name <<
+# wrong constant name ==
+# uninitialized constant Gem::SourceList::Elem
+# wrong constant name clear
+# wrong constant name delete
+# wrong constant name each
+# wrong constant name each_source
+# wrong constant name empty?
+# wrong constant name first
+# wrong constant name include?
+# wrong constant name replace
+# wrong constant name sources
+# wrong constant name to_a
+# wrong constant name to_ary
+# wrong constant name <static-init>
+# wrong constant name from
+# wrong constant name available_specs
+# wrong constant name detect
+# wrong constant name initialize
+# wrong constant name latest_specs
+# wrong constant name prerelease_specs
+# wrong constant name search_for_dependency
+# wrong constant name sources
+# wrong constant name spec_for_dependency
+# wrong constant name specs
+# wrong constant name suggest_gems_from_name
+# wrong constant name tuples_for
+# wrong constant name <static-init>
+# wrong constant name fetcher
+# wrong constant name fetcher=
+# wrong constant name errors
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name version
+# wrong constant name <=>
+# wrong constant name ==
+# uninitialized constant Gem::Specification::GENERICS
+# Did you mean?  Gem::Specification::GENERICS
+# uninitialized constant Gem::Specification::GENERIC_CACHE
+# Did you mean?  Gem::Specification::GENERIC_CACHE
+# wrong constant name _dump
+# wrong constant name abbreviate
+# wrong constant name activate
+# wrong constant name activate_dependencies
+# wrong constant name activated
+# wrong constant name activated=
+# wrong constant name add_bindir
+# wrong constant name add_dependency
+# wrong constant name add_development_dependency
+# wrong constant name add_runtime_dependency
+# wrong constant name add_self_to_load_path
+# wrong constant name author
+# wrong constant name author=
+# wrong constant name authors
+# wrong constant name authors=
+# wrong constant name autorequire
+# wrong constant name autorequire=
+# wrong constant name bin_dir
+# wrong constant name bin_file
+# wrong constant name bindir
+# wrong constant name bindir=
+# wrong constant name build_args
+# wrong constant name build_extensions
+# wrong constant name build_info_dir
+# wrong constant name build_info_file
+# wrong constant name bundled_gem_in_old_ruby?
+# wrong constant name cache_dir
+# wrong constant name cache_file
+# wrong constant name cert_chain
+# wrong constant name cert_chain=
+# wrong constant name conficts_when_loaded_with?
+# wrong constant name conflicts
+# wrong constant name date
+# wrong constant name date=
+# wrong constant name default_executable
+# wrong constant name default_executable=
+# wrong constant name default_value
+# wrong constant name dependencies
+# wrong constant name dependent_gems
+# wrong constant name dependent_specs
+# wrong constant name description
+# wrong constant name description=
+# wrong constant name development_dependencies
+# wrong constant name doc_dir
+# wrong constant name email
+# wrong constant name email=
+# wrong constant name encode_with
+# wrong constant name eql?
+# wrong constant name executable
+# wrong constant name executable=
+# wrong constant name executables
+# wrong constant name executables=
+# wrong constant name extensions
+# wrong constant name extensions=
+# wrong constant name extra_rdoc_files
+# wrong constant name extra_rdoc_files=
+# wrong constant name file_name
+# wrong constant name files
+# wrong constant name files=
+# wrong constant name for_cache
+# wrong constant name git_version
+# wrong constant name groups
+# wrong constant name has_conflicts?
+# wrong constant name has_rdoc
+# wrong constant name has_rdoc=
+# wrong constant name has_rdoc?
+# wrong constant name has_test_suite?
+# wrong constant name has_unit_tests?
+# wrong constant name homepage
+# wrong constant name homepage=
+# wrong constant name init_with
+# wrong constant name initialize
+# wrong constant name installed_by_version
+# wrong constant name installed_by_version=
+# wrong constant name lib_files
+# wrong constant name license
+# wrong constant name license=
+# wrong constant name licenses
+# wrong constant name licenses=
+# wrong constant name load_paths
+# wrong constant name location
+# wrong constant name location=
+# wrong constant name mark_version
+# wrong constant name metadata
+# wrong constant name metadata=
+# wrong constant name method_missing
+# wrong constant name missing_extensions?
+# wrong constant name name=
+# wrong constant name name_tuple
+# wrong constant name nondevelopment_dependencies
+# wrong constant name normalize
+# wrong constant name original_name
+# wrong constant name original_platform
+# wrong constant name original_platform=
+# wrong constant name platform=
+# wrong constant name post_install_message
+# wrong constant name post_install_message=
+# wrong constant name raise_if_conflicts
+# wrong constant name rdoc_options
+# wrong constant name rdoc_options=
+# wrong constant name relative_loaded_from
+# wrong constant name relative_loaded_from=
+# wrong constant name remote
+# wrong constant name remote=
+# wrong constant name require_path
+# wrong constant name require_path=
+# wrong constant name require_paths=
+# wrong constant name required_ruby_version
+# wrong constant name required_ruby_version=
+# wrong constant name required_rubygems_version
+# wrong constant name required_rubygems_version=
+# wrong constant name requirements
+# wrong constant name requirements=
+# wrong constant name reset_nil_attributes_to_default
+# wrong constant name rg_extension_dir
+# wrong constant name rg_full_gem_path
+# wrong constant name rg_loaded_from
+# wrong constant name ri_dir
+# wrong constant name rubyforge_project
+# wrong constant name rubyforge_project=
+# wrong constant name rubygems_version
+# wrong constant name rubygems_version=
+# wrong constant name runtime_dependencies
+# wrong constant name sanitize
+# wrong constant name sanitize_string
+# wrong constant name satisfies_requirement?
+# wrong constant name signing_key
+# wrong constant name signing_key=
+# wrong constant name sort_obj
+# wrong constant name source
+# wrong constant name source=
+# wrong constant name spec_dir
+# wrong constant name spec_file
+# wrong constant name spec_name
+# wrong constant name specification_version
+# wrong constant name specification_version=
+# wrong constant name summary
+# wrong constant name summary=
+# wrong constant name test_file
+# wrong constant name test_file=
+# wrong constant name test_files
+# wrong constant name test_files=
+# wrong constant name to_gemfile
+# wrong constant name to_ruby
+# wrong constant name to_ruby_for_cache
+# wrong constant name to_yaml
+# wrong constant name traverse
+# wrong constant name validate
+# wrong constant name validate_dependencies
+# wrong constant name validate_metadata
+# wrong constant name validate_permissions
+# wrong constant name version=
+# wrong constant name warning
+# wrong constant name yaml_initialize
 # uninitialized constant Gem::Specification::Elem
-# undefined method `default$2' for class `Hash'
-# undefined method `fetch$2' for class `Hash'
-# undefined method `initialize$2' for class `Hash'
-# Did you mean?  initialize
+# wrong constant name _all
+# wrong constant name _clear_load_cache
+# wrong constant name _latest_specs
+# wrong constant name _load
+# wrong constant name _resort!
+# wrong constant name add_spec
+# wrong constant name add_specs
+# wrong constant name all
+# wrong constant name all=
+# wrong constant name all_names
+# wrong constant name array_attributes
+# wrong constant name attribute_names
+# wrong constant name dirs
+# wrong constant name dirs=
+# wrong constant name each
+# wrong constant name each_gemspec
+# wrong constant name each_spec
+# wrong constant name find_active_stub_by_path
+# wrong constant name find_all_by_full_name
+# wrong constant name find_all_by_name
+# wrong constant name find_by_name
+# wrong constant name find_by_path
+# wrong constant name find_in_unresolved
+# wrong constant name find_in_unresolved_tree
+# wrong constant name find_inactive_by_path
+# wrong constant name from_yaml
+# wrong constant name latest_specs
+# wrong constant name load
+# wrong constant name load_defaults
+# wrong constant name non_nil_attributes
+# wrong constant name normalize_yaml_input
+# wrong constant name outdated
+# wrong constant name outdated_and_latest_version
+# wrong constant name remove_spec
+# wrong constant name required_attribute?
+# wrong constant name required_attributes
+# wrong constant name reset
+# wrong constant name stubs
+# wrong constant name stubs_for
+# wrong constant name unresolved_deps
+# wrong constant name _gets_noecho
+# wrong constant name alert
+# wrong constant name alert_error
+# wrong constant name alert_warning
+# wrong constant name ask
+# wrong constant name ask_for_password
+# wrong constant name ask_yes_no
+# wrong constant name backtrace
+# wrong constant name choose_from_list
+# wrong constant name close
+# wrong constant name debug
+# wrong constant name download_reporter
+# wrong constant name errs
+# wrong constant name initialize
+# wrong constant name ins
+# wrong constant name outs
+# wrong constant name progress_reporter
+# wrong constant name require_io_console
+# wrong constant name say
+# wrong constant name terminate_interaction
+# wrong constant name tty?
+# wrong constant name <static-init>
+# wrong constant name build_extensions
+# wrong constant name extensions
+# wrong constant name initialize
+# wrong constant name missing_extensions?
+# wrong constant name valid?
+# wrong constant name extensions
+# wrong constant name full_name
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name platform
+# wrong constant name require_paths
+# wrong constant name version
+# wrong constant name default_gemspec_stub
+# wrong constant name gemspec_stub
+# wrong constant name exit_code
+# wrong constant name exit_code=
+# wrong constant name initialize
+# wrong constant name clean_text
+# wrong constant name format_text
+# wrong constant name levenshtein_distance
+# wrong constant name min3
+# wrong constant name truncate_text
+# wrong constant name <static-init>
+# wrong constant name dependency
+# wrong constant name errors
+# wrong constant name errors=
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name version
+# wrong constant name escape
+# wrong constant name initialize
+# wrong constant name normalize
+# wrong constant name unescape
+# wrong constant name uri
+# wrong constant name <static-init>
+# wrong constant name alert
+# wrong constant name alert_error
+# wrong constant name alert_warning
+# wrong constant name ask
+# wrong constant name ask_for_password
+# wrong constant name ask_yes_no
+# wrong constant name choose_from_list
+# wrong constant name say
+# wrong constant name terminate_interaction
+# wrong constant name verbose
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name gunzip
+# wrong constant name gzip
+# wrong constant name inflate
+# wrong constant name popen
+# wrong constant name silent_system
+# wrong constant name traverse_parents
+# wrong constant name <=>
+# wrong constant name _segments
+# wrong constant name _split_segments
+# wrong constant name _version
+# wrong constant name approximate_recommendation
+# wrong constant name bump
+# wrong constant name canonical_segments
+# wrong constant name encode_with
+# wrong constant name eql?
+# wrong constant name init_with
+# wrong constant name marshal_dump
+# wrong constant name marshal_load
+# wrong constant name prerelease?
+# wrong constant name release
+# wrong constant name segments
+# wrong constant name to_yaml_properties
+# wrong constant name version
+# wrong constant name yaml_initialize
+# wrong constant name correct?
+# wrong constant name create
+# wrong constant name new
+# wrong constant name _deprecated_datadir
+# wrong constant name activate_bin_path
+# wrong constant name default_ext_dir_for
+# wrong constant name default_gems_use_full_paths?
+# wrong constant name default_spec_cache_dir
+# wrong constant name deflate
+# wrong constant name detect_gemdeps
+# wrong constant name dir
+# wrong constant name done_installing
+# wrong constant name done_installing_hooks
+# wrong constant name ensure_default_gem_subdirectories
+# wrong constant name ensure_gem_subdirectories
+# wrong constant name ensure_subdirectories
+# wrong constant name env_requirement
+# wrong constant name extension_api_version
+# wrong constant name find_files
+# wrong constant name find_files_from_load_path
+# wrong constant name find_latest_files
+# wrong constant name find_unresolved_default_spec
+# wrong constant name finish_resolve
+# wrong constant name gemdeps
+# wrong constant name gunzip
+# wrong constant name gzip
+# wrong constant name host
+# wrong constant name host=
+# wrong constant name inflate
+# wrong constant name install
+# wrong constant name install_extension_in_lib
+# wrong constant name latest_rubygems_version
+# wrong constant name latest_spec_for
+# wrong constant name latest_version_for
+# wrong constant name load_env_plugins
+# wrong constant name load_path_insert_index
+# wrong constant name load_plugin_files
+# wrong constant name load_plugins
+# wrong constant name load_yaml
+# wrong constant name loaded_specs
+# wrong constant name location_of_caller
+# wrong constant name marshal_version
+# wrong constant name needs
+# wrong constant name path
+# wrong constant name path_separator
+# wrong constant name paths
+# wrong constant name paths=
+# wrong constant name platform_defaults
+# wrong constant name platforms
+# wrong constant name platforms=
+# wrong constant name post_build
+# wrong constant name post_build_hooks
+# wrong constant name post_install
+# wrong constant name post_install_hooks
+# wrong constant name post_reset
+# wrong constant name post_reset_hooks
+# wrong constant name post_uninstall
+# wrong constant name post_uninstall_hooks
+# wrong constant name pre_install
+# wrong constant name pre_install_hooks
+# wrong constant name pre_reset
+# wrong constant name pre_reset_hooks
+# wrong constant name pre_uninstall
+# wrong constant name pre_uninstall_hooks
+# wrong constant name prefix
+# wrong constant name read_binary
+# wrong constant name refresh
+# wrong constant name register_default_spec
+# wrong constant name remove_unresolved_default_spec
+# wrong constant name ruby
+# wrong constant name ruby_api_version
+# wrong constant name ruby_engine
+# wrong constant name ruby_version
+# wrong constant name rubygems_version
+# wrong constant name sources
+# wrong constant name sources=
+# wrong constant name spec_cache_dir
+# wrong constant name suffix_pattern
+# wrong constant name suffixes
+# wrong constant name time
+# wrong constant name try_activate
+# wrong constant name ui
+# wrong constant name use_gemdeps
+# wrong constant name use_paths
+# wrong constant name user_dir
+# wrong constant name user_home
+# wrong constant name vendor_dir
+# wrong constant name win_platform?
+# wrong constant name write_binary
 # wrong constant name <
 # wrong constant name <=
 # wrong constant name >
 # wrong constant name >=
 # wrong constant name compact
 # wrong constant name compact!
-# wrong constant name default$2
 # wrong constant name default_proc
 # wrong constant name default_proc=
 # wrong constant name dig
-# wrong constant name fetch$2
 # wrong constant name fetch_values
-# wrong constant name filter!
 # wrong constant name flatten
 # wrong constant name index
-# wrong constant name initialize$2
 # wrong constant name merge!
 # wrong constant name replace
 # wrong constant name slice
@@ -1125,33 +4207,7 @@
 # wrong constant name transform_values!
 # wrong constant name update
 # wrong constant name try_convert
-# undefined method `advise$1' for class `IO'
-# undefined method `each$2' for class `IO'
-# undefined method `each_line$2' for class `IO'
-# undefined method `fcntl$1' for class `IO'
-# undefined method `initialize$1' for class `IO'
-# Did you mean?  initialize
-# undefined method `ioctl$1' for class `IO'
-# undefined method `lines$2' for class `IO'
-# undefined method `read$1' for class `IO'
-# Did you mean?  read
-# undefined method `read_nonblock$2' for class `IO'
-# undefined method `readpartial$2' for class `IO'
-# undefined method `reopen$2' for class `IO'
-# undefined method `seek$1' for class `IO'
-# undefined method `set_encoding$2' for class `IO'
-# undefined method `sysread$1' for class `IO'
-# undefined method `sysseek$1' for class `IO'
-# undefined method `write$1' for class `IO'
-# Did you mean?  write
-# wrong constant name advise$1
-# wrong constant name each$2
-# wrong constant name each_line$2
 # wrong constant name external_encoding
-# wrong constant name fcntl$1
-# wrong constant name initialize$1
-# wrong constant name ioctl$1
-# wrong constant name lines$2
 # wrong constant name nonblock
 # wrong constant name nonblock=
 # wrong constant name nonblock?
@@ -1159,36 +4215,13 @@
 # wrong constant name pathconf
 # wrong constant name pread
 # wrong constant name pwrite
-# wrong constant name read$1
-# wrong constant name read_nonblock$2
-# wrong constant name readpartial$2
 # wrong constant name ready?
-# wrong constant name reopen$2
-# wrong constant name seek$1
-# wrong constant name set_encoding$2
-# wrong constant name sysread$1
-# wrong constant name sysseek$1
 # wrong constant name wait
 # wrong constant name wait_readable
 # wrong constant name wait_writable
-# wrong constant name write$1
 # wrong constant name write_nonblock
-# undefined singleton method `binread$1' for `IO'
-# undefined singleton method `binwrite$1' for `IO'
-# undefined singleton method `copy_stream$1' for `IO'
-# undefined singleton method `for_fd$1' for `IO'
-# undefined singleton method `read$1' for `IO'
-# undefined singleton method `sysopen$1' for `IO'
-# undefined singleton method `write$1' for `IO'
-# wrong constant name binread$1
-# wrong constant name binwrite$1
-# wrong constant name copy_stream$1
-# wrong constant name for_fd$1
 # wrong constant name foreach
 # wrong constant name pipe
-# wrong constant name read$1
-# wrong constant name sysopen$1
-# wrong constant name write$1
 # wrong constant name &
 # wrong constant name <<
 # wrong constant name <=>
@@ -1235,80 +4268,20 @@
 # wrong constant name <static-init>
 # wrong constant name new_ntoh
 # wrong constant name ntop
-# undefined method `chr$2' for class `Integer'
-# undefined method `inspect$1' for class `Integer'
-# Did you mean?  inspect
-# undefined method `rationalize$2' for class `Integer'
-# Did you mean?  Rational
-# undefined method `to_s$1' for class `Integer'
-# Did you mean?  to_s
 # wrong constant name allbits?
 # wrong constant name anybits?
-# wrong constant name chr$2
 # wrong constant name digits
-# wrong constant name inspect$1
 # wrong constant name nobits?
 # wrong constant name pow
-# wrong constant name rationalize$2
 # wrong constant name to_bn
-# wrong constant name to_s$1
 # wrong constant name sqrt
 # wrong constant name from_state
 # wrong constant name initialize
-# undefined method `clone$1' for module `Kernel'
-# Did you mean?  clone
-# undefined method `define_singleton_method$2' for module `Kernel'
-# Did you mean?  define_singleton_method
-# undefined method `display$1' for module `Kernel'
-# Did you mean?  display
-# undefined method `enum_for$2' for module `Kernel'
-# Did you mean?  enum_for
-# undefined method `exit$2' for module `Kernel'
-# Did you mean?  exit
-#                exit!
-# undefined method `extend$1' for module `Kernel'
-# Did you mean?  extend
-#                extended
-# undefined method `methods$1' for module `Kernel'
-# Did you mean?  methods
-#                method
-#                method
-# undefined method `private_methods$1' for module `Kernel'
-# Did you mean?  private_methods
-# undefined method `protected_methods$1' for module `Kernel'
-# Did you mean?  protected_methods
-# undefined method `public_methods$1' for module `Kernel'
-# Did you mean?  public_methods
-#                public_method
-# undefined method `public_send$1' for module `Kernel'
-# Did you mean?  public_send
-# undefined method `send$2' for module `Kernel'
-# Did you mean?  send
-# undefined method `singleton_methods$1' for module `Kernel'
-# Did you mean?  singleton_methods
-#                singleton_method
-# undefined method `to_enum$2' for module `Kernel'
-# Did you mean?  to_enum
-# wrong constant name clone$1
-# wrong constant name define_singleton_method$2
-# wrong constant name display$1
-# wrong constant name enum_for$2
-# wrong constant name exit$2
-# wrong constant name extend$1
 # wrong constant name gem
 # wrong constant name itself
-# wrong constant name methods$1
 # wrong constant name object_id
 # wrong constant name pretty_inspect
-# wrong constant name private_methods$1
-# wrong constant name protected_methods$1
-# wrong constant name public_methods$1
-# wrong constant name public_send$1
 # wrong constant name respond_to?
-# wrong constant name send$2
-# wrong constant name singleton_methods$1
-# wrong constant name then
-# wrong constant name to_enum$2
 # wrong constant name at_exit
 # wrong constant name key
 # wrong constant name receiver
@@ -1317,84 +4290,10 @@
 # wrong constant name reason
 # uninitialized constant Logger
 # uninitialized constant Logger
-# undefined singleton method `dump$2' for `Marshal'
-# wrong constant name dump$2
 # wrong constant name restore
-# undefined method `[]$2' for class `MatchData'
-# wrong constant name []$2
-# wrong constant name named_captures
 # uninitialized constant MessagePack
 # uninitialized constant MessagePack
-# wrong constant name <<
-# wrong constant name ===
-# wrong constant name >>
-# wrong constant name []
-# wrong constant name arity
-# wrong constant name clone
-# wrong constant name curry
-# wrong constant name name
-# wrong constant name original_name
-# wrong constant name owner
-# wrong constant name parameters
-# wrong constant name receiver
-# wrong constant name source_location
-# wrong constant name super_method
-# wrong constant name unbind
-# undefined method `class_eval$2' for class `Module'
-# Did you mean?  class_eval
-# undefined method `class_variables$1' for class `Module'
-# Did you mean?  class_variables
-#                class_variable_set
-#                class_variable_get
-# undefined method `const_defined?$1' for class `Module'
-# Did you mean?  const_defined?
-# undefined method `const_get$1' for class `Module'
-# Did you mean?  const_get
-#                const_set
-# undefined method `constants$1' for class `Module'
-# Did you mean?  constants
-# undefined method `define_method$2' for class `Module'
-# Did you mean?  define_method
-# undefined method `instance_methods$1' for class `Module'
-# Did you mean?  instance_methods
-#                instance_method
-# undefined method `method_defined?$1' for class `Module'
-# Did you mean?  method_defined?
-#                method_undefined
-# undefined method `module_eval$2' for class `Module'
-# Did you mean?  module_eval
-# undefined method `private_instance_methods$1' for class `Module'
-# Did you mean?  private_instance_methods
-# undefined method `private_method_defined?$1' for class `Module'
-# Did you mean?  private_method_defined?
-# undefined method `protected_instance_methods$1' for class `Module'
-# Did you mean?  protected_instance_methods
-# undefined method `protected_method_defined?$1' for class `Module'
-# Did you mean?  protected_method_defined?
-# undefined method `public_instance_methods$1' for class `Module'
-# Did you mean?  public_instance_methods
-#                public_instance_method
-# undefined method `public_method_defined?$1' for class `Module'
-# Did you mean?  public_method_defined?
-# undefined method `remove_method$1' for class `Module'
-# Did you mean?  remove_method
-# wrong constant name class_eval$2
-# wrong constant name class_variables$1
-# wrong constant name const_defined?$1
-# wrong constant name const_get$1
-# wrong constant name constants$1
-# wrong constant name define_method$2
 # wrong constant name deprecate_constant
-# wrong constant name instance_methods$1
-# wrong constant name method_defined?$1
-# wrong constant name module_eval$2
-# wrong constant name private_instance_methods$1
-# wrong constant name private_method_defined?$1
-# wrong constant name protected_instance_methods$1
-# wrong constant name protected_method_defined?$1
-# wrong constant name public_instance_methods$1
-# wrong constant name public_method_defined?$1
-# wrong constant name remove_method$1
 # wrong constant name undef_method
 # wrong constant name used_modules
 # wrong constant name enter
@@ -1418,7 +4317,9 @@
 # wrong constant name wait_while
 # wrong constant name extend_object
 # uninitialized constant Mutex_m
+# Did you mean?  Mutex
 # uninitialized constant Mutex_m
+# Did you mean?  Mutex
 # wrong constant name name
 # wrong constant name receiver
 # uninitialized constant Net::FTP
@@ -1442,7 +4343,9 @@
 # uninitialized constant Net::FTPTempError
 # Did you mean?  TypeError
 # uninitialized constant Net::HTTP::DigestAuth
+# Did you mean?  Digest
 # uninitialized constant Net::HTTP::DigestAuth
+# Did you mean?  Digest
 # uninitialized constant Net::HTTP::Persistent
 # uninitialized constant Net::HTTP::Persistent
 # uninitialized constant Net::IMAP
@@ -1464,34 +4367,20 @@
 # uninitialized constant Net::SMTPServerBusy
 # uninitialized constant Net::SMTPServerBusy
 # uninitialized constant Net::SMTPSyntaxError
-# Did you mean?  Net::ProtoSyntaxError
+# Did you mean?  SyntaxError
+#                Net::ProtoSyntaxError
 # uninitialized constant Net::SMTPSyntaxError
-# Did you mean?  Net::ProtoSyntaxError
+# Did you mean?  SyntaxError
+#                Net::ProtoSyntaxError
 # uninitialized constant Net::SMTPUnknownError
 # uninitialized constant Net::SMTPUnknownError
 # uninitialized constant Net::SMTPUnsupportedCommand
 # uninitialized constant Net::SMTPUnsupportedCommand
-# undefined method `rationalize$1' for class `NilClass'
-# Did you mean?  Rational
-# wrong constant name rationalize$1
 # wrong constant name to_i
 # wrong constant name args
 # wrong constant name private_call?
-# undefined method `ceil$2' for class `Numeric'
-# undefined method `floor$2' for class `Numeric'
-# undefined method `round$1' for class `Numeric'
-# undefined method `step$2' for class `Numeric'
-# undefined method `truncate$1' for class `Numeric'
-# wrong constant name ceil$2
-# wrong constant name finite?
-# wrong constant name floor$2
-# wrong constant name infinite?
-# wrong constant name negative?
-# wrong constant name positive?
-# wrong constant name round$1
-# wrong constant name step$2
-# wrong constant name truncate$1
 # uninitialized constant RUBYGEMS_ACTIVATION_MONITOR
+# Did you mean?  RUBYGEMS_ACTIVATION_MONITOR
 # wrong constant name <Class:Object>
 # wrong constant name []
 # wrong constant name []=
@@ -1504,100 +4393,66 @@
 # wrong constant name length
 # wrong constant name size
 # wrong constant name values
-# undefined singleton method `each_object$2' for `ObjectSpace'
 # wrong constant name count_objects
 # wrong constant name define_finalizer
-# wrong constant name each_object$2
 # wrong constant name garbage_collect
 # wrong constant name undefine_finalizer
-# uninitialized constant OpenSSL::Digest::DSS
-# uninitialized constant OpenSSL::Digest::DSS
-# uninitialized constant OpenSSL::Digest::DSS1
-# uninitialized constant OpenSSL::Digest::DSS1
-# uninitialized constant OpenSSL::Digest::SHA
-# Did you mean?  OpenSSL::Digest::SHA1
-# uninitialized constant OpenSSL::Digest::SHA
-# Did you mean?  OpenSSL::Digest::SHA1
 # uninitialized constant OpenSSL::PKCS5::PKCS5Error
 # uninitialized constant OpenSSL::PKCS5::PKCS5Error
-# wrong constant name def_head_option
-# wrong constant name def_option
-# wrong constant name def_tail_option
-# wrong constant name set_banner
-# wrong constant name set_program_name
-# wrong constant name set_summary_indent
-# wrong constant name set_summary_width
 # uninitialized constant Opus
 # uninitialized constant Opus
-# undefined method `basename$1' for class `Pathname'
-# undefined method `binread$1' for class `Pathname'
-# undefined method `binwrite$1' for class `Pathname'
-# undefined method `each_line$2' for class `Pathname'
-# undefined method `expand_path$1' for class `Pathname'
-# undefined method `find$2' for class `Pathname'
-# undefined method `fnmatch$1' for class `Pathname'
-# undefined method `mkdir$1' for class `Pathname'
-# undefined method `opendir$2' for class `Pathname'
-# undefined method `read$1' for class `Pathname'
-# undefined method `realdirpath$1' for class `Pathname'
-# undefined method `realpath$1' for class `Pathname'
-# undefined method `symlink?$2' for class `Pathname'
-# undefined method `sysopen$1' for class `Pathname'
-# undefined method `write$1' for class `Pathname'
-# wrong constant name basename$1
-# wrong constant name binread$1
-# wrong constant name binwrite$1
-# wrong constant name each_line$2
 # wrong constant name empty?
-# wrong constant name expand_path$1
-# wrong constant name find$2
-# wrong constant name fnmatch$1
 # wrong constant name fnmatch?
 # wrong constant name glob
 # wrong constant name make_symlink
-# wrong constant name mkdir$1
-# wrong constant name opendir$2
-# wrong constant name read$1
-# wrong constant name realdirpath$1
-# wrong constant name realpath$1
-# wrong constant name symlink?$2
-# wrong constant name sysopen$1
-# wrong constant name write$1
-# undefined method `curry$1' for class `Proc'
-# wrong constant name <<
 # wrong constant name ===
-# wrong constant name >>
 # wrong constant name clone
-# wrong constant name curry$1
-# wrong constant name lambda?
 # wrong constant name yield
 # uninitialized constant Proc0
+# Did you mean?  Proc
 # uninitialized constant Proc0
+# Did you mean?  Proc
 # uninitialized constant Proc1
+# Did you mean?  Proc
 # uninitialized constant Proc1
+# Did you mean?  Proc
 # uninitialized constant Proc10
+# Did you mean?  Proc
 # uninitialized constant Proc10
+# Did you mean?  Proc
 # uninitialized constant Proc2
+# Did you mean?  Proc
 # uninitialized constant Proc2
+# Did you mean?  Proc
 # uninitialized constant Proc3
+# Did you mean?  Proc
 # uninitialized constant Proc3
+# Did you mean?  Proc
 # uninitialized constant Proc4
+# Did you mean?  Proc
 # uninitialized constant Proc4
+# Did you mean?  Proc
 # uninitialized constant Proc5
+# Did you mean?  Proc
 # uninitialized constant Proc5
+# Did you mean?  Proc
 # uninitialized constant Proc6
+# Did you mean?  Proc
 # uninitialized constant Proc6
+# Did you mean?  Proc
 # uninitialized constant Proc7
+# Did you mean?  Proc
 # uninitialized constant Proc7
+# Did you mean?  Proc
 # uninitialized constant Proc8
+# Did you mean?  Proc
 # uninitialized constant Proc8
+# Did you mean?  Proc
 # uninitialized constant Proc9
+# Did you mean?  Proc
 # uninitialized constant Proc9
-# undefined singleton method `setrgid$1' for `Process::Sys'
-# undefined singleton method `setruid$1' for `Process::Sys'
+# Did you mean?  Proc
 # wrong constant name getegid
-# wrong constant name setrgid$1
-# wrong constant name setruid$1
 # wrong constant name cstime
 # wrong constant name cstime=
 # wrong constant name cutime
@@ -1608,30 +4463,25 @@
 # wrong constant name utime=
 # wrong constant name []
 # wrong constant name members
-# undefined singleton method `clock_getres$1' for `Process'
-# undefined singleton method `clock_gettime$1' for `Process'
-# undefined singleton method `daemon$1' for `Process'
-# undefined singleton method `getsid$1' for `Process'
-# undefined singleton method `kill$1' for `Process'
-# undefined singleton method `setrlimit$1' for `Process'
-# undefined singleton method `wait$1' for `Process'
-# undefined singleton method `wait2$1' for `Process'
-# undefined singleton method `waitpid$1' for `Process'
-# undefined singleton method `waitpid2$1' for `Process'
-# wrong constant name clock_getres$1
-# wrong constant name clock_gettime$1
-# wrong constant name daemon$1
-# wrong constant name getsid$1
-# wrong constant name kill$1
 # wrong constant name last_status
 # wrong constant name setpgrp
-# wrong constant name setrlimit$1
-# wrong constant name wait$1
-# wrong constant name wait2$1
-# wrong constant name waitpid$1
-# wrong constant name waitpid2$1
+# wrong constant name <Class:Expectations>
+# wrong constant name <Class:Matchers>
+# wrong constant name <Class:Mocks>
+# wrong constant name call
+# wrong constant name initialize
+# wrong constant name relative_file_name
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Core::ExampleGroup::BE_PREDICATE_REGEX
+# Did you mean?  RSpec::Core::ExampleGroup::BE_PREDICATE_REGEX
+# uninitialized constant RSpec::Core::ExampleGroup::DYNAMIC_MATCHER_REGEX
+# Did you mean?  RSpec::Core::ExampleGroup::DYNAMIC_MATCHER_REGEX
+# uninitialized constant RSpec::Core::ExampleGroup::HAS_REGEX
+# Did you mean?  RSpec::Core::ExampleGroup::HAS_REGEX
 # uninitialized constant RSpec::Core::ExampleGroup::NOT_YET_IMPLEMENTED
+# Did you mean?  RSpec::Core::ExampleGroup::NOT_YET_IMPLEMENTED
 # uninitialized constant RSpec::Core::ExampleGroup::NO_REASON_GIVEN
+# Did you mean?  RSpec::Core::ExampleGroup::NO_REASON_GIVEN
 # wrong constant name initialize
 # wrong constant name persist
 # wrong constant name <static-init>
@@ -1664,6 +4514,11 @@
 # wrong constant name example_group_finished
 # wrong constant name example_passed
 # wrong constant name example_pending
+# wrong constant name example_started
+# wrong constant name <static-init>
+# wrong constant name dump_profile
+# wrong constant name example_failed
+# wrong constant name message
 # wrong constant name <static-init>
 # wrong constant name initialize
 # wrong constant name message
@@ -1694,11 +4549,20 @@
 # wrong constant name example_pending
 # wrong constant name start_dump
 # wrong constant name <static-init>
+# wrong constant name <Class:RSpec>
+# wrong constant name setup_mocks_for_rspec
+# wrong constant name teardown_mocks_for_rspec
+# wrong constant name verify_mocks_for_rspec
+# wrong constant name <static-init>
+# wrong constant name configuration
+# wrong constant name framework_name
+# wrong constant name <static-init>
 # wrong constant name example_group_finished
 # wrong constant name example_group_started
 # wrong constant name example_groups
 # wrong constant name example_started
 # wrong constant name <static-init>
+# wrong constant name exit_early
 # wrong constant name <Class:Recording>
 # wrong constant name __shared_context_recordings
 # wrong constant name after
@@ -1729,88 +4593,1708 @@
 # wrong constant name members
 # wrong constant name <static-init>
 # wrong constant name record
+# wrong constant name <Class:BlockExpectationTarget>
+# wrong constant name <Class:BlockSnippetExtractor>
+# wrong constant name <Class:Configuration>
+# wrong constant name <Class:ExpectationHelper>
+# wrong constant name <Class:ExpectationNotMetError>
+# wrong constant name <Class:ExpectationTarget>
+# wrong constant name <Class:FailureAggregator>
+# wrong constant name <Class:LegacyMatcherAdapter>
+# wrong constant name <Class:MultipleExpectationsNotMetError>
+# wrong constant name <Class:NegativeExpectationHandler>
+# wrong constant name <Class:PositiveExpectationHandler>
+# wrong constant name <Class:Syntax>
+# wrong constant name <Class:Version>
+# wrong constant name not_to
+# wrong constant name to
+# wrong constant name to_not
+# wrong constant name <static-init>
+# wrong constant name <Class:AmbiguousTargetError>
+# wrong constant name <Class:BlockLocator>
+# wrong constant name <Class:BlockTokenExtractor>
+# wrong constant name <Class:Error>
+# wrong constant name <Class:TargetNotFoundError>
+# wrong constant name body_content_lines
+# wrong constant name initialize
+# wrong constant name method_name
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Expectations::BlockSnippetExtractor::BlockLocator::Elem
+# wrong constant name beginning_line_number
+# wrong constant name beginning_line_number=
+# wrong constant name body_content_locations
+# wrong constant name method_call_location
+# wrong constant name method_name
+# wrong constant name method_name=
+# wrong constant name source
+# wrong constant name source=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# uninitialized constant RSpec::Expectations::BlockSnippetExtractor::BlockTokenExtractor::Elem
+# wrong constant name beginning_line_number
+# wrong constant name beginning_line_number=
+# wrong constant name body_tokens
+# wrong constant name method_name
+# wrong constant name method_name=
+# wrong constant name source
+# wrong constant name source=
+# wrong constant name state
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name try_extracting_single_line_body_of
+# wrong constant name <Class:NullBacktraceFormatter>
+# wrong constant name add_should_and_should_not_to
+# wrong constant name backtrace_formatter
+# wrong constant name backtrace_formatter=
+# wrong constant name color?
+# wrong constant name false_positives_handler
+# wrong constant name include_chain_clauses_in_custom_matcher_descriptions=
+# wrong constant name include_chain_clauses_in_custom_matcher_descriptions?
+# wrong constant name max_formatted_output_length=
+# wrong constant name on_potential_false_positives
+# wrong constant name on_potential_false_positives=
+# wrong constant name reset_syntaxes_to_default
+# wrong constant name syntax
+# wrong constant name syntax=
+# wrong constant name warn_about_potential_false_positives=
+# wrong constant name warn_about_potential_false_positives?
+# wrong constant name <static-init>
+# wrong constant name format_backtrace
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name check_message
+# wrong constant name handle_failure
+# wrong constant name modern_matcher_from
+# wrong constant name with_matcher
+# wrong constant name <static-init>
+# wrong constant name <Class:InstanceMethods>
+# wrong constant name <Class:UndefinedValue>
+# wrong constant name initialize
+# wrong constant name target
+# wrong constant name not_to
+# wrong constant name to
+# wrong constant name to_not
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name for
+# wrong constant name aggregate
+# wrong constant name block_label
+# wrong constant name call
+# wrong constant name failures
+# wrong constant name initialize
+# wrong constant name metadata
+# wrong constant name other_errors
+# wrong constant name <static-init>
+# wrong constant name <Class:RSpec1>
+# wrong constant name <Class:RSpec2>
+# wrong constant name initialize
+# wrong constant name failure_message
+# wrong constant name failure_message_when_negated
+# wrong constant name <static-init>
+# wrong constant name interface_matches?
+# wrong constant name failure_message
+# wrong constant name failure_message_when_negated
+# wrong constant name <static-init>
+# wrong constant name interface_matches?
+# wrong constant name <static-init>
+# wrong constant name wrap
+# wrong constant name aggregation_block_label
+# wrong constant name aggregation_metadata
+# wrong constant name all_exceptions
+# wrong constant name exception_count_description
+# wrong constant name failures
+# wrong constant name initialize
+# wrong constant name other_errors
+# wrong constant name summary
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name does_not_match?
+# wrong constant name handle_matcher
+# wrong constant name opposite_should_method
+# wrong constant name should_method
+# wrong constant name verb
+# wrong constant name <static-init>
+# wrong constant name handle_matcher
+# wrong constant name opposite_should_method
+# wrong constant name should_method
+# wrong constant name verb
+# wrong constant name <static-init>
+# wrong constant name default_should_host
+# wrong constant name disable_expect
+# wrong constant name disable_should
+# wrong constant name enable_expect
+# wrong constant name enable_should
+# wrong constant name expect_enabled?
+# wrong constant name should_enabled?
+# wrong constant name warn_about_should!
+# wrong constant name warn_about_should_unless_configured
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name configuration
+# wrong constant name differ
+# wrong constant name fail_with
+# wrong constant name <Class:AliasedMatcher>
+# wrong constant name <Class:AliasedMatcherWithOperatorSupport>
+# wrong constant name <Class:AliasedNegatedMatcher>
+# wrong constant name <Class:BuiltIn>
+# wrong constant name <Class:Composable>
+# wrong constant name <Class:DSL>
+# wrong constant name <Class:EnglishPhrasing>
+# wrong constant name <Class:ExpectedsForMultipleDiffs>
+# wrong constant name <Class:MatcherDelegator>
+# wrong constant name a_block_changing
+# wrong constant name a_block_outputting
+# wrong constant name a_block_raising
+# wrong constant name a_block_throwing
+# wrong constant name a_block_yielding_control
+# wrong constant name a_block_yielding_successive_args
+# wrong constant name a_block_yielding_with_args
+# wrong constant name a_block_yielding_with_no_args
+# wrong constant name a_collection_containing_exactly
+# wrong constant name a_collection_ending_with
+# wrong constant name a_collection_including
+# wrong constant name a_collection_starting_with
+# wrong constant name a_falsey_value
+# wrong constant name a_falsy_value
+# wrong constant name a_hash_including
+# wrong constant name a_kind_of
+# wrong constant name a_nil_value
+# wrong constant name a_range_covering
+# wrong constant name a_string_ending_with
+# wrong constant name a_string_including
+# wrong constant name a_string_matching
+# wrong constant name a_string_starting_with
+# wrong constant name a_truthy_value
+# wrong constant name a_value
+# wrong constant name a_value_between
+# wrong constant name a_value_within
+# wrong constant name aggregate_failures
+# wrong constant name all
+# wrong constant name an_instance_of
+# wrong constant name an_object_eq_to
+# wrong constant name an_object_eql_to
+# wrong constant name an_object_equal_to
+# wrong constant name an_object_existing
+# wrong constant name an_object_having_attributes
+# wrong constant name an_object_matching
+# wrong constant name an_object_responding_to
+# wrong constant name an_object_satisfying
+# wrong constant name be
+# wrong constant name be_a
+# wrong constant name be_a_kind_of
+# wrong constant name be_an
+# wrong constant name be_an_instance_of
+# wrong constant name be_between
+# wrong constant name be_falsey
+# wrong constant name be_falsy
+# wrong constant name be_instance_of
+# wrong constant name be_kind_of
+# wrong constant name be_nil
+# wrong constant name be_truthy
+# wrong constant name be_within
+# wrong constant name change
+# wrong constant name changing
+# wrong constant name contain_exactly
+# wrong constant name containing_exactly
+# wrong constant name cover
+# wrong constant name covering
+# wrong constant name end_with
+# wrong constant name ending_with
+# wrong constant name eq
+# wrong constant name eq_to
+# wrong constant name eql
+# wrong constant name eql_to
+# wrong constant name equal
+# wrong constant name equal_to
+# wrong constant name exist
+# wrong constant name existing
+# wrong constant name expect
+# wrong constant name have_attributes
+# wrong constant name having_attributes
+# wrong constant name include
+# wrong constant name including
+# wrong constant name match
+# wrong constant name match_array
+# wrong constant name match_regex
+# wrong constant name matching
+# wrong constant name output
+# wrong constant name raise_error
+# wrong constant name raise_exception
+# wrong constant name raising
+# wrong constant name respond_to
+# wrong constant name responding_to
+# wrong constant name satisfy
+# wrong constant name satisfying
+# wrong constant name start_with
+# wrong constant name starting_with
+# wrong constant name throw_symbol
+# wrong constant name throwing
+# wrong constant name within
+# wrong constant name yield_control
+# wrong constant name yield_successive_args
+# wrong constant name yield_with_args
+# wrong constant name yield_with_no_args
+# wrong constant name yielding_control
+# wrong constant name yielding_successive_args
+# wrong constant name yielding_with_args
+# wrong constant name yielding_with_no_args
+# wrong constant name description
+# wrong constant name failure_message
+# wrong constant name failure_message_when_negated
+# wrong constant name initialize
+# wrong constant name method_missing
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name does_not_match?
+# wrong constant name matches?
+# wrong constant name <static-init>
+# wrong constant name <Class:All>
+# wrong constant name <Class:BaseMatcher>
+# wrong constant name <Class:Be>
+# wrong constant name <Class:BeAKindOf>
+# wrong constant name <Class:BeAnInstanceOf>
+# wrong constant name <Class:BeBetween>
+# wrong constant name <Class:BeComparedTo>
+# wrong constant name <Class:BeFalsey>
+# wrong constant name <Class:BeHelpers>
+# wrong constant name <Class:BeNil>
+# wrong constant name <Class:BePredicate>
+# wrong constant name <Class:BeTruthy>
+# wrong constant name <Class:BeWithin>
+# wrong constant name <Class:Change>
+# wrong constant name <Class:Compound>
+# wrong constant name <Class:ContainExactly>
+# wrong constant name <Class:Cover>
+# wrong constant name <Class:EndWith>
+# wrong constant name <Class:Eq>
+# wrong constant name <Class:Eql>
+# wrong constant name <Class:Equal>
+# wrong constant name <Class:Exist>
+# wrong constant name <Class:Has>
+# wrong constant name <Class:HaveAttributes>
+# wrong constant name <Class:Include>
+# wrong constant name <Class:Match>
+# wrong constant name <Class:NegativeOperatorMatcher>
+# wrong constant name <Class:OperatorMatcher>
+# wrong constant name <Class:Output>
+# wrong constant name <Class:PositiveOperatorMatcher>
+# wrong constant name <Class:RaiseError>
+# wrong constant name <Class:RespondTo>
+# wrong constant name <Class:Satisfy>
+# wrong constant name <Class:StartOrEndWith>
+# wrong constant name <Class:StartWith>
+# wrong constant name <Class:ThrowSymbol>
+# wrong constant name <Class:YieldControl>
+# wrong constant name <Class:YieldSuccessiveArgs>
+# wrong constant name <Class:YieldWithArgs>
+# wrong constant name <Class:YieldWithNoArgs>
+# uninitialized constant RSpec::Matchers::BuiltIn::All::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::All::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name failed_objects
+# wrong constant name initialize
+# wrong constant name matcher
+# wrong constant name <static-init>
+# wrong constant name <Class:DefaultFailureMessages>
+# wrong constant name <Class:HashFormatting>
+# wrong constant name actual
+# wrong constant name actual_formatted
+# wrong constant name description
+# wrong constant name diffable?
+# wrong constant name expected
+# wrong constant name expected_formatted
+# wrong constant name expects_call_stack_jump?
+# wrong constant name initialize
+# wrong constant name match_unless_raises
+# wrong constant name matcher_name
+# wrong constant name matcher_name=
+# wrong constant name matches?
+# wrong constant name present_ivars
+# wrong constant name rescued_exception
+# wrong constant name supports_block_expectations?
+# wrong constant name failure_message
+# wrong constant name failure_message_when_negated
+# wrong constant name <static-init>
+# wrong constant name has_default_failure_messages?
+# wrong constant name <static-init>
+# wrong constant name improve_hash_formatting
+# wrong constant name <static-init>
+# wrong constant name matcher_name
+# wrong constant name <
+# wrong constant name <=
+# wrong constant name ==
+# wrong constant name ===
+# wrong constant name =~
+# wrong constant name >
+# wrong constant name >=
+# uninitialized constant RSpec::Matchers::BuiltIn::Be::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Be::UNDEFINED
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeAKindOf::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::BeAKindOf::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeAnInstanceOf::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::BeAnInstanceOf::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeBetween::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::BeBetween::UNDEFINED
+# wrong constant name exclusive
+# wrong constant name inclusive
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeComparedTo::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::BeComparedTo::UNDEFINED
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeFalsey::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::BeFalsey::UNDEFINED
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeNil::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::BeNil::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BePredicate::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::BePredicate::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeTruthy::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::BeTruthy::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeWithin::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::BeWithin::UNDEFINED
+# wrong constant name initialize
+# wrong constant name of
+# wrong constant name percent_of
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Change::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Change::UNDEFINED
+# wrong constant name by
+# wrong constant name by_at_least
+# wrong constant name by_at_most
+# wrong constant name does_not_match?
+# wrong constant name from
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name to
+# wrong constant name <static-init>
+# wrong constant name <Class:And>
+# wrong constant name <Class:NestedEvaluator>
+# wrong constant name <Class:Or>
+# wrong constant name <Class:SequentialEvaluator>
+# uninitialized constant RSpec::Matchers::BuiltIn::Compound::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Compound::UNDEFINED
+# wrong constant name diffable_matcher_list
+# wrong constant name does_not_match?
+# wrong constant name evaluator
+# wrong constant name initialize
+# wrong constant name matcher_1
+# wrong constant name matcher_2
+# uninitialized constant RSpec::Matchers::BuiltIn::Compound::And::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Compound::And::UNDEFINED
+#                RSpec::Matchers::BuiltIn::Compound::UNDEFINED
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name matcher_matches?
+# wrong constant name <static-init>
+# wrong constant name matcher_expects_call_stack_jump?
+# uninitialized constant RSpec::Matchers::BuiltIn::Compound::Or::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Compound::Or::UNDEFINED
+#                RSpec::Matchers::BuiltIn::Compound::UNDEFINED
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name matcher_matches?
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <Class:PairingsMaximizer>
+# uninitialized constant RSpec::Matchers::BuiltIn::ContainExactly::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::ContainExactly::UNDEFINED
+# wrong constant name <Class:NullSolution>
+# wrong constant name <Class:Solution>
+# wrong constant name actual_to_expected_matched_indexes
+# wrong constant name expected_to_actual_matched_indexes
+# wrong constant name find_best_solution
+# wrong constant name initialize
+# wrong constant name solution
+# wrong constant name <static-init>
+# wrong constant name worse_than?
+# wrong constant name +
+# uninitialized constant #<Class:0x00007ff390833c50>::Elem
+# wrong constant name candidate?
+# wrong constant name ideal?
+# wrong constant name indeterminate_actual_indexes
+# wrong constant name indeterminate_actual_indexes=
+# wrong constant name indeterminate_expected_indexes
+# wrong constant name indeterminate_expected_indexes=
+# wrong constant name unmatched_actual_indexes
+# wrong constant name unmatched_actual_indexes=
+# wrong constant name unmatched_expected_indexes
+# wrong constant name unmatched_expected_indexes=
+# wrong constant name unmatched_item_count
+# wrong constant name worse_than?
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Cover::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Cover::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::EndWith::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::EndWith::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Eq::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Eq::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Eql::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Eql::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Equal::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Equal::UNDEFINED
+# wrong constant name <static-init>
+# wrong constant name <Class:ExistenceTest>
+# uninitialized constant RSpec::Matchers::BuiltIn::Exist::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Exist::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name actual_exists?
+# wrong constant name valid_test?
+# wrong constant name validity_message
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Has::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Has::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::HaveAttributes::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::HaveAttributes::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name respond_to_failed
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Include::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Include::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name expecteds
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Match::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Match::UNDEFINED
+# wrong constant name initialize
+# wrong constant name with_captures
+# wrong constant name <static-init>
+# wrong constant name __delegate_operator
+# wrong constant name <static-init>
+# wrong constant name !=
+# wrong constant name !~
+# wrong constant name <
+# wrong constant name <=
+# wrong constant name ==
+# wrong constant name ===
+# wrong constant name =~
+# wrong constant name >
+# wrong constant name >=
+# wrong constant name description
+# wrong constant name fail_with_message
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name get
+# wrong constant name register
+# wrong constant name registry
+# wrong constant name unregister
+# wrong constant name use_custom_matcher_or_delegate
+# uninitialized constant RSpec::Matchers::BuiltIn::Output::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Output::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name to_stderr
+# wrong constant name to_stderr_from_any_process
+# wrong constant name to_stdout
+# wrong constant name to_stdout_from_any_process
+# wrong constant name <static-init>
+# wrong constant name __delegate_operator
+# wrong constant name <static-init>
+# wrong constant name description
+# wrong constant name does_not_match?
+# wrong constant name expects_call_stack_jump?
+# wrong constant name failure_message
+# wrong constant name failure_message_when_negated
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name supports_block_expectations?
+# wrong constant name with_message
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::RespondTo::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::RespondTo::UNDEFINED
+# wrong constant name and_any_keywords
+# wrong constant name and_keywords
+# wrong constant name and_unlimited_arguments
+# wrong constant name argument
+# wrong constant name arguments
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name with
+# wrong constant name with_any_keywords
+# wrong constant name with_keywords
+# wrong constant name with_unlimited_arguments
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Satisfy::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Satisfy::UNDEFINED
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::StartOrEndWith::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::StartOrEndWith::UNDEFINED
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::StartWith::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::StartWith::UNDEFINED
+# wrong constant name <static-init>
+# wrong constant name description
+# wrong constant name does_not_match?
+# wrong constant name expects_call_stack_jump?
+# wrong constant name failure_message
+# wrong constant name failure_message_when_negated
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name supports_block_expectations?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::YieldControl::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::YieldControl::UNDEFINED
+# wrong constant name at_least
+# wrong constant name at_most
+# wrong constant name does_not_match?
+# wrong constant name exactly
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name once
+# wrong constant name thrice
+# wrong constant name times
+# wrong constant name twice
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::YieldSuccessiveArgs::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::YieldSuccessiveArgs::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::YieldWithArgs::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::YieldWithArgs::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::YieldWithNoArgs::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::YieldWithNoArgs::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name matches?
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name &
+# wrong constant name ===
+# wrong constant name and
+# wrong constant name or
+# wrong constant name |
+# wrong constant name <static-init>
+# wrong constant name should_enumerate?
+# wrong constant name surface_descriptions_in
+# wrong constant name unreadable_io?
+# wrong constant name <Class:DefaultImplementations>
+# wrong constant name <Class:Macros>
+# wrong constant name <Class:Matcher>
+# wrong constant name alias_matcher
+# wrong constant name define
+# wrong constant name define_negated_matcher
+# wrong constant name matcher
+# wrong constant name description
+# wrong constant name diffable?
+# wrong constant name expects_call_stack_jump?
+# wrong constant name supports_block_expectations?
+# wrong constant name <static-init>
+# wrong constant name <Class:Deprecated>
+# wrong constant name chain
+# wrong constant name description
+# wrong constant name diffable
+# wrong constant name failure_message
+# wrong constant name failure_message_when_negated
+# wrong constant name match
+# wrong constant name match_unless_raises
+# wrong constant name match_when_negated
+# wrong constant name supports_block_expectations
+# wrong constant name failure_message_for_should
+# wrong constant name failure_message_for_should_not
+# wrong constant name match_for_should
+# wrong constant name match_for_should_not
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::DSL::Matcher::BE_PREDICATE_REGEX
+# Did you mean?  RSpec::Matchers::DSL::Matcher::BE_PREDICATE_REGEX
+#                RSpec::Matchers::BE_PREDICATE_REGEX
+# uninitialized constant RSpec::Matchers::DSL::Matcher::DYNAMIC_MATCHER_REGEX
+# Did you mean?  RSpec::Matchers::DSL::Matcher::DYNAMIC_MATCHER_REGEX
+#                RSpec::Matchers::DYNAMIC_MATCHER_REGEX
+# uninitialized constant RSpec::Matchers::DSL::Matcher::HAS_REGEX
+# Did you mean?  RSpec::Matchers::DSL::Matcher::HAS_REGEX
+#                RSpec::Matchers::HAS_REGEX
+# wrong constant name actual
+# wrong constant name block_arg
+# wrong constant name expected
+# wrong constant name expected_as_array
+# wrong constant name initialize
+# wrong constant name name
+# wrong constant name rescued_exception
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name list
+# wrong constant name split_words
+# wrong constant name initialize
+# wrong constant name message_with_diff
+# wrong constant name <static-init>
+# wrong constant name for_many_matchers
+# wrong constant name from
+# wrong constant name base_matcher
+# wrong constant name initialize
+# wrong constant name method_missing
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name alias_matcher
+# wrong constant name clear_generated_description
+# wrong constant name configuration
+# wrong constant name generated_description
+# wrong constant name is_a_describable_matcher?
+# wrong constant name is_a_matcher?
+# wrong constant name last_description
+# wrong constant name last_expectation_handler
+# wrong constant name last_expectation_handler=
+# wrong constant name last_matcher
+# wrong constant name last_matcher=
+# wrong constant name <Class:AllowanceTarget>
+# wrong constant name <Class:AndReturnImplementation>
+# wrong constant name <Class:AndWrapOriginalImplementation>
+# wrong constant name <Class:AndYieldImplementation>
+# wrong constant name <Class:AnyInstance>
+# wrong constant name <Class:AnyInstanceAllowanceTarget>
+# wrong constant name <Class:AnyInstanceExpectationTarget>
+# wrong constant name <Class:ArgumentListMatcher>
+# wrong constant name <Class:ArgumentMatchers>
+# wrong constant name <Class:CallbackInvocationStrategy>
+# wrong constant name <Class:CannotSupportArgMutationsError>
+# wrong constant name <Class:ClassNewMethodReference>
+# wrong constant name <Class:ClassVerifyingDouble>
+# wrong constant name <Class:Configuration>
+# wrong constant name <Class:Constant>
+# wrong constant name <Class:ConstantMutator>
+# wrong constant name <Class:DirectObjectReference>
+# wrong constant name <Class:Double>
+# wrong constant name <Class:ErrorGenerator>
+# wrong constant name <Class:ExampleMethods>
+# wrong constant name <Class:ExpectChain>
+# wrong constant name <Class:ExpectationTarget>
+# wrong constant name <Class:ExpectationTargetMethods>
+# wrong constant name <Class:ExpiredTestDoubleError>
+# wrong constant name <Class:Implementation>
+# wrong constant name <Class:InstanceMethodReference>
+# wrong constant name <Class:InstanceMethodStasher>
+# wrong constant name <Class:InstanceVerifyingDouble>
+# wrong constant name <Class:MarshalExtension>
+# wrong constant name <Class:Matchers>
+# wrong constant name <Class:MessageChain>
+# wrong constant name <Class:MessageExpectation>
+# wrong constant name <Class:MethodDouble>
+# wrong constant name <Class:MethodReference>
+# wrong constant name <Class:MockExpectationAlreadyInvokedError>
+# wrong constant name <Class:MockExpectationError>
+# wrong constant name <Class:NamedObjectReference>
+# wrong constant name <Class:NegationUnsupportedError>
+# wrong constant name <Class:NestedSpace>
+# wrong constant name <Class:NoCallbackInvocationStrategy>
+# wrong constant name <Class:ObjectMethodReference>
+# wrong constant name <Class:ObjectReference>
+# wrong constant name <Class:ObjectVerifyingDouble>
+# wrong constant name <Class:ObjectVerifyingDoubleMethods>
+# wrong constant name <Class:OrderGroup>
+# wrong constant name <Class:OutsideOfExampleError>
+# wrong constant name <Class:PartialClassDoubleProxy>
+# wrong constant name <Class:PartialClassDoubleProxyMethods>
+# wrong constant name <Class:PartialDoubleProxy>
+# wrong constant name <Class:Proxy>
+# wrong constant name <Class:ProxyForNil>
+# wrong constant name <Class:RootSpace>
+# wrong constant name <Class:SimpleMessageExpectation>
+# wrong constant name <Class:Space>
+# wrong constant name <Class:StubChain>
+# wrong constant name <Class:Syntax>
+# wrong constant name <Class:TargetBase>
+# wrong constant name <Class:TargetDelegationClassMethods>
+# wrong constant name <Class:TargetDelegationInstanceMethods>
+# wrong constant name <Class:TestDouble>
+# wrong constant name <Class:TestDoubleFormatter>
+# wrong constant name <Class:TestDoubleProxy>
+# wrong constant name <Class:UnsupportedMatcherError>
+# wrong constant name <Class:VerifyingDouble>
+# wrong constant name <Class:VerifyingDoubleNotDefinedError>
+# wrong constant name <Class:VerifyingExistingClassNewMethodDouble>
+# wrong constant name <Class:VerifyingExistingMethodDouble>
+# wrong constant name <Class:VerifyingMessageExpectation>
+# wrong constant name <Class:VerifyingMethodDouble>
+# wrong constant name <Class:VerifyingPartialClassDoubleProxy>
+# wrong constant name <Class:VerifyingPartialDoubleProxy>
+# wrong constant name <Class:VerifyingProxy>
+# wrong constant name <Class:VerifyingProxyMethods>
+# wrong constant name <Class:Version>
+# wrong constant name expression
+# wrong constant name not_to
+# wrong constant name to
+# wrong constant name to_not
+# wrong constant name <static-init>
+# wrong constant name call
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <Class:CannotModifyFurtherError>
+# wrong constant name call
+# wrong constant name initial_action=
+# wrong constant name initialize
+# wrong constant name inner_action
+# wrong constant name inner_action=
+# wrong constant name present?
+# wrong constant name terminal_action=
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name call
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <Class:Chain>
+# wrong constant name <Class:ErrorGenerator>
+# wrong constant name <Class:ExpectChainChain>
+# wrong constant name <Class:ExpectationChain>
+# wrong constant name <Class:FluentInterfaceProxy>
+# wrong constant name <Class:MessageChains>
+# wrong constant name <Class:PositiveExpectationChain>
+# wrong constant name <Class:Proxy>
+# wrong constant name <Class:Recorder>
+# wrong constant name <Class:StubChain>
+# wrong constant name <Class:StubChainChain>
+# wrong constant name <Class:Customizations>
+# wrong constant name constrained_to_any_of?
+# wrong constant name expectation_fulfilled!
+# wrong constant name initialize
+# wrong constant name matches_args?
+# wrong constant name never
+# wrong constant name playback!
+# wrong constant name and_call_original
+# wrong constant name and_raise
+# wrong constant name and_return
+# wrong constant name and_throw
+# wrong constant name and_wrap_original
+# wrong constant name and_yield
+# wrong constant name at_least
+# wrong constant name at_most
+# wrong constant name exactly
+# wrong constant name never
+# wrong constant name once
+# wrong constant name thrice
+# wrong constant name time
+# wrong constant name times
+# wrong constant name twice
+# wrong constant name with
+# wrong constant name <static-init>
+# wrong constant name record
+# wrong constant name <static-init>
+# wrong constant name raise_does_not_implement_error
+# wrong constant name raise_message_already_received_by_other_instance_error
+# wrong constant name raise_not_supported_with_prepend_error
+# wrong constant name raise_second_instance_received_message_error
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Mocks::AnyInstance::ExpectChainChain::EmptyInvocationOrder
+# Did you mean?  RSpec::Mocks::AnyInstance::ExpectChainChain::EmptyInvocationOrder
+#                RSpec::Mocks::AnyInstance::ExpectChainChain::InvocationOrder
+# uninitialized constant RSpec::Mocks::AnyInstance::ExpectChainChain::InvocationOrder
+# Did you mean?  RSpec::Mocks::AnyInstance::ExpectChainChain::InvocationOrder
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name expectation_fulfilled?
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name method_missing
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name add
+# wrong constant name all_expectations_fulfilled?
+# wrong constant name each_unfulfilled_expectation_matching
+# wrong constant name has_expectation?
+# wrong constant name playback!
+# wrong constant name received_expected_message!
+# wrong constant name remove_stub_chains_for!
+# wrong constant name unfulfilled_expectations
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name expect_chain
+# wrong constant name initialize
+# wrong constant name klass
+# wrong constant name should_not_receive
+# wrong constant name should_receive
+# wrong constant name stub
+# wrong constant name stub_chain
+# wrong constant name unstub
+# wrong constant name <static-init>
+# wrong constant name already_observing?
+# wrong constant name build_alias_method_name
+# wrong constant name expect_chain
+# wrong constant name initialize
+# wrong constant name instance_that_received
+# wrong constant name klass
+# wrong constant name message_chains
+# wrong constant name notify_received_message
+# wrong constant name playback!
+# wrong constant name should_not_receive
+# wrong constant name should_receive
+# wrong constant name stop_all_observation!
+# wrong constant name stop_observing!
+# wrong constant name stub
+# wrong constant name stub_chain
+# wrong constant name stubs
+# wrong constant name unstub
+# wrong constant name verify
+# wrong constant name <static-init>
+# wrong constant name expectation_fulfilled?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Mocks::AnyInstance::StubChainChain::EmptyInvocationOrder
+# Did you mean?  RSpec::Mocks::AnyInstance::StubChainChain::EmptyInvocationOrder
+#                RSpec::Mocks::AnyInstance::StubChainChain::InvocationOrder
+# uninitialized constant RSpec::Mocks::AnyInstance::StubChainChain::InvocationOrder
+# Did you mean?  RSpec::Mocks::AnyInstance::StubChainChain::InvocationOrder
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name error_generator
+# wrong constant name expression
+# wrong constant name not_to
+# wrong constant name to
+# wrong constant name to_not
+# wrong constant name <static-init>
+# wrong constant name expression
+# wrong constant name not_to
+# wrong constant name to
+# wrong constant name to_not
+# wrong constant name <static-init>
+# wrong constant name args_match?
+# wrong constant name expected_args
+# wrong constant name initialize
+# wrong constant name resolve_expected_args_based_on
+# wrong constant name <static-init>
+# wrong constant name a_kind_of
+# wrong constant name an_instance_of
+# wrong constant name any_args
+# wrong constant name anything
+# wrong constant name array_including
+# wrong constant name boolean
+# wrong constant name duck_type
+# wrong constant name hash_excluding
+# wrong constant name hash_including
+# wrong constant name hash_not_including
+# wrong constant name instance_of
+# wrong constant name kind_of
+# wrong constant name no_args
+# wrong constant name <static-init>
+# wrong constant name anythingize_lonely_keys
+# wrong constant name call
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name applies_to?
+# wrong constant name <static-init>
+# wrong constant name add_stub_and_should_receive_to
+# wrong constant name allow_message_expectations_on_nil
+# wrong constant name allow_message_expectations_on_nil=
+# wrong constant name before_verifying_doubles
+# wrong constant name color?
+# wrong constant name patch_marshal_to_support_partial_doubles=
+# wrong constant name reset_syntaxes_to_default
+# wrong constant name syntax
+# wrong constant name syntax=
+# wrong constant name temporarily_suppress_partial_double_verification
+# wrong constant name temporarily_suppress_partial_double_verification=
+# wrong constant name transfer_nested_constants=
+# wrong constant name transfer_nested_constants?
+# wrong constant name verify_doubled_constant_names=
+# wrong constant name verify_doubled_constant_names?
+# wrong constant name verify_partial_doubles=
+# wrong constant name verify_partial_doubles?
+# wrong constant name verifying_double_callbacks
+# wrong constant name when_declaring_verifying_double
+# wrong constant name yield_receiver_to_any_instance_implementation_blocks=
+# wrong constant name yield_receiver_to_any_instance_implementation_blocks?
+# wrong constant name <static-init>
+# wrong constant name hidden=
+# wrong constant name hidden?
+# wrong constant name initialize
+# wrong constant name mutated?
+# wrong constant name name
+# wrong constant name original_value
+# wrong constant name original_value=
+# wrong constant name previously_defined=
+# wrong constant name previously_defined?
+# wrong constant name stubbed=
+# wrong constant name stubbed?
+# wrong constant name valid_name=
+# wrong constant name valid_name?
+# wrong constant name <static-init>
+# wrong constant name original
+# wrong constant name unmutated
+# wrong constant name <Class:BaseMutator>
+# wrong constant name <Class:ConstantHider>
+# wrong constant name <Class:DefinedConstantReplacer>
+# wrong constant name <Class:UndefinedConstantSetter>
+# wrong constant name full_constant_name
+# wrong constant name idempotently_reset
+# wrong constant name initialize
+# wrong constant name original_value
+# wrong constant name to_constant
+# wrong constant name <static-init>
+# wrong constant name mutate
+# wrong constant name reset
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name mutate
+# wrong constant name reset
+# wrong constant name should_transfer_nested_constants?
+# wrong constant name transfer_nested_constants
+# wrong constant name verify_constants_to_transfer!
+# wrong constant name <static-init>
+# wrong constant name mutate
+# wrong constant name reset
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name hide
+# wrong constant name mutate
+# wrong constant name raise_on_invalid_const
+# wrong constant name stub
+# wrong constant name const_to_replace
+# wrong constant name defined?
+# wrong constant name description
+# wrong constant name initialize
+# wrong constant name target
+# wrong constant name when_loaded
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name default_error_message
+# wrong constant name describe_expectation
+# wrong constant name expectation_on_nil_message
+# wrong constant name initialize
+# wrong constant name intro
+# wrong constant name method_call_args_description
+# wrong constant name opts
+# wrong constant name opts=
+# wrong constant name raise_already_invoked_error
+# wrong constant name raise_cant_constrain_count_for_negated_have_received_error
+# wrong constant name raise_double_negation_error
+# wrong constant name raise_expectation_error
+# wrong constant name raise_expectation_on_mocked_method
+# wrong constant name raise_expectation_on_nil_error
+# wrong constant name raise_expectation_on_unstubbed_method
+# wrong constant name raise_expired_test_double_error
+# wrong constant name raise_have_received_disallowed
+# wrong constant name raise_invalid_arguments_error
+# wrong constant name raise_method_not_stubbed_error
+# wrong constant name raise_missing_block_error
+# wrong constant name raise_missing_default_stub_error
+# wrong constant name raise_non_public_error
+# wrong constant name raise_only_valid_on_a_partial_double
+# wrong constant name raise_out_of_order_error
+# wrong constant name raise_similar_message_args_error
+# wrong constant name raise_unexpected_message_args_error
+# wrong constant name raise_unexpected_message_error
+# wrong constant name raise_unimplemented_error
+# wrong constant name raise_verifying_double_not_defined_error
+# wrong constant name raise_wrong_arity_error
+# wrong constant name <static-init>
+# wrong constant name <Class:ExpectHost>
+# wrong constant name allow
+# wrong constant name allow_any_instance_of
+# wrong constant name allow_message_expectations_on_nil
+# wrong constant name class_double
+# wrong constant name class_spy
+# wrong constant name double
+# wrong constant name expect_any_instance_of
+# wrong constant name have_received
+# wrong constant name hide_const
+# wrong constant name instance_double
+# wrong constant name instance_spy
+# wrong constant name object_double
+# wrong constant name object_spy
+# wrong constant name receive
+# wrong constant name receive_message_chain
+# wrong constant name receive_messages
+# wrong constant name spy
+# wrong constant name stub_const
+# wrong constant name without_partial_double_verification
+# wrong constant name expect
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name declare_double
+# wrong constant name declare_verifying_double
+# wrong constant name extended
+# wrong constant name included
+# wrong constant name <static-init>
+# wrong constant name expect_chain_on
+# wrong constant name <static-init>
+# wrong constant name expression
+# wrong constant name not_to
+# wrong constant name to
+# wrong constant name to_not
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name call
+# wrong constant name initial_action
+# wrong constant name initial_action=
+# wrong constant name inner_action
+# wrong constant name inner_action=
+# wrong constant name present?
+# wrong constant name terminal_action
+# wrong constant name terminal_action=
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name handle_restoration_failures
+# wrong constant name initialize
+# wrong constant name method_is_stashed?
+# wrong constant name original_method
+# wrong constant name restore
+# wrong constant name stash
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name patch!
+# wrong constant name unpatch!
+# wrong constant name <Class:HaveReceived>
+# wrong constant name <Class:Matcher>
+# wrong constant name <Class:Receive>
+# wrong constant name <Class:ReceiveMessageChain>
+# wrong constant name <Class:ReceiveMessages>
+# wrong constant name at_least
+# wrong constant name at_most
+# wrong constant name description
+# wrong constant name does_not_match?
+# wrong constant name exactly
+# wrong constant name failure_message
+# wrong constant name failure_message_when_negated
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name name
+# wrong constant name once
+# wrong constant name ordered
+# wrong constant name setup_allowance
+# wrong constant name setup_any_instance_allowance
+# wrong constant name setup_any_instance_expectation
+# wrong constant name setup_any_instance_negative_expectation
+# wrong constant name setup_expectation
+# wrong constant name setup_negative_expectation
+# wrong constant name thrice
+# wrong constant name time
+# wrong constant name times
+# wrong constant name twice
+# wrong constant name with
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <Class:DefaultDescribable>
+# wrong constant name and_call_original
+# wrong constant name and_raise
+# wrong constant name and_return
+# wrong constant name and_throw
+# wrong constant name and_wrap_original
+# wrong constant name and_yield
+# wrong constant name at_least
+# wrong constant name at_most
+# wrong constant name description
+# wrong constant name does_not_match?
+# wrong constant name exactly
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name name
+# wrong constant name never
+# wrong constant name once
+# wrong constant name ordered
+# wrong constant name setup_allowance
+# wrong constant name setup_any_instance_allowance
+# wrong constant name setup_any_instance_expectation
+# wrong constant name setup_any_instance_negative_expectation
+# wrong constant name setup_expectation
+# wrong constant name setup_negative_expectation
+# wrong constant name thrice
+# wrong constant name time
+# wrong constant name times
+# wrong constant name twice
+# wrong constant name with
+# wrong constant name description_for
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name and_call_original
+# wrong constant name and_raise
+# wrong constant name and_return
+# wrong constant name and_throw
+# wrong constant name and_yield
+# wrong constant name description
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name name
+# wrong constant name setup_allowance
+# wrong constant name setup_any_instance_allowance
+# wrong constant name setup_any_instance_expectation
+# wrong constant name setup_expectation
+# wrong constant name setup_negative_expectation
+# wrong constant name with
+# wrong constant name <static-init>
+# wrong constant name description
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name name
+# wrong constant name setup_allowance
+# wrong constant name setup_any_instance_allowance
+# wrong constant name setup_any_instance_expectation
+# wrong constant name setup_expectation
+# wrong constant name setup_negative_expectation
+# wrong constant name warn_about_block
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name block
+# wrong constant name chain
+# wrong constant name initialize
+# wrong constant name object
+# wrong constant name setup_chain
+# wrong constant name <static-init>
+# wrong constant name <Class:ImplementationDetails>
+# wrong constant name and_call_original
+# wrong constant name and_raise
+# wrong constant name and_return
+# wrong constant name and_throw
+# wrong constant name and_wrap_original
+# wrong constant name and_yield
+# wrong constant name at_least
+# wrong constant name at_most
+# wrong constant name exactly
+# wrong constant name never
+# wrong constant name once
+# wrong constant name ordered
+# wrong constant name thrice
+# wrong constant name time
+# wrong constant name times
+# wrong constant name twice
+# wrong constant name with
+# wrong constant name actual_received_count_matters?
+# wrong constant name additional_expected_calls
+# wrong constant name advise
+# wrong constant name and_yield_receiver_to_implementation
+# wrong constant name argument_list_matcher=
+# wrong constant name called_max_times?
+# wrong constant name description_for
+# wrong constant name ensure_expected_ordering_received!
+# wrong constant name error_generator
+# wrong constant name error_generator=
+# wrong constant name expectation_count_type
+# wrong constant name expected_args
+# wrong constant name expected_from=
+# wrong constant name expected_messages_received?
+# wrong constant name expected_received_count=
+# wrong constant name generate_error
+# wrong constant name ignoring_args?
+# wrong constant name implementation
+# wrong constant name implementation=
+# wrong constant name increase_actual_received_count!
+# wrong constant name initialize
+# wrong constant name invoke
+# wrong constant name invoke_without_incrementing_received_count
+# wrong constant name matches?
+# wrong constant name matches_at_least_count?
+# wrong constant name matches_at_most_count?
+# wrong constant name matches_exact_count?
+# wrong constant name matches_name_but_not_args
+# wrong constant name message
+# wrong constant name negative?
+# wrong constant name negative_expectation_for?
+# wrong constant name ordered?
+# wrong constant name orig_object
+# wrong constant name raise_out_of_order_error
+# wrong constant name raise_unexpected_message_args_error
+# wrong constant name safe_invoke
+# wrong constant name similar_messages
+# wrong constant name type
+# wrong constant name unadvise
+# wrong constant name verify_messages_received
+# wrong constant name yield_receiver_to_implementation_block?
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <Class:RSpecPrependedModule>
+# wrong constant name add_default_stub
+# wrong constant name add_expectation
+# wrong constant name add_simple_expectation
+# wrong constant name add_simple_stub
+# wrong constant name add_stub
+# wrong constant name build_expectation
+# wrong constant name clear
+# wrong constant name configure_method
+# wrong constant name define_proxy_method
+# wrong constant name expectations
+# wrong constant name initialize
+# wrong constant name message_expectation_class
+# wrong constant name method_name
+# wrong constant name method_stasher
+# wrong constant name object
+# wrong constant name object_singleton_class
+# wrong constant name original_implementation_callable
+# wrong constant name original_method
+# wrong constant name proxy_method_invoked
+# wrong constant name raise_method_not_stubbed_error
+# wrong constant name remove_stub
+# wrong constant name remove_stub_if_present
+# wrong constant name reset
+# wrong constant name restore_original_method
+# wrong constant name restore_original_visibility
+# wrong constant name save_original_implementation_callable!
+# wrong constant name setup_simple_method_double
+# wrong constant name show_frozen_warning
+# wrong constant name stubs
+# wrong constant name verify
+# wrong constant name visibility
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name defined?
+# wrong constant name implemented?
+# wrong constant name initialize
+# wrong constant name unimplemented?
+# wrong constant name visibility
+# wrong constant name with_signature
+# wrong constant name <static-init>
+# wrong constant name for
+# wrong constant name instance_method_visibility_for
+# wrong constant name method_defined_at_any_visibility?
+# wrong constant name method_visibility_for
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name const_to_replace
+# wrong constant name defined?
+# wrong constant name description
+# wrong constant name initialize
+# wrong constant name target
+# wrong constant name when_loaded
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name call
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name for
+# wrong constant name <static-init>
+# wrong constant name as_stubbed_const
+# wrong constant name <static-init>
+# wrong constant name clear
+# wrong constant name consume
+# wrong constant name empty?
+# wrong constant name handle_order_constraint
+# wrong constant name invoked
+# wrong constant name ready_for?
+# wrong constant name register
+# wrong constant name verify_invocation_order
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Mocks::PartialClassDoubleProxy::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# Did you mean?  RSpec::Mocks::PartialClassDoubleProxy::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name method_double_from_ancestor_for
+# wrong constant name original_method_handle_for
+# wrong constant name original_unbound_method_handle_from_ancestor_for
+# wrong constant name superclass_proxy
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Mocks::PartialDoubleProxy::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# Did you mean?  RSpec::Mocks::PartialDoubleProxy::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# wrong constant name original_method_handle_for
+# wrong constant name visibility_for
+# wrong constant name <static-init>
+# wrong constant name <Class:SpecificMessage>
+# wrong constant name add_message_expectation
+# wrong constant name add_simple_expectation
+# wrong constant name add_simple_stub
+# wrong constant name add_stub
+# wrong constant name build_expectation
+# wrong constant name check_for_unexpected_arguments
+# wrong constant name ensure_implemented
+# wrong constant name has_negative_expectation?
+# wrong constant name initialize
+# wrong constant name message_received
+# wrong constant name messages_arg_list
+# wrong constant name method_double_if_exists_for_message
+# wrong constant name object
+# wrong constant name original_method_handle_for
+# wrong constant name prepended_modules_of_singleton_class
+# wrong constant name raise_missing_default_stub_error
+# wrong constant name raise_unexpected_message_error
+# wrong constant name received_message?
+# wrong constant name record_message_received
+# wrong constant name remove_stub
+# wrong constant name remove_stub_if_present
+# wrong constant name replay_received_message_on
+# wrong constant name reset
+# wrong constant name verify
+# wrong constant name visibility_for
+# wrong constant name ==
+# uninitialized constant RSpec::Mocks::Proxy::SpecificMessage::Elem
+# wrong constant name args
+# wrong constant name args=
+# wrong constant name message
+# wrong constant name message=
+# wrong constant name object
+# wrong constant name object=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# wrong constant name <static-init>
+# wrong constant name prepended_modules_of
+# uninitialized constant RSpec::Mocks::ProxyForNil::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# Did you mean?  RSpec::Mocks::ProxyForNil::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# wrong constant name disallow_expectations
+# wrong constant name disallow_expectations=
+# wrong constant name initialize
+# wrong constant name warn_about_expectations
+# wrong constant name warn_about_expectations=
+# wrong constant name <static-init>
+# wrong constant name any_instance_proxy_for
+# wrong constant name any_instance_recorder_for
+# wrong constant name any_instance_recorders_from_ancestry_of
+# wrong constant name new_scope
+# wrong constant name proxy_for
+# wrong constant name register_constant_mutator
+# wrong constant name registered?
+# wrong constant name reset_all
+# wrong constant name superclass_proxy_for
+# wrong constant name verify_all
+# wrong constant name <static-init>
+# wrong constant name called_max_times?
+# wrong constant name initialize
+# wrong constant name invoke
+# wrong constant name matches?
+# wrong constant name unadvise
+# wrong constant name verify_messages_received
+# wrong constant name <static-init>
+# wrong constant name any_instance_mutex
+# wrong constant name any_instance_proxy_for
+# wrong constant name any_instance_recorder_for
+# wrong constant name any_instance_recorders
+# wrong constant name any_instance_recorders_from_ancestry_of
+# wrong constant name constant_mutator_for
+# wrong constant name ensure_registered
+# wrong constant name new_scope
+# wrong constant name proxies
+# wrong constant name proxies_of
+# wrong constant name proxy_for
+# wrong constant name proxy_mutex
+# wrong constant name register_constant_mutator
+# wrong constant name registered?
+# wrong constant name reset_all
+# wrong constant name superclass_proxy_for
+# wrong constant name verify_all
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name stub_chain_on
+# wrong constant name <static-init>
+# wrong constant name default_should_syntax_host
+# wrong constant name disable_expect
+# wrong constant name disable_should
+# wrong constant name enable_expect
+# wrong constant name enable_should
+# wrong constant name expect_enabled?
+# wrong constant name should_enabled?
+# wrong constant name warn_about_should!
+# wrong constant name warn_unless_should_configured
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name delegate_not_to
+# wrong constant name delegate_to
+# wrong constant name disallow_negation
+# wrong constant name <static-init>
+# wrong constant name target
+# wrong constant name <static-init>
+# wrong constant name ==
+# wrong constant name __build_mock_proxy_unless_expired
+# wrong constant name __disallow_further_usage!
+# wrong constant name as_null_object
+# wrong constant name freeze
+# wrong constant name initialize
+# wrong constant name inspect
+# wrong constant name null_object?
+# wrong constant name respond_to?
+# wrong constant name to_s
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name format
+# uninitialized constant RSpec::Mocks::TestDoubleProxy::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# Did you mean?  RSpec::Mocks::TestDoubleProxy::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <Class:SilentIO>
+# wrong constant name __send__
+# wrong constant name initialize
+# wrong constant name method_missing
+# wrong constant name respond_to?
+# wrong constant name send
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name unimplemented?
+# wrong constant name with_signature
+# wrong constant name <static-init>
+# wrong constant name for
+# wrong constant name initialize
+# wrong constant name method_reference
+# wrong constant name method_reference=
+# wrong constant name <static-init>
+# wrong constant name add_expectation
+# wrong constant name add_stub
+# wrong constant name initialize
+# wrong constant name proxy_method_invoked
+# wrong constant name validate_arguments!
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Mocks::VerifyingPartialClassDoubleProxy::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# Did you mean?  RSpec::Mocks::VerifyingPartialClassDoubleProxy::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Mocks::VerifyingPartialDoubleProxy::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# Did you mean?  RSpec::Mocks::VerifyingPartialDoubleProxy::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# wrong constant name ensure_implemented
+# wrong constant name initialize
+# wrong constant name method_reference
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Mocks::VerifyingProxy::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# Did you mean?  RSpec::Mocks::VerifyingProxy::DEFAULT_MESSAGE_EXPECTATION_OPTS
+# wrong constant name initialize
+# wrong constant name method_reference
+# wrong constant name validate_arguments!
+# wrong constant name visibility_for
+# wrong constant name <static-init>
+# wrong constant name add_message_expectation
+# wrong constant name add_simple_stub
+# wrong constant name add_stub
+# wrong constant name ensure_implemented
+# wrong constant name ensure_publicly_implemented
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name allow_message
+# wrong constant name configuration
+# wrong constant name error_generator
+# wrong constant name expect_message
+# wrong constant name setup
+# wrong constant name space
+# wrong constant name teardown
+# wrong constant name verify
+# wrong constant name with_temporary_scope
+# wrong constant name <Class:BlockSignature>
 # wrong constant name <Class:Differ>
+# wrong constant name <Class:FuzzyMatcher>
+# wrong constant name <Class:LooseSignatureVerifier>
+# wrong constant name <Class:MethodSignature>
+# wrong constant name <Class:MethodSignatureExpectation>
+# wrong constant name <Class:MethodSignatureVerifier>
+# wrong constant name <Class:ObjectFormatter>
+# uninitialized constant RSpec::Support::BlockSignature::INFINITY
+# Did you mean?  RSpec::Support::BlockSignature::INFINITY
+# wrong constant name <static-init>
 # wrong constant name color?
 # wrong constant name diff
 # wrong constant name diff_as_object
 # wrong constant name diff_as_string
 # wrong constant name initialize
 # wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name values_match?
+# wrong constant name <Class:SignatureWithKeywordArgumentsMatcher>
+# wrong constant name has_kw_args_in?
+# wrong constant name initialize
+# wrong constant name invalid_kw_args_from
+# wrong constant name missing_kw_args_from
+# wrong constant name non_kw_args_arity_description
+# wrong constant name valid_non_kw_args?
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name arbitrary_kw_args?
+# wrong constant name classify_arity
+# wrong constant name classify_parameters
+# wrong constant name could_contain_kw_args?
+# wrong constant name description
+# wrong constant name has_kw_args_in?
+# wrong constant name initialize
+# wrong constant name invalid_kw_args_from
+# wrong constant name max_non_kw_args
+# wrong constant name min_non_kw_args
+# wrong constant name missing_kw_args_from
+# wrong constant name non_kw_args_arity_description
+# wrong constant name optional_kw_args
+# wrong constant name required_kw_args
+# wrong constant name unlimited_args?
+# wrong constant name valid_non_kw_args?
+# wrong constant name <static-init>
+# wrong constant name empty?
+# wrong constant name expect_arbitrary_keywords
+# wrong constant name expect_arbitrary_keywords=
+# wrong constant name expect_unlimited_arguments
+# wrong constant name expect_unlimited_arguments=
+# wrong constant name keywords
+# wrong constant name keywords=
+# wrong constant name max_count
+# wrong constant name max_count=
+# wrong constant name min_count
+# wrong constant name min_count=
+# wrong constant name <static-init>
+# wrong constant name error_message
+# wrong constant name initialize
+# wrong constant name kw_args
+# wrong constant name max_non_kw_args
+# wrong constant name min_non_kw_args
+# wrong constant name non_kw_args
+# wrong constant name valid?
+# wrong constant name with_expectation
+# wrong constant name <static-init>
+# wrong constant name <Class:BaseInspector>
+# wrong constant name <Class:BigDecimalInspector>
+# wrong constant name <Class:DateTimeInspector>
+# wrong constant name <Class:DelegatorInspector>
+# wrong constant name <Class:DescribableMatcherInspector>
+# wrong constant name <Class:InspectableItem>
+# wrong constant name <Class:InspectableObjectInspector>
+# wrong constant name <Class:TimeInspector>
+# wrong constant name <Class:UninspectableObjectInspector>
+# wrong constant name format
+# wrong constant name initialize
+# wrong constant name max_formatted_output_length
+# wrong constant name max_formatted_output_length=
+# wrong constant name prepare_array
+# wrong constant name prepare_element
+# wrong constant name prepare_for_inspection
+# wrong constant name prepare_hash
+# wrong constant name recursive_structure?
+# wrong constant name sort_hash_keys
+# wrong constant name with_entering_structure
+# uninitialized constant RSpec::Support::ObjectFormatter::BaseInspector::Elem
+# wrong constant name formatter
+# wrong constant name formatter=
+# wrong constant name object
+# wrong constant name object=
+# wrong constant name pretty_print
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name can_inspect?
+# wrong constant name members
+# uninitialized constant RSpec::Support::ObjectFormatter::BigDecimalInspector::Elem
+# wrong constant name <static-init>
+# wrong constant name can_inspect?
+# uninitialized constant RSpec::Support::ObjectFormatter::DateTimeInspector::Elem
+# wrong constant name <static-init>
+# wrong constant name can_inspect?
+# uninitialized constant RSpec::Support::ObjectFormatter::DelegatorInspector::Elem
+# wrong constant name <static-init>
+# wrong constant name can_inspect?
+# uninitialized constant RSpec::Support::ObjectFormatter::DescribableMatcherInspector::Elem
+# wrong constant name <static-init>
+# wrong constant name can_inspect?
+# uninitialized constant RSpec::Support::ObjectFormatter::InspectableItem::Elem
+# wrong constant name pretty_print
+# wrong constant name text
+# wrong constant name text=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# uninitialized constant RSpec::Support::ObjectFormatter::InspectableObjectInspector::Elem
+# wrong constant name <static-init>
+# wrong constant name can_inspect?
+# uninitialized constant RSpec::Support::ObjectFormatter::TimeInspector::Elem
+# wrong constant name <static-init>
+# wrong constant name can_inspect?
+# uninitialized constant RSpec::Support::ObjectFormatter::UninspectableObjectInspector::Elem
+# wrong constant name klass
+# wrong constant name native_object_id
+# wrong constant name <static-init>
+# wrong constant name can_inspect?
+# wrong constant name <static-init>
+# wrong constant name default_instance
+# wrong constant name format
+# wrong constant name prepare_for_inspection
 # wrong constant name deregister_matcher_definition
 # wrong constant name is_a_matcher?
 # wrong constant name matcher_definitions
 # wrong constant name register_matcher_definition
+# wrong constant name require_rspec_expectations
+# wrong constant name require_rspec_matchers
+# wrong constant name require_rspec_mocks
 # wrong constant name rspec_description_for_object
 # uninitialized constant Racc
 # uninitialized constant Racc
+# wrong constant name to_ansi_domain
+# wrong constant name method_missing
+# wrong constant name method_missing
+# wrong constant name uncolor
+# wrong constant name new
 # uninitialized constant Rake::DSL::DEFAULT
+# Did you mean?  Rake::DSL::DEFAULT
 # uninitialized constant Rake::DSL::LN_SUPPORTED
+# Did you mean?  Rake::DSL::LN_SUPPORTED
 # uninitialized constant Rake::DSL::LOW_METHODS
 # Did you mean?  Rake::DSL::LowMethods
+#                Rake::DSL::LOW_METHODS
 # uninitialized constant Rake::DSL::METHODS
 # Did you mean?  Method
+#                Rake::DSL::METHODS
 # uninitialized constant Rake::DSL::OPT_TABLE
+# Did you mean?  Rake::DSL::OPT_TABLE
 # uninitialized constant Rake::DSL::RUBY
+# Did you mean?  Rake::DSL::RUBY
 # uninitialized constant Rake::DSL::VERSION
 # Did you mean?  Rake::Version
+#                Rake::DSL::VERSION
 #                Rake::VERSION
 # uninitialized constant Rake::FileUtilsExt::LN_SUPPORTED
+# Did you mean?  Rake::FileUtilsExt::LN_SUPPORTED
 # uninitialized constant Rake::FileUtilsExt::LOW_METHODS
 # Did you mean?  Rake::FileUtilsExt::LowMethods
+#                Rake::FileUtilsExt::LOW_METHODS
 # uninitialized constant Rake::FileUtilsExt::METHODS
 # Did you mean?  Method
+#                Rake::FileUtilsExt::METHODS
 # uninitialized constant Rake::FileUtilsExt::OPT_TABLE
+# Did you mean?  Rake::FileUtilsExt::OPT_TABLE
 # uninitialized constant Rake::FileUtilsExt::RUBY
+# Did you mean?  Rake::FileUtilsExt::RUBY
 # uninitialized constant Rake::FileUtilsExt::VERSION
 # Did you mean?  Rake::Version
+#                Rake::FileUtilsExt::VERSION
 #                Rake::VERSION
-# undefined method `rand$2' for module `Random::Formatter'
-# Did you mean?  rand
-# undefined method `random_number$2' for module `Random::Formatter'
 # wrong constant name alphanumeric
-# wrong constant name rand$2
-# wrong constant name random_number$2
-# wrong constant name bytes
 # wrong constant name urandom
-# undefined method `initialize$1' for class `Range'
-# Did you mean?  initialize
-# undefined method `last$2' for class `Range'
-# undefined method `step$2' for class `Range'
-# wrong constant name %
-# wrong constant name entries
-# wrong constant name initialize$1
-# wrong constant name last$2
-# wrong constant name step$2
-# wrong constant name to_a
 # wrong constant name expand
-# wrong constant name fire_update!
 # wrong constant name ruby
-# undefined method `initialize$2' for class `Regexp'
-# Did you mean?  initialize
-# undefined method `match$1' for class `Regexp'
-# wrong constant name initialize$2
-# wrong constant name match$1
 # wrong constant name match?
-# undefined singleton method `compile$2' for `Regexp'
-# undefined singleton method `last_match$2' for `Regexp'
-# wrong constant name compile$2
-# wrong constant name last_match$2
 # wrong constant name union
 # uninitialized constant Ripper
 # uninitialized constant Ripper
-# wrong constant name <Class:Node>
-# wrong constant name children
-# wrong constant name first_column
-# wrong constant name first_lineno
-# wrong constant name last_column
-# wrong constant name last_lineno
-# wrong constant name pretty_print_children
-# wrong constant name type
-# wrong constant name <static-init>
-# wrong constant name <static-init>
-# wrong constant name of
-# wrong constant name parse
-# wrong constant name parse_file
 # wrong constant name absolute_path
 # wrong constant name base_label
 # wrong constant name disasm
@@ -1832,11 +6316,6 @@
 # wrong constant name load_from_binary
 # wrong constant name load_from_binary_extra_data
 # wrong constant name of
-# wrong constant name <static-init>
-# wrong constant name enabled?
-# wrong constant name pause
-# wrong constant name resume
-# wrong constant name resolve_feature_path
 # wrong constant name stat
 # wrong constant name ==
 # wrong constant name ===
@@ -1844,7 +6323,6 @@
 # wrong constant name compare_by_identity?
 # wrong constant name divide
 # wrong constant name eql?
-# wrong constant name filter!
 # wrong constant name flatten_merge
 # wrong constant name pretty_print
 # wrong constant name pretty_print_cycle
@@ -1930,10 +6408,10 @@
 # wrong constant name disable_tracepoints
 # wrong constant name finish
 # wrong constant name install_tracepoints
-# wrong constant name method_added
-# wrong constant name module_created
-# wrong constant name module_extended
-# wrong constant name module_included
+# wrong constant name on_method_added
+# wrong constant name on_module_created
+# wrong constant name on_module_extended
+# wrong constant name on_module_included
 # wrong constant name pre_cache_module_methods
 # wrong constant name register_delegate_class
 # wrong constant name start
@@ -1997,6 +6475,8 @@
 # wrong constant name my_require
 # wrong constant name patch_kernel
 # wrong constant name rails?
+# wrong constant name rails_load_paths
+# wrong constant name rb_file_paths
 # wrong constant name require_all_files
 # wrong constant name require_everything
 # wrong constant name alias
@@ -2032,139 +6512,26 @@
 # wrong constant name main
 # wrong constant name output_file
 # uninitialized constant SortedSet::InspectKey
+# Did you mean?  SortedSet::InspectKey
 # wrong constant name initialize
 # wrong constant name setup
 # wrong constant name result
-# undefined method `[]$2' for class `String'
-# undefined method `byteslice$2' for class `String'
-# undefined method `capitalize$1' for class `String'
-# undefined method `capitalize!$1' for class `String'
-# undefined method `center$1' for class `String'
-# undefined method `chomp$1' for class `String'
-# undefined method `chomp!$1' for class `String'
-# undefined method `concat$1' for class `String'
-# undefined method `count$1' for class `String'
-# undefined method `delete$1' for class `String'
-# Did you mean?  DelegateClass
-# undefined method `delete!$1' for class `String'
-# undefined method `downcase$1' for class `String'
-# undefined method `downcase!$1' for class `String'
-# undefined method `each_line$2' for class `String'
-# undefined method `gsub$2' for class `String'
-# undefined method `gsub!$2' for class `String'
-# undefined method `index$1' for class `String'
-# undefined method `initialize$1' for class `String'
-# Did you mean?  initialize
-# undefined method `lines$1' for class `String'
-# undefined method `ljust$1' for class `String'
-# undefined method `match$2' for class `String'
-# undefined method `match?$2' for class `String'
-# undefined method `prepend$1' for class `String'
-# Did you mean?  prepend
-#                prepended
-# undefined method `rindex$1' for class `String'
-# undefined method `rjust$1' for class `String'
-# undefined method `scrub$2' for class `String'
-# undefined method `scrub!$2' for class `String'
-# undefined method `slice$2' for class `String'
-# undefined method `slice!$2' for class `String'
-# undefined method `split$2' for class `String'
-# undefined method `squeeze$1' for class `String'
-# undefined method `squeeze!$1' for class `String'
-# undefined method `sub$2' for class `String'
-# undefined method `sub!$2' for class `String'
-# undefined method `sum$1' for class `String'
-# undefined method `swapcase$1' for class `String'
-# undefined method `swapcase!$1' for class `String'
-# undefined method `to_i$1' for class `String'
-# undefined method `upcase$1' for class `String'
-# undefined method `upcase!$1' for class `String'
-# undefined method `upto$2' for class `String'
-# wrong constant name +@
-# wrong constant name -@
-# wrong constant name []$2
 # wrong constant name []=
-# wrong constant name byteslice$2
-# wrong constant name capitalize$1
-# wrong constant name capitalize!$1
 # wrong constant name casecmp?
-# wrong constant name center$1
-# wrong constant name chomp$1
-# wrong constant name chomp!$1
-# wrong constant name concat$1
-# wrong constant name count$1
-# wrong constant name delete$1
-# wrong constant name delete!$1
-# wrong constant name delete_prefix
-# wrong constant name delete_prefix!
-# wrong constant name delete_suffix
-# wrong constant name delete_suffix!
-# wrong constant name downcase$1
-# wrong constant name downcase!$1
 # wrong constant name each_grapheme_cluster
-# wrong constant name each_line$2
-# wrong constant name encode
 # wrong constant name encode!
 # wrong constant name grapheme_clusters
-# wrong constant name gsub$2
-# wrong constant name gsub!$2
-# wrong constant name index$1
-# wrong constant name initialize$1
-# wrong constant name lines$1
-# wrong constant name ljust$1
-# wrong constant name match$2
-# wrong constant name match?$2
-# wrong constant name prepend$1
 # wrong constant name reverse!
-# wrong constant name rindex$1
-# wrong constant name rjust$1
-# wrong constant name scrub$2
-# wrong constant name scrub!$2
 # wrong constant name shellescape
 # wrong constant name shellsplit
-# wrong constant name slice$2
-# wrong constant name slice!$2
-# wrong constant name split$2
-# wrong constant name squeeze$1
-# wrong constant name squeeze!$1
-# wrong constant name sub$2
-# wrong constant name sub!$2
 # wrong constant name succ!
-# wrong constant name sum$1
-# wrong constant name swapcase$1
-# wrong constant name swapcase!$1
-# wrong constant name to_i$1
 # wrong constant name undump
 # wrong constant name unicode_normalize
 # wrong constant name unicode_normalize!
 # wrong constant name unicode_normalized?
 # wrong constant name unpack1
-# wrong constant name upcase$1
-# wrong constant name upcase!$1
-# wrong constant name upto$2
-# undefined method `each$2' for class `StringIO'
-# undefined method `each_line$2' for class `StringIO'
-# undefined method `fcntl$1' for class `StringIO'
-# undefined method `initialize$1' for class `StringIO'
-# Did you mean?  initialize
-# undefined method `lines$2' for class `StringIO'
-# undefined method `read$1' for class `StringIO'
-# undefined method `reopen$2' for class `StringIO'
-# undefined method `seek$1' for class `StringIO'
-# undefined method `set_encoding$2' for class `StringIO'
-# undefined method `write$1' for class `StringIO'
-# wrong constant name each$2
-# wrong constant name each_line$2
-# wrong constant name fcntl$1
-# wrong constant name initialize$1
 # wrong constant name length
-# wrong constant name lines$2
-# wrong constant name read$1
-# wrong constant name reopen$2
-# wrong constant name seek$1
-# wrong constant name set_encoding$2
 # wrong constant name truncate
-# wrong constant name write$1
 # wrong constant name <<
 # wrong constant name []
 # wrong constant name beginning_of_line?
@@ -2209,14 +6576,10 @@
 # wrong constant name unscan
 # wrong constant name values_at
 # wrong constant name must_C_version
-# undefined method `initialize$1' for class `Struct'
-# Did you mean?  initialize
 # wrong constant name []
 # wrong constant name []=
 # wrong constant name dig
 # wrong constant name each_pair
-# wrong constant name filter
-# wrong constant name initialize$1
 # wrong constant name length
 # wrong constant name members
 # wrong constant name select
@@ -2225,115 +6588,13 @@
 # wrong constant name to_h
 # wrong constant name values
 # wrong constant name values_at
-# undefined method `[]$2' for class `Symbol'
-# undefined method `capitalize$1' for class `Symbol'
-# undefined method `downcase$1' for class `Symbol'
-# undefined method `match$1' for class `Symbol'
-# undefined method `slice$2' for class `Symbol'
-# undefined method `swapcase$1' for class `Symbol'
-# undefined method `upcase$1' for class `Symbol'
-# wrong constant name []$2
-# wrong constant name capitalize$1
-# wrong constant name casecmp?
-# wrong constant name downcase$1
-# wrong constant name match$1
-# wrong constant name match?
-# wrong constant name next
-# wrong constant name slice$2
-# wrong constant name swapcase$1
-# wrong constant name upcase$1
 # wrong constant name errno
 # wrong constant name status
 # wrong constant name success?
 # wrong constant name T.noreturn
 # wrong constant name T.noreturn
 # wrong constant name T.untyped
-# wrong constant name abort_on_exception
-# wrong constant name abort_on_exception=
-# wrong constant name add_trace_func
-# wrong constant name backtrace
-# wrong constant name backtrace_locations
-# wrong constant name exit
-# wrong constant name fetch
-# wrong constant name group
-# wrong constant name initialize
-# wrong constant name join
-# wrong constant name key?
-# wrong constant name keys
-# wrong constant name name
-# wrong constant name name=
-# wrong constant name pending_interrupt?
-# wrong constant name priority
-# wrong constant name priority=
-# wrong constant name report_on_exception
-# wrong constant name report_on_exception=
-# wrong constant name run
-# wrong constant name safe_level
-# wrong constant name status
-# wrong constant name stop?
-# wrong constant name terminate
-# wrong constant name thread_variable?
-# wrong constant name thread_variable_get
-# wrong constant name thread_variable_set
-# wrong constant name thread_variables
-# wrong constant name value
-# wrong constant name wakeup
-# wrong constant name broadcast
-# wrong constant name marshal_dump
-# wrong constant name signal
-# wrong constant name wait
-# wrong constant name lock
-# wrong constant name locked?
-# wrong constant name owned?
-# wrong constant name synchronize
-# wrong constant name try_lock
-# wrong constant name unlock
-# wrong constant name <<
-# wrong constant name clear
-# wrong constant name close
-# wrong constant name closed?
-# wrong constant name deq
-# wrong constant name empty?
-# wrong constant name enq
-# wrong constant name length
-# wrong constant name marshal_dump
-# wrong constant name num_waiting
-# wrong constant name pop
-# wrong constant name push
-# wrong constant name shift
-# wrong constant name size
-# wrong constant name <<
-# wrong constant name enq
-# wrong constant name initialize
-# wrong constant name max
-# wrong constant name max=
-# wrong constant name push
-# wrong constant name abort_on_exception
-# wrong constant name abort_on_exception=
-# wrong constant name exclusive
-# wrong constant name exit
-# wrong constant name fork
-# wrong constant name handle_interrupt
-# wrong constant name kill
-# wrong constant name list
-# wrong constant name pass
-# wrong constant name pending_interrupt?
-# wrong constant name report_on_exception
-# wrong constant name report_on_exception=
-# wrong constant name start
-# wrong constant name stop
-# wrong constant name add
-# wrong constant name enclose
-# wrong constant name enclosed?
-# wrong constant name list
-# undefined method `enable$2' for class `TracePoint'
-# wrong constant name __enable
-# wrong constant name enable$2
-# wrong constant name eval_script
 # wrong constant name event
-# wrong constant name instruction_sequence
-# wrong constant name parameters
-# wrong constant name <Class:File>
 # wrong constant name decode
 # wrong constant name encode
 # wrong constant name escape
@@ -2342,132 +6603,6 @@
 # wrong constant name typecode
 # wrong constant name typecode=
 # wrong constant name new2
-# uninitialized constant URI::File::ABS_PATH
-# Did you mean?  URI::ABS_PATH
-# uninitialized constant URI::File::ABS_URI
-# Did you mean?  URI::ABS_URI
-# uninitialized constant URI::File::ABS_URI_REF
-# Did you mean?  URI::ABS_URI_REF
-# uninitialized constant URI::File::DEFAULT_PARSER
-# Did you mean?  URI::File::DEFAULT_PORT
-#                URI::DEFAULT_PARSER
-# uninitialized constant URI::File::ESCAPED
-# Did you mean?  URI::File::Escape
-#                URI::Escape
-#                URI::ESCAPED
-# uninitialized constant URI::File::FRAGMENT
-# Did you mean?  URI::FRAGMENT
-# uninitialized constant URI::File::HOST
-# Did you mean?  URI::HOST
-# uninitialized constant URI::File::OPAQUE
-# Did you mean?  URI::OPAQUE
-# uninitialized constant URI::File::PORT
-# Did you mean?  URI::PORT
-# uninitialized constant URI::File::QUERY
-# Did you mean?  URI::QUERY
-# uninitialized constant URI::File::REGISTRY
-# Did you mean?  URI::REGISTRY
-# uninitialized constant URI::File::REL_PATH
-# Did you mean?  URI::REL_PATH
-# uninitialized constant URI::File::REL_URI
-# Did you mean?  URI::REL_URI
-# uninitialized constant URI::File::REL_URI_REF
-# Did you mean?  URI::REL_URI_REF
-# uninitialized constant URI::File::RFC3986_PARSER
-# Did you mean?  URI::File::RFC3986_Parser
-#                URI::RFC3986_Parser
-#                URI::File::RFC2396_Parser
-#                URI::RFC2396_Parser
-#                URI::RFC3986_PARSER
-# uninitialized constant URI::File::SCHEME
-# Did you mean?  URI::SCHEME
-# uninitialized constant URI::File::TBLDECWWWCOMP_
-# Did you mean?  URI::File::TBLENCWWWCOMP_
-#                URI::TBLDECWWWCOMP_
-#                URI::TBLENCWWWCOMP_
-# uninitialized constant URI::File::TBLENCWWWCOMP_
-# Did you mean?  URI::File::TBLDECWWWCOMP_
-#                URI::TBLDECWWWCOMP_
-#                URI::TBLENCWWWCOMP_
-# uninitialized constant URI::File::UNSAFE
-# Did you mean?  URI::UNSAFE
-# uninitialized constant URI::File::URI_REF
-# Did you mean?  URI::URI_REF
-# uninitialized constant URI::File::USERINFO
-# Did you mean?  URI::USERINFO
-# uninitialized constant URI::File::USE_REGISTRY
-# uninitialized constant URI::File::VERSION
-# Did you mean?  URI::VERSION
-# uninitialized constant URI::File::VERSION_CODE
-# Did you mean?  URI::VERSION_CODE
-# uninitialized constant URI::File::WEB_ENCODINGS_
-# Did you mean?  URI::WEB_ENCODINGS_
-# wrong constant name check_password
-# wrong constant name check_user
-# wrong constant name check_userinfo
-# wrong constant name set_userinfo
-# wrong constant name <static-init>
-# wrong constant name +
-# wrong constant name -
-# wrong constant name ==
-# wrong constant name absolute
-# wrong constant name absolute?
-# wrong constant name coerce
-# wrong constant name component
-# wrong constant name component_ary
-# wrong constant name default_port
-# wrong constant name eql?
-# wrong constant name find_proxy
-# wrong constant name fragment
-# wrong constant name fragment=
-# wrong constant name hierarchical?
-# wrong constant name host
-# wrong constant name host=
-# wrong constant name hostname
-# wrong constant name hostname=
-# wrong constant name initialize
-# wrong constant name merge
-# wrong constant name merge!
-# wrong constant name normalize
-# wrong constant name normalize!
-# wrong constant name opaque
-# wrong constant name opaque=
-# wrong constant name parser
-# wrong constant name password
-# wrong constant name password=
-# wrong constant name path
-# wrong constant name path=
-# wrong constant name port
-# wrong constant name port=
-# wrong constant name query
-# wrong constant name query=
-# wrong constant name registry
-# wrong constant name registry=
-# wrong constant name relative?
-# wrong constant name route_from
-# wrong constant name route_to
-# wrong constant name scheme
-# wrong constant name scheme=
-# wrong constant name select
-# wrong constant name set_host
-# wrong constant name set_opaque
-# wrong constant name set_password
-# wrong constant name set_path
-# wrong constant name set_port
-# wrong constant name set_registry
-# wrong constant name set_scheme
-# wrong constant name set_user
-# wrong constant name set_userinfo
-# wrong constant name user
-# wrong constant name user=
-# wrong constant name userinfo
-# wrong constant name userinfo=
-# wrong constant name build
-# wrong constant name build2
-# wrong constant name component
-# wrong constant name default_port
-# wrong constant name use_proxy?
-# wrong constant name use_registry
 # wrong constant name request_uri
 # wrong constant name attributes
 # wrong constant name attributes=

--- a/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -5,74 +5,630 @@
 
 class Array
   include ::JSON::Ext::Generator::GeneratorMethods::Array
-  def append(*_); end
-
   def bsearch(); end
 
   def bsearch_index(); end
 
   def collect!(); end
 
-  def difference(*_); end
-
   def dig(*_); end
-
-  def filter!(); end
 
   def flatten!(*_); end
 
   def pack(*_); end
-
-  def prepend(*_); end
 
   def replace(_); end
 
   def shelljoin(); end
 
   def to_h(); end
-
-  def union(*_); end
 end
 
 class Array
   def self.try_convert(_); end
 end
 
-BasicObject::BasicObject = BasicObject
+class BasicObject
+  def as_null_object(); end
 
-class BasicSocket
-  def read_nonblock(len, str=T.unsafe(nil), exception: T.unsafe(nil)); end
+  def null_object?(); end
+
+  def received_message?(message, *args, &block); end
+
+  def should(matcher=T.unsafe(nil), message=T.unsafe(nil), &block); end
+
+  def should_not(matcher=T.unsafe(nil), message=T.unsafe(nil), &block); end
+
+  def should_not_receive(message, &block); end
+
+  def should_receive(message, opts=T.unsafe(nil), &block); end
+
+  def stub(message_or_hash, opts=T.unsafe(nil), &block); end
+
+  def stub_chain(*chain, &blk); end
+
+  def unstub(message); end
 end
+
+BasicObject::BasicObject = BasicObject
 
 class BigDecimal
   def clone(); end
-
   EXCEPTION_NaN = ::T.let(nil, ::T.untyped)
   SIGN_NaN = ::T.let(nil, ::T.untyped)
   VERSION = ::T.let(nil, ::T.untyped)
 end
 
 class BigDecimal
-  def self.new(*args, **kwargs); end
+  def self.ver(); end
 end
 
 class Binding
   def clone(); end
 
   def irb(); end
+end
 
-  def local_variable_defined?(_); end
+module Bundler
+  FREEBSD = ::T.let(nil, ::T.untyped)
+  NULL = ::T.let(nil, ::T.untyped)
+  ORIGINAL_ENV = ::T.let(nil, ::T.untyped)
+  SUDO_MUTEX = ::T.let(nil, ::T.untyped)
+  VERSION = ::T.let(nil, ::T.untyped)
+  WINDOWS = ::T.let(nil, ::T.untyped)
+end
 
-  def local_variable_get(_); end
+class Bundler::APIResponseMismatchError
+  def status_code(); end
+end
 
-  def local_variable_set(_, _1); end
+class Bundler::APIResponseMismatchError
+end
 
-  def receiver(); end
+module Bundler::BuildMetadata
+end
 
-  def source_location(); end
+module Bundler::BuildMetadata
+  def self.built_at(); end
+
+  def self.git_commit_sha(); end
+
+  def self.release?(); end
+
+  def self.to_h(); end
+end
+
+class Bundler::BundlerError
+end
+
+class Bundler::BundlerError
+  def self.all_errors(); end
+
+  def self.status_code(code); end
+end
+
+class Bundler::CurrentRuby
+  def jruby?(); end
+
+  def jruby_18?(); end
+
+  def jruby_19?(); end
+
+  def jruby_1?(); end
+
+  def jruby_20?(); end
+
+  def jruby_21?(); end
+
+  def jruby_22?(); end
+
+  def jruby_23?(); end
+
+  def jruby_24?(); end
+
+  def jruby_25?(); end
+
+  def jruby_26?(); end
+
+  def jruby_27?(); end
+
+  def jruby_2?(); end
+
+  def maglev?(); end
+
+  def maglev_18?(); end
+
+  def maglev_19?(); end
+
+  def maglev_1?(); end
+
+  def maglev_20?(); end
+
+  def maglev_21?(); end
+
+  def maglev_22?(); end
+
+  def maglev_23?(); end
+
+  def maglev_24?(); end
+
+  def maglev_25?(); end
+
+  def maglev_26?(); end
+
+  def maglev_27?(); end
+
+  def maglev_2?(); end
+
+  def mingw?(); end
+
+  def mingw_18?(); end
+
+  def mingw_19?(); end
+
+  def mingw_1?(); end
+
+  def mingw_20?(); end
+
+  def mingw_21?(); end
+
+  def mingw_22?(); end
+
+  def mingw_23?(); end
+
+  def mingw_24?(); end
+
+  def mingw_25?(); end
+
+  def mingw_26?(); end
+
+  def mingw_27?(); end
+
+  def mingw_2?(); end
+
+  def mri?(); end
+
+  def mri_18?(); end
+
+  def mri_19?(); end
+
+  def mri_1?(); end
+
+  def mri_20?(); end
+
+  def mri_21?(); end
+
+  def mri_22?(); end
+
+  def mri_23?(); end
+
+  def mri_24?(); end
+
+  def mri_25?(); end
+
+  def mri_26?(); end
+
+  def mri_27?(); end
+
+  def mri_2?(); end
+
+  def mswin64?(); end
+
+  def mswin64_18?(); end
+
+  def mswin64_19?(); end
+
+  def mswin64_1?(); end
+
+  def mswin64_20?(); end
+
+  def mswin64_21?(); end
+
+  def mswin64_22?(); end
+
+  def mswin64_23?(); end
+
+  def mswin64_24?(); end
+
+  def mswin64_25?(); end
+
+  def mswin64_26?(); end
+
+  def mswin64_27?(); end
+
+  def mswin64_2?(); end
+
+  def mswin?(); end
+
+  def mswin_18?(); end
+
+  def mswin_19?(); end
+
+  def mswin_1?(); end
+
+  def mswin_20?(); end
+
+  def mswin_21?(); end
+
+  def mswin_22?(); end
+
+  def mswin_23?(); end
+
+  def mswin_24?(); end
+
+  def mswin_25?(); end
+
+  def mswin_26?(); end
+
+  def mswin_27?(); end
+
+  def mswin_2?(); end
+
+  def on_18?(); end
+
+  def on_19?(); end
+
+  def on_1?(); end
+
+  def on_20?(); end
+
+  def on_21?(); end
+
+  def on_22?(); end
+
+  def on_23?(); end
+
+  def on_24?(); end
+
+  def on_25?(); end
+
+  def on_26?(); end
+
+  def on_27?(); end
+
+  def on_2?(); end
+
+  def rbx?(); end
+
+  def rbx_18?(); end
+
+  def rbx_19?(); end
+
+  def rbx_1?(); end
+
+  def rbx_20?(); end
+
+  def rbx_21?(); end
+
+  def rbx_22?(); end
+
+  def rbx_23?(); end
+
+  def rbx_24?(); end
+
+  def rbx_25?(); end
+
+  def rbx_26?(); end
+
+  def rbx_27?(); end
+
+  def rbx_2?(); end
+
+  def ruby?(); end
+
+  def ruby_18?(); end
+
+  def ruby_19?(); end
+
+  def ruby_1?(); end
+
+  def ruby_20?(); end
+
+  def ruby_21?(); end
+
+  def ruby_22?(); end
+
+  def ruby_23?(); end
+
+  def ruby_24?(); end
+
+  def ruby_25?(); end
+
+  def ruby_26?(); end
+
+  def ruby_27?(); end
+
+  def ruby_2?(); end
+
+  def truffleruby?(); end
+
+  def truffleruby_18?(); end
+
+  def truffleruby_19?(); end
+
+  def truffleruby_1?(); end
+
+  def truffleruby_20?(); end
+
+  def truffleruby_21?(); end
+
+  def truffleruby_22?(); end
+
+  def truffleruby_23?(); end
+
+  def truffleruby_24?(); end
+
+  def truffleruby_25?(); end
+
+  def truffleruby_26?(); end
+
+  def truffleruby_27?(); end
+
+  def truffleruby_2?(); end
+
+  def x64_mingw?(); end
+
+  def x64_mingw_18?(); end
+
+  def x64_mingw_19?(); end
+
+  def x64_mingw_1?(); end
+
+  def x64_mingw_20?(); end
+
+  def x64_mingw_21?(); end
+
+  def x64_mingw_22?(); end
+
+  def x64_mingw_23?(); end
+
+  def x64_mingw_24?(); end
+
+  def x64_mingw_25?(); end
+
+  def x64_mingw_26?(); end
+
+  def x64_mingw_27?(); end
+
+  def x64_mingw_2?(); end
+  KNOWN_MAJOR_VERSIONS = ::T.let(nil, ::T.untyped)
+  KNOWN_MINOR_VERSIONS = ::T.let(nil, ::T.untyped)
+  KNOWN_PLATFORMS = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::CurrentRuby
+end
+
+class Bundler::CyclicDependencyError
+  def status_code(); end
+end
+
+class Bundler::CyclicDependencyError
+end
+
+class Bundler::Definition
+  include ::Bundler::GemHelpers
+  def add_current_platform(); end
+
+  def add_platform(platform); end
+
+  def current_dependencies(); end
+
+  def dependencies(); end
+
+  def ensure_equivalent_gemfile_and_lockfile(explicit_flag=T.unsafe(nil)); end
+
+  def find_indexed_specs(current_spec); end
+
+  def find_resolved_spec(current_spec); end
+
+  def gem_version_promoter(); end
+
+  def gemfiles(); end
+
+  def groups(); end
+
+  def has_local_dependencies?(); end
+
+  def has_rubygems_remotes?(); end
+
+  def index(); end
+
+  def initialize(lockfile, dependencies, sources, unlock, ruby_version=T.unsafe(nil), optional_groups=T.unsafe(nil), gemfiles=T.unsafe(nil)); end
+
+  def lock(file, preserve_unknown_sections=T.unsafe(nil)); end
+
+  def locked_bundler_version(); end
+
+  def locked_deps(); end
+
+  def locked_gems(); end
+
+  def locked_ruby_version(); end
+
+  def locked_ruby_version_object(); end
+
+  def lockfile(); end
+
+  def missing_specs(); end
+
+  def missing_specs?(); end
+
+  def new_platform?(); end
+
+  def new_specs(); end
+
+  def nothing_changed?(); end
+
+  def platforms(); end
+
+  def remove_platform(platform); end
+
+  def removed_specs(); end
+
+  def requested_specs(); end
+
+  def requires(); end
+
+  def resolve(); end
+
+  def resolve_remotely!(); end
+
+  def resolve_with_cache!(); end
+
+  def ruby_version(); end
+
+  def spec_git_paths(); end
+
+  def specs(); end
+
+  def specs_for(groups); end
+
+  def to_lock(); end
+
+  def unlocking?(); end
+
+  def validate_platforms!(); end
+
+  def validate_ruby!(); end
+
+  def validate_runtime!(); end
+end
+
+class Bundler::Definition
+  def self.build(gemfile, lockfile, unlock); end
+end
+
+class Bundler::DepProxy
+  def ==(other); end
+
+  def __platform(); end
+
+  def dep(); end
+
+  def eql?(other); end
+
+  def initialize(dep, platform); end
+
+  def name(); end
+
+  def requirement(); end
+
+  def type(); end
+end
+
+class Bundler::DepProxy
+end
+
+class Bundler::Dependency
+  def autorequire(); end
+
+  def current_env?(); end
+
+  def current_platform?(); end
+
+  def gem_platforms(valid_platforms); end
+
+  def gemfile(); end
+
+  def initialize(name, version, options=T.unsafe(nil), &blk); end
+
+  def platforms(); end
+
+  def should_include?(); end
+  PLATFORM_MAP = ::T.let(nil, ::T.untyped)
+  REVERSE_PLATFORM_MAP = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::Dependency
 end
 
 Bundler::Deprecate = Gem::Deprecate
+
+class Bundler::DeprecatedError
+  def status_code(); end
+end
+
+class Bundler::DeprecatedError
+end
+
+class Bundler::Dsl
+  include ::Bundler::RubyDsl
+  def dependencies(); end
+
+  def dependencies=(dependencies); end
+
+  def env(name); end
+
+  def eval_gemfile(gemfile, contents=T.unsafe(nil)); end
+
+  def gem(name, *args); end
+
+  def gemspec(opts=T.unsafe(nil)); end
+
+  def gemspecs(); end
+
+  def git(uri, options=T.unsafe(nil), &blk); end
+
+  def git_source(name, &block); end
+
+  def github(repo, options=T.unsafe(nil)); end
+
+  def group(*args, &blk); end
+
+  def install_if(*args); end
+
+  def method_missing(name, *args); end
+
+  def path(path, options=T.unsafe(nil), &blk); end
+
+  def platform(*platforms); end
+
+  def platforms(*platforms); end
+
+  def plugin(*args); end
+
+  def source(source, *args, &blk); end
+
+  def to_definition(lockfile, unlock); end
+  VALID_KEYS = ::T.let(nil, ::T.untyped)
+  VALID_PLATFORMS = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::Dsl::DSLError
+  def contents(); end
+
+  def description(); end
+
+  def dsl_path(); end
+
+  def initialize(description, dsl_path, backtrace, contents=T.unsafe(nil)); end
+end
+
+class Bundler::Dsl::DSLError
+end
+
+class Bundler::Dsl
+  def self.evaluate(gemfile, lockfile, unlock); end
+end
+
+class Bundler::EndpointSpecification
+  def __swap__(spec); end
+
+  def _local_specification(); end
+
+  def checksum(); end
+
+  def dependencies=(dependencies); end
+
+  def fetch_platform(); end
+
+  def initialize(name, version, platform, dependencies, metadata=T.unsafe(nil)); end
+  ILLFORMED_MESSAGE = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::EndpointSpecification
+end
 
 class Bundler::Env
 end
@@ -85,10 +641,111 @@ class Bundler::Env
   def self.write(io); end
 end
 
+class Bundler::EnvironmentPreserver
+  def backup(); end
+
+  def initialize(env, keys); end
+
+  def restore(); end
+  BUNDLER_KEYS = ::T.let(nil, ::T.untyped)
+  BUNDLER_PREFIX = ::T.let(nil, ::T.untyped)
+  INTENTIONALLY_NIL = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::EnvironmentPreserver
+end
+
 class Bundler::FeatureFlag
+  def allow_bundler_dependency_conflicts?(); end
+
+  def allow_offline_install?(); end
+
+  def auto_clean_without_path?(); end
+
+  def auto_config_jobs?(); end
+
+  def bundler_10_mode?(); end
+
+  def bundler_1_mode?(); end
+
+  def bundler_2_mode?(); end
+
+  def bundler_3_mode?(); end
+
+  def bundler_4_mode?(); end
+
+  def bundler_5_mode?(); end
+
+  def bundler_6_mode?(); end
+
+  def bundler_7_mode?(); end
+
+  def bundler_8_mode?(); end
+
+  def bundler_9_mode?(); end
+
+  def cache_all?(); end
+
+  def cache_command_is_package?(); end
+
+  def console_command?(); end
+
+  def default_cli_command(); end
+
+  def default_install_uses_path?(); end
+
+  def deployment_means_frozen?(); end
+
+  def disable_multisource?(); end
+
+  def error_on_stderr?(); end
+
+  def forget_cli_options?(); end
+
   def github_https?(); end
 
+  def global_gem_cache?(); end
+
+  def global_path_appends_ruby_scope?(); end
+
+  def init_gems_rb?(); end
+
+  def initialize(bundler_version); end
+
+  def list_command?(); end
+
   def lockfile_upgrade_warning?(); end
+
+  def lockfile_uses_separate_rubygems_sources?(); end
+
+  def only_update_to_newer_versions?(); end
+
+  def path_relative_to_cwd?(); end
+
+  def plugins?(); end
+
+  def prefer_gems_rb?(); end
+
+  def print_only_version_number?(); end
+
+  def setup_makes_kernel_gem_public?(); end
+
+  def skip_default_git_sources?(); end
+
+  def specific_platform?(); end
+
+  def suppress_install_using_messages?(); end
+
+  def unlock_source_unlocks_spec?(); end
+
+  def update_requires_all_flag?(); end
+
+  def use_gem_version_promoter_for_major_updates?(); end
+
+  def viz_command?(); end
+end
+
+class Bundler::FeatureFlag
 end
 
 class Bundler::Fetcher
@@ -119,8 +776,14 @@ class Bundler::Fetcher::AuthenticationRequiredError
   def initialize(remote_uri); end
 end
 
+class Bundler::Fetcher::AuthenticationRequiredError
+end
+
 class Bundler::Fetcher::BadAuthenticationError
   def initialize(remote_uri); end
+end
+
+class Bundler::Fetcher::BadAuthenticationError
 end
 
 class Bundler::Fetcher::Base
@@ -146,6 +809,9 @@ end
 
 class Bundler::Fetcher::CertificateFailureError
   def initialize(remote_uri); end
+end
+
+class Bundler::Fetcher::CertificateFailureError
 end
 
 class Bundler::Fetcher::CompactIndex
@@ -210,6 +876,12 @@ end
 class Bundler::Fetcher::Downloader
 end
 
+class Bundler::Fetcher::FallbackError
+end
+
+class Bundler::Fetcher::FallbackError
+end
+
 class Bundler::Fetcher::Index
   def fetch_spec(spec); end
 
@@ -219,8 +891,17 @@ end
 class Bundler::Fetcher::Index
 end
 
+class Bundler::Fetcher::NetworkDownError
+end
+
+class Bundler::Fetcher::NetworkDownError
+end
+
 class Bundler::Fetcher::SSLError
   def initialize(msg=T.unsafe(nil)); end
+end
+
+class Bundler::Fetcher::SSLError
 end
 
 class Bundler::Fetcher
@@ -242,17 +923,235 @@ class Bundler::Fetcher
 end
 
 module Bundler::FileUtils
-  VERSION = ::T.let(nil, ::T.untyped)
+  include ::Bundler::FileUtils::StreamUtils_
+  LOW_METHODS = ::T.let(nil, ::T.untyped)
+  METHODS = ::T.let(nil, ::T.untyped)
+  OPT_TABLE = ::T.let(nil, ::T.untyped)
+end
+
+module Bundler::FileUtils::DryRun
+  include ::Bundler::FileUtils
+  include ::Bundler::FileUtils::StreamUtils_
+  include ::Bundler::FileUtils::LowMethods
+end
+
+module Bundler::FileUtils::DryRun
+  extend ::Bundler::FileUtils::DryRun
+  extend ::Bundler::FileUtils
+  extend ::Bundler::FileUtils::StreamUtils_
+  extend ::Bundler::FileUtils::LowMethods
 end
 
 class Bundler::FileUtils::Entry_
-  def link(dest); end
+  include ::Bundler::FileUtils::StreamUtils_
+  def blockdev?(); end
+
+  def chardev?(); end
+
+  def chmod(mode); end
+
+  def chown(uid, gid); end
+
+  def copy(dest); end
+
+  def copy_file(dest); end
+
+  def copy_metadata(path); end
+
+  def dereference?(); end
+
+  def directory?(); end
+
+  def door?(); end
+
+  def entries(); end
+
+  def exist?(); end
+
+  def file?(); end
+
+  def initialize(a, b=T.unsafe(nil), deref=T.unsafe(nil)); end
+
+  def lstat(); end
+
+  def lstat!(); end
+
+  def path(); end
+
+  def pipe?(); end
+
+  def platform_support(); end
+
+  def postorder_traverse(); end
+
+  def prefix(); end
+
+  def preorder_traverse(); end
+
+  def rel(); end
+
+  def remove(); end
+
+  def remove_dir1(); end
+
+  def remove_file(); end
+
+  def socket?(); end
+
+  def stat(); end
+
+  def stat!(); end
+
+  def symlink?(); end
+
+  def traverse(); end
+
+  def wrap_traverse(pre, post); end
+  DIRECTORY_TERM = ::T.let(nil, ::T.untyped)
+  SYSCASE = ::T.let(nil, ::T.untyped)
+  S_IF_DOOR = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::FileUtils::Entry_
+end
+
+module Bundler::FileUtils::LowMethods
+end
+
+module Bundler::FileUtils::LowMethods
+end
+
+module Bundler::FileUtils::NoWrite
+  include ::Bundler::FileUtils
+  include ::Bundler::FileUtils::StreamUtils_
+  include ::Bundler::FileUtils::LowMethods
+end
+
+module Bundler::FileUtils::NoWrite
+  extend ::Bundler::FileUtils::NoWrite
+  extend ::Bundler::FileUtils
+  extend ::Bundler::FileUtils::StreamUtils_
+  extend ::Bundler::FileUtils::LowMethods
+end
+
+module Bundler::FileUtils::StreamUtils_
+end
+
+module Bundler::FileUtils::StreamUtils_
+end
+
+module Bundler::FileUtils::Verbose
+  include ::Bundler::FileUtils
+  include ::Bundler::FileUtils::StreamUtils_
+end
+
+module Bundler::FileUtils::Verbose
+  extend ::Bundler::FileUtils::Verbose
+  extend ::Bundler::FileUtils
+  extend ::Bundler::FileUtils::StreamUtils_
 end
 
 module Bundler::FileUtils
-  def self.cp_lr(src, dest, noop: T.unsafe(nil), verbose: T.unsafe(nil), dereference_root: T.unsafe(nil), remove_destination: T.unsafe(nil)); end
+  extend ::Bundler::FileUtils::StreamUtils_
+  def self.cd(dir, verbose: T.unsafe(nil), &block); end
 
-  def self.link_entry(src, dest, dereference_root=T.unsafe(nil), remove_destination=T.unsafe(nil)); end
+  def self.chdir(dir, verbose: T.unsafe(nil), &block); end
+
+  def self.chmod(mode, list, noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.chmod_R(mode, list, noop: T.unsafe(nil), verbose: T.unsafe(nil), force: T.unsafe(nil)); end
+
+  def self.chown(user, group, list, noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.chown_R(user, group, list, noop: T.unsafe(nil), verbose: T.unsafe(nil), force: T.unsafe(nil)); end
+
+  def self.cmp(a, b); end
+
+  def self.collect_method(opt); end
+
+  def self.commands(); end
+
+  def self.compare_file(a, b); end
+
+  def self.compare_stream(a, b); end
+
+  def self.copy(src, dest, preserve: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.copy_entry(src, dest, preserve=T.unsafe(nil), dereference_root=T.unsafe(nil), remove_destination=T.unsafe(nil)); end
+
+  def self.copy_file(src, dest, preserve=T.unsafe(nil), dereference=T.unsafe(nil)); end
+
+  def self.copy_stream(src, dest); end
+
+  def self.cp(src, dest, preserve: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.cp_r(src, dest, preserve: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil), dereference_root: T.unsafe(nil), remove_destination: T.unsafe(nil)); end
+
+  def self.getwd(); end
+
+  def self.have_option?(mid, opt); end
+
+  def self.identical?(a, b); end
+
+  def self.install(src, dest, mode: T.unsafe(nil), owner: T.unsafe(nil), group: T.unsafe(nil), preserve: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.link(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.ln(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.ln_s(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.ln_sf(src, dest, noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.makedirs(list, mode: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.mkdir(list, mode: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.mkdir_p(list, mode: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.mkpath(list, mode: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.move(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil), secure: T.unsafe(nil)); end
+
+  def self.mv(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil), secure: T.unsafe(nil)); end
+
+  def self.options(); end
+
+  def self.options_of(mid); end
+
+  def self.private_module_function(name); end
+
+  def self.pwd(); end
+
+  def self.remove(list, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.remove_dir(path, force=T.unsafe(nil)); end
+
+  def self.remove_entry(path, force=T.unsafe(nil)); end
+
+  def self.remove_entry_secure(path, force=T.unsafe(nil)); end
+
+  def self.remove_file(path, force=T.unsafe(nil)); end
+
+  def self.rm(list, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.rm_f(list, noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.rm_r(list, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil), secure: T.unsafe(nil)); end
+
+  def self.rm_rf(list, noop: T.unsafe(nil), verbose: T.unsafe(nil), secure: T.unsafe(nil)); end
+
+  def self.rmdir(list, parents: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.rmtree(list, noop: T.unsafe(nil), verbose: T.unsafe(nil), secure: T.unsafe(nil)); end
+
+  def self.safe_unlink(list, noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.symlink(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.touch(list, noop: T.unsafe(nil), verbose: T.unsafe(nil), mtime: T.unsafe(nil), nocreate: T.unsafe(nil)); end
+
+  def self.uptodate?(new, old_list); end
 end
 
 class Bundler::GemHelper
@@ -300,9 +1199,7 @@ class Bundler::GemHelper
 
   def sh(cmd, &block); end
 
-  def sh_with_input(cmd); end
-
-  def sh_with_status(cmd, &block); end
+  def sh_with_code(cmd, &block); end
 
   def spec_path(); end
 
@@ -323,10 +1220,71 @@ class Bundler::GemHelper
   def self.instance=(instance); end
 end
 
+module Bundler::GemHelpers
+  GENERICS = ::T.let(nil, ::T.untyped)
+  GENERIC_CACHE = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::GemHelpers::PlatformMatch
+  def cpu_match(); end
+
+  def cpu_match=(_); end
+
+  def os_match(); end
+
+  def os_match=(_); end
+
+  def platform_version_match(); end
+
+  def platform_version_match=(_); end
+  EXACT_MATCH = ::T.let(nil, ::T.untyped)
+  WORST_MATCH = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::GemHelpers::PlatformMatch
+  def self.[](*_); end
+
+  def self.cpu_match(spec_platform, user_platform); end
+
+  def self.members(); end
+
+  def self.os_match(spec_platform, user_platform); end
+
+  def self.platform_version_match(spec_platform, user_platform); end
+end
+
+module Bundler::GemHelpers
+  def self.generic(p); end
+
+  def self.generic_local_platform(); end
+
+  def self.platform_specificity_match(spec_platform, user_platform); end
+
+  def self.select_best_platform_match(specs, platform); end
+end
+
+class Bundler::GemNotFound
+  def status_code(); end
+end
+
+class Bundler::GemNotFound
+end
+
 class Bundler::GemRemoteFetcher
 end
 
 class Bundler::GemRemoteFetcher
+end
+
+class Bundler::GemRequireError
+  def initialize(orig_exception, msg); end
+
+  def orig_exception(); end
+
+  def status_code(); end
+end
+
+class Bundler::GemRequireError
 end
 
 class Bundler::GemVersionPromoter
@@ -357,6 +1315,58 @@ class Bundler::GemVersionPromoter
 end
 
 class Bundler::GemVersionPromoter
+end
+
+class Bundler::GemfileError
+  def status_code(); end
+end
+
+class Bundler::GemfileError
+end
+
+class Bundler::GemfileEvalError
+end
+
+class Bundler::GemfileEvalError
+end
+
+class Bundler::GemfileLockNotFound
+  def status_code(); end
+end
+
+class Bundler::GemfileLockNotFound
+end
+
+class Bundler::GemfileNotFound
+  def status_code(); end
+end
+
+class Bundler::GemfileNotFound
+end
+
+class Bundler::GemspecError
+  def status_code(); end
+end
+
+class Bundler::GemspecError
+end
+
+class Bundler::GenericSystemCallError
+  def initialize(underlying_error, message); end
+
+  def status_code(); end
+
+  def underlying_error(); end
+end
+
+class Bundler::GenericSystemCallError
+end
+
+class Bundler::GitError
+  def status_code(); end
+end
+
+class Bundler::GitError
 end
 
 class Bundler::Graph
@@ -392,8 +1402,65 @@ end
 class Bundler::Graph
 end
 
+class Bundler::HTTPError
+  def filter_uri(uri); end
+
+  def status_code(); end
+end
+
+class Bundler::HTTPError
+end
+
 class Bundler::Index
   include ::Enumerable
+  def <<(spec); end
+
+  def ==(other); end
+
+  def [](query, base=T.unsafe(nil)); end
+
+  def add_source(index); end
+
+  def all_specs(); end
+
+  def dependencies_eql?(spec, other_spec); end
+
+  def dependency_names(); end
+
+  def each(&blk); end
+
+  def empty?(); end
+
+  def local_search(query, base=T.unsafe(nil)); end
+
+  def search(query, base=T.unsafe(nil)); end
+
+  def search_all(name); end
+
+  def size(); end
+
+  def sort_specs(specs); end
+
+  def sources(); end
+
+  def spec_names(); end
+
+  def specs(); end
+
+  def unmet_dependency_names(); end
+
+  def unsorted_search(query, base); end
+
+  def use(other, override_dupes=T.unsafe(nil)); end
+  EMPTY_SEARCH = ::T.let(nil, ::T.untyped)
+  NULL = ::T.let(nil, ::T.untyped)
+  RUBY = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::Index
+  def self.build(); end
+
+  def self.sort_specs(specs); end
 end
 
 class Bundler::Injector
@@ -409,6 +1476,20 @@ class Bundler::Injector
   def self.inject(new_deps, options=T.unsafe(nil)); end
 
   def self.remove(gems, options=T.unsafe(nil)); end
+end
+
+class Bundler::InstallError
+  def status_code(); end
+end
+
+class Bundler::InstallError
+end
+
+class Bundler::InstallHookError
+  def status_code(); end
+end
+
+class Bundler::InstallHookError
 end
 
 class Bundler::Installer
@@ -431,12 +1512,766 @@ class Bundler::Installer
   def self.install(root, definition, options=T.unsafe(nil)); end
 end
 
+class Bundler::InvalidOption
+  def status_code(); end
+end
+
+class Bundler::InvalidOption
+end
+
+class Bundler::LazySpecification
+  include ::Bundler::MatchPlatform
+  include ::Bundler::GemHelpers
+  def ==(other); end
+
+  def __materialize__(); end
+
+  def dependencies(); end
+
+  def full_name(); end
+
+  def git_version(); end
+
+  def identifier(); end
+
+  def initialize(name, version, platform, source=T.unsafe(nil)); end
+
+  def name(); end
+
+  def platform(); end
+
+  def remote(); end
+
+  def remote=(remote); end
+
+  def respond_to?(*args); end
+
+  def satisfies?(dependency); end
+
+  def source(); end
+
+  def source=(source); end
+
+  def to_lock(); end
+
+  def version(); end
+end
+
+class Bundler::LazySpecification::Identifier
+  include ::Comparable
+  def dependencies(); end
+
+  def dependencies=(_); end
+
+  def name(); end
+
+  def name=(_); end
+
+  def platform(); end
+
+  def platform=(_); end
+
+  def platform_string(); end
+
+  def source(); end
+
+  def source=(_); end
+
+  def version(); end
+
+  def version=(_); end
+end
+
+class Bundler::LazySpecification::Identifier
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class Bundler::LazySpecification
+end
+
+class Bundler::LockfileError
+  def status_code(); end
+end
+
+class Bundler::LockfileError
+end
+
+class Bundler::LockfileParser
+  def bundler_version(); end
+
+  def dependencies(); end
+
+  def initialize(lockfile); end
+
+  def platforms(); end
+
+  def ruby_version(); end
+
+  def sources(); end
+
+  def specs(); end
+
+  def warn_for_outdated_bundler_version(); end
+  BUNDLED = ::T.let(nil, ::T.untyped)
+  DEPENDENCIES = ::T.let(nil, ::T.untyped)
+  ENVIRONMENT_VERSION_SECTIONS = ::T.let(nil, ::T.untyped)
+  GEM = ::T.let(nil, ::T.untyped)
+  GIT = ::T.let(nil, ::T.untyped)
+  KNOWN_SECTIONS = ::T.let(nil, ::T.untyped)
+  NAME_VERSION = ::T.let(nil, ::T.untyped)
+  OPTIONS = ::T.let(nil, ::T.untyped)
+  PATH = ::T.let(nil, ::T.untyped)
+  PLATFORMS = ::T.let(nil, ::T.untyped)
+  PLUGIN = ::T.let(nil, ::T.untyped)
+  RUBY = ::T.let(nil, ::T.untyped)
+  SECTIONS_BY_VERSION_INTRODUCED = ::T.let(nil, ::T.untyped)
+  SOURCE = ::T.let(nil, ::T.untyped)
+  SPECS = ::T.let(nil, ::T.untyped)
+  TYPES = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::LockfileParser
+  def self.sections_in_lockfile(lockfile_contents); end
+
+  def self.sections_to_ignore(base_version=T.unsafe(nil)); end
+
+  def self.unknown_sections_in_lockfile(lockfile_contents); end
+end
+
+class Bundler::MarshalError
+end
+
+class Bundler::MarshalError
+end
+
+module Bundler::MatchPlatform
+  include ::Bundler::GemHelpers
+  def match_platform(p); end
+end
+
+module Bundler::MatchPlatform
+  def self.platforms_match?(gemspec_platform, local_platform); end
+end
+
+module Bundler::Molinillo
+  VERSION = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::Molinillo::CircularDependencyError
+  def dependencies(); end
+
+  def initialize(vertices); end
+end
+
+class Bundler::Molinillo::CircularDependencyError
+end
+
+module Bundler::Molinillo::Compatibility
+end
+
+module Bundler::Molinillo::Compatibility
+  def self.flat_map(enum, &blk); end
+end
+
+module Bundler::Molinillo::Delegates
+end
+
+module Bundler::Molinillo::Delegates::ResolutionState
+  def activated(); end
+
+  def conflicts(); end
+
+  def depth(); end
+
+  def name(); end
+
+  def possibilities(); end
+
+  def requirement(); end
+
+  def requirements(); end
+
+  def unused_unwind_options(); end
+end
+
+module Bundler::Molinillo::Delegates::ResolutionState
+end
+
+module Bundler::Molinillo::Delegates::SpecificationProvider
+  def allow_missing?(dependency); end
+
+  def dependencies_for(specification); end
+
+  def name_for(dependency); end
+
+  def name_for_explicit_dependency_source(); end
+
+  def name_for_locking_dependency_source(); end
+
+  def requirement_satisfied_by?(requirement, activated, spec); end
+
+  def search_for(dependency); end
+
+  def sort_dependencies(dependencies, activated, conflicts); end
+end
+
+module Bundler::Molinillo::Delegates::SpecificationProvider
+end
+
+module Bundler::Molinillo::Delegates
+end
+
 class Bundler::Molinillo::DependencyGraph
   include ::Enumerable
+  include ::TSort
+  def ==(other); end
+
+  def add_child_vertex(name, payload, parent_names, requirement); end
+
+  def add_edge(origin, destination, requirement); end
+
+  def add_vertex(name, payload, root=T.unsafe(nil)); end
+
+  def delete_edge(edge); end
+
+  def detach_vertex_named(name); end
+
+  def each(&blk); end
+
+  def log(); end
+
+  def rewind_to(tag); end
+
+  def root_vertex_named(name); end
+
+  def set_payload(name, payload); end
+
+  def tag(tag); end
+
+  def to_dot(options=T.unsafe(nil)); end
+
+  def tsort_each_child(vertex, &block); end
+
+  def vertex_named(name); end
+
+  def vertices(); end
+end
+
+class Bundler::Molinillo::DependencyGraph::Action
+  def down(graph); end
+
+  def next(); end
+
+  def next=(_); end
+
+  def previous(); end
+
+  def previous=(previous); end
+
+  def up(graph); end
+end
+
+class Bundler::Molinillo::DependencyGraph::Action
+  def self.action_name(); end
+end
+
+class Bundler::Molinillo::DependencyGraph::AddEdgeNoCircular
+  def destination(); end
+
+  def initialize(origin, destination, requirement); end
+
+  def make_edge(graph); end
+
+  def origin(); end
+
+  def requirement(); end
+end
+
+class Bundler::Molinillo::DependencyGraph::AddEdgeNoCircular
+end
+
+class Bundler::Molinillo::DependencyGraph::AddVertex
+  def initialize(name, payload, root); end
+
+  def name(); end
+
+  def payload(); end
+
+  def root(); end
+end
+
+class Bundler::Molinillo::DependencyGraph::AddVertex
+end
+
+class Bundler::Molinillo::DependencyGraph::DeleteEdge
+  def destination_name(); end
+
+  def initialize(origin_name, destination_name, requirement); end
+
+  def make_edge(graph); end
+
+  def origin_name(); end
+
+  def requirement(); end
+end
+
+class Bundler::Molinillo::DependencyGraph::DeleteEdge
+end
+
+class Bundler::Molinillo::DependencyGraph::DetachVertexNamed
+  def initialize(name); end
+
+  def name(); end
+end
+
+class Bundler::Molinillo::DependencyGraph::DetachVertexNamed
+end
+
+class Bundler::Molinillo::DependencyGraph::Edge
+  def destination(); end
+
+  def destination=(_); end
+
+  def origin(); end
+
+  def origin=(_); end
+
+  def requirement(); end
+
+  def requirement=(_); end
+end
+
+class Bundler::Molinillo::DependencyGraph::Edge
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class Bundler::Molinillo::DependencyGraph::Log
+  def add_edge_no_circular(graph, origin, destination, requirement); end
+
+  def add_vertex(graph, name, payload, root); end
+
+  def delete_edge(graph, origin_name, destination_name, requirement); end
+
+  def detach_vertex_named(graph, name); end
+
+  def each(&blk); end
+
+  def pop!(graph); end
+
+  def reverse_each(); end
+
+  def rewind_to(graph, tag); end
+
+  def set_payload(graph, name, payload); end
+
+  def tag(graph, tag); end
 end
 
 class Bundler::Molinillo::DependencyGraph::Log
   extend ::Enumerable
+end
+
+class Bundler::Molinillo::DependencyGraph::SetPayload
+  def initialize(name, payload); end
+
+  def name(); end
+
+  def payload(); end
+end
+
+class Bundler::Molinillo::DependencyGraph::SetPayload
+end
+
+class Bundler::Molinillo::DependencyGraph::Tag
+  def down(_graph); end
+
+  def initialize(tag); end
+
+  def tag(); end
+
+  def up(_graph); end
+end
+
+class Bundler::Molinillo::DependencyGraph::Tag
+end
+
+class Bundler::Molinillo::DependencyGraph::Vertex
+  def ==(other); end
+
+  def _path_to?(other, visited=T.unsafe(nil)); end
+
+  def ancestor?(other); end
+
+  def descendent?(other); end
+
+  def eql?(other); end
+
+  def explicit_requirements(); end
+
+  def incoming_edges(); end
+
+  def incoming_edges=(incoming_edges); end
+
+  def initialize(name, payload); end
+
+  def is_reachable_from?(other); end
+
+  def name(); end
+
+  def name=(name); end
+
+  def outgoing_edges(); end
+
+  def outgoing_edges=(outgoing_edges); end
+
+  def path_to?(other); end
+
+  def payload(); end
+
+  def payload=(payload); end
+
+  def predecessors(); end
+
+  def recursive_predecessors(); end
+
+  def recursive_successors(); end
+
+  def requirements(); end
+
+  def root(); end
+
+  def root=(root); end
+
+  def root?(); end
+
+  def shallow_eql?(other); end
+
+  def successors(); end
+end
+
+class Bundler::Molinillo::DependencyGraph::Vertex
+end
+
+class Bundler::Molinillo::DependencyGraph
+  def self.tsort(vertices); end
+end
+
+class Bundler::Molinillo::DependencyState
+  def pop_possibility_state(); end
+end
+
+class Bundler::Molinillo::DependencyState
+end
+
+class Bundler::Molinillo::NoSuchDependencyError
+  def dependency(); end
+
+  def dependency=(dependency); end
+
+  def initialize(dependency, required_by=T.unsafe(nil)); end
+
+  def required_by(); end
+
+  def required_by=(required_by); end
+end
+
+class Bundler::Molinillo::NoSuchDependencyError
+end
+
+class Bundler::Molinillo::PossibilityState
+end
+
+class Bundler::Molinillo::PossibilityState
+end
+
+class Bundler::Molinillo::ResolutionState
+  def activated(); end
+
+  def activated=(_); end
+
+  def conflicts(); end
+
+  def conflicts=(_); end
+
+  def depth(); end
+
+  def depth=(_); end
+
+  def name(); end
+
+  def name=(_); end
+
+  def possibilities(); end
+
+  def possibilities=(_); end
+
+  def requirement(); end
+
+  def requirement=(_); end
+
+  def requirements(); end
+
+  def requirements=(_); end
+
+  def unused_unwind_options(); end
+
+  def unused_unwind_options=(_); end
+end
+
+class Bundler::Molinillo::ResolutionState
+  def self.[](*_); end
+
+  def self.empty(); end
+
+  def self.members(); end
+end
+
+class Bundler::Molinillo::Resolver
+  def initialize(specification_provider, resolver_ui); end
+
+  def resolve(requested, base=T.unsafe(nil)); end
+
+  def resolver_ui(); end
+
+  def specification_provider(); end
+end
+
+class Bundler::Molinillo::Resolver::Resolution
+  include ::Bundler::Molinillo::Delegates::ResolutionState
+  include ::Bundler::Molinillo::Delegates::SpecificationProvider
+  def base(); end
+
+  def initialize(specification_provider, resolver_ui, requested, base); end
+
+  def iteration_rate=(iteration_rate); end
+
+  def original_requested(); end
+
+  def resolve(); end
+
+  def resolver_ui(); end
+
+  def specification_provider(); end
+
+  def started_at=(started_at); end
+
+  def states=(states); end
+end
+
+class Bundler::Molinillo::Resolver::Resolution::Conflict
+  def activated_by_name(); end
+
+  def activated_by_name=(_); end
+
+  def existing(); end
+
+  def existing=(_); end
+
+  def locked_requirement(); end
+
+  def locked_requirement=(_); end
+
+  def possibility(); end
+
+  def possibility_set(); end
+
+  def possibility_set=(_); end
+
+  def requirement(); end
+
+  def requirement=(_); end
+
+  def requirement_trees(); end
+
+  def requirement_trees=(_); end
+
+  def requirements(); end
+
+  def requirements=(_); end
+
+  def underlying_error(); end
+
+  def underlying_error=(_); end
+end
+
+class Bundler::Molinillo::Resolver::Resolution::Conflict
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class Bundler::Molinillo::Resolver::Resolution::PossibilitySet
+  def dependencies(); end
+
+  def dependencies=(_); end
+
+  def latest_version(); end
+
+  def possibilities(); end
+
+  def possibilities=(_); end
+end
+
+class Bundler::Molinillo::Resolver::Resolution::PossibilitySet
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class Bundler::Molinillo::Resolver::Resolution::UnwindDetails
+  include ::Comparable
+  def all_requirements(); end
+
+  def conflicting_requirements(); end
+
+  def conflicting_requirements=(_); end
+
+  def requirement_tree(); end
+
+  def requirement_tree=(_); end
+
+  def requirement_trees(); end
+
+  def requirement_trees=(_); end
+
+  def requirements_unwound_to_instead(); end
+
+  def requirements_unwound_to_instead=(_); end
+
+  def reversed_requirement_tree_index(); end
+
+  def state_index(); end
+
+  def state_index=(_); end
+
+  def state_requirement(); end
+
+  def state_requirement=(_); end
+
+  def sub_dependencies_to_avoid(); end
+
+  def unwinding_to_primary_requirement?(); end
+end
+
+class Bundler::Molinillo::Resolver::Resolution::UnwindDetails
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class Bundler::Molinillo::Resolver::Resolution
+end
+
+class Bundler::Molinillo::Resolver
+end
+
+class Bundler::Molinillo::ResolverError
+end
+
+class Bundler::Molinillo::ResolverError
+end
+
+module Bundler::Molinillo::SpecificationProvider
+  def allow_missing?(dependency); end
+
+  def dependencies_for(specification); end
+
+  def name_for(dependency); end
+
+  def name_for_explicit_dependency_source(); end
+
+  def name_for_locking_dependency_source(); end
+
+  def requirement_satisfied_by?(requirement, activated, spec); end
+
+  def search_for(dependency); end
+
+  def sort_dependencies(dependencies, activated, conflicts); end
+end
+
+module Bundler::Molinillo::SpecificationProvider
+end
+
+module Bundler::Molinillo::UI
+  def after_resolution(); end
+
+  def before_resolution(); end
+
+  def debug(depth=T.unsafe(nil)); end
+
+  def debug?(); end
+
+  def indicate_progress(); end
+
+  def output(); end
+
+  def progress_rate(); end
+end
+
+module Bundler::Molinillo::UI
+end
+
+class Bundler::Molinillo::VersionConflict
+  include ::Bundler::Molinillo::Delegates::SpecificationProvider
+  def conflicts(); end
+
+  def initialize(conflicts, specification_provider); end
+
+  def message_with_trees(opts=T.unsafe(nil)); end
+
+  def specification_provider(); end
+end
+
+class Bundler::Molinillo::VersionConflict
+end
+
+module Bundler::Molinillo
+end
+
+class Bundler::NoSpaceOnDeviceError
+end
+
+class Bundler::NoSpaceOnDeviceError
+end
+
+class Bundler::OperationNotSupportedError
+end
+
+class Bundler::OperationNotSupportedError
+end
+
+class Bundler::PathError
+  def status_code(); end
+end
+
+class Bundler::PathError
+end
+
+class Bundler::PermissionError
+  def action(); end
+
+  def initialize(path, permission_type=T.unsafe(nil)); end
+
+  def status_code(); end
+end
+
+class Bundler::PermissionError
+end
+
+module Bundler::Plugin
+  PLUGIN_FILE_NAME = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::Plugin::API
+  def cache_dir(); end
+
+  def method_missing(name, *args, &blk); end
+
+  def tmp(*names); end
 end
 
 module Bundler::Plugin::API::Source
@@ -508,11 +2343,66 @@ end
 module Bundler::Plugin::API::Source
 end
 
+class Bundler::Plugin::API
+  def self.command(command, cls=T.unsafe(nil)); end
+
+  def self.hook(event, &block); end
+
+  def self.source(source, cls=T.unsafe(nil)); end
+end
+
+class Bundler::Plugin::DSL
+  def _gem(name, *args); end
+
+  def inferred_plugins(); end
+
+  def plugin(name, *args); end
+end
+
+class Bundler::Plugin::DSL::PluginGemfileError
+end
+
+class Bundler::Plugin::DSL::PluginGemfileError
+end
+
+class Bundler::Plugin::DSL
+end
+
 module Bundler::Plugin::Events
   GEM_AFTER_INSTALL = ::T.let(nil, ::T.untyped)
   GEM_AFTER_INSTALL_ALL = ::T.let(nil, ::T.untyped)
   GEM_BEFORE_INSTALL = ::T.let(nil, ::T.untyped)
   GEM_BEFORE_INSTALL_ALL = ::T.let(nil, ::T.untyped)
+end
+
+module Bundler::Plugin::Events
+  def self.defined_event?(event); end
+end
+
+class Bundler::Plugin::Index
+  def command_plugin(command); end
+
+  def commands(); end
+
+  def global_index_file(); end
+
+  def hook_plugins(event); end
+
+  def index_file(); end
+
+  def installed?(name); end
+
+  def load_paths(name); end
+
+  def local_index_file(); end
+
+  def plugin_path(name); end
+
+  def register_plugin(name, path, load_paths, commands, sources, hooks); end
+
+  def source?(source); end
+
+  def source_plugin(name); end
 end
 
 class Bundler::Plugin::Index::CommandConflict
@@ -527,6 +2417,9 @@ class Bundler::Plugin::Index::SourceConflict
 end
 
 class Bundler::Plugin::Index::SourceConflict
+end
+
+class Bundler::Plugin::Index
 end
 
 class Bundler::Plugin::Installer
@@ -551,10 +2444,73 @@ end
 class Bundler::Plugin::Installer
 end
 
+class Bundler::Plugin::MalformattedPlugin
+end
+
+class Bundler::Plugin::MalformattedPlugin
+end
+
 class Bundler::Plugin::SourceList
 end
 
 class Bundler::Plugin::SourceList
+end
+
+class Bundler::Plugin::UndefinedCommandError
+end
+
+class Bundler::Plugin::UndefinedCommandError
+end
+
+class Bundler::Plugin::UnknownSourceError
+end
+
+class Bundler::Plugin::UnknownSourceError
+end
+
+module Bundler::Plugin
+  def self.add_command(command, cls); end
+
+  def self.add_hook(event, &block); end
+
+  def self.add_source(source, cls); end
+
+  def self.cache(); end
+
+  def self.command?(command); end
+
+  def self.exec_command(command, args); end
+
+  def self.gemfile_install(gemfile=T.unsafe(nil), &inline); end
+
+  def self.global_root(); end
+
+  def self.hook(event, *args, &arg_blk); end
+
+  def self.index(); end
+
+  def self.install(names, options); end
+
+  def self.installed?(plugin); end
+
+  def self.local_root(); end
+
+  def self.reset!(); end
+
+  def self.root(); end
+
+  def self.source(name); end
+
+  def self.source?(name); end
+
+  def self.source_from_lock(locked_opts); end
+end
+
+class Bundler::PluginError
+  def status_code(); end
+end
+
+class Bundler::PluginError
 end
 
 class Bundler::ProcessLock
@@ -562,6 +2518,109 @@ end
 
 class Bundler::ProcessLock
   def self.lock(bundle_path=T.unsafe(nil)); end
+end
+
+class Bundler::ProductionError
+  def status_code(); end
+end
+
+class Bundler::ProductionError
+end
+
+class Bundler::RemoteSpecification
+  include ::Bundler::MatchPlatform
+  include ::Bundler::GemHelpers
+  include ::Comparable
+  def __swap__(spec); end
+
+  def dependencies(); end
+
+  def dependencies=(dependencies); end
+
+  def fetch_platform(); end
+
+  def full_name(); end
+
+  def git_version(); end
+
+  def initialize(name, version, platform, spec_fetcher); end
+
+  def name(); end
+
+  def platform(); end
+
+  def remote(); end
+
+  def remote=(remote); end
+
+  def respond_to?(method, include_all=T.unsafe(nil)); end
+
+  def sort_obj(); end
+
+  def source(); end
+
+  def source=(source); end
+
+  def version(); end
+end
+
+class Bundler::RemoteSpecification
+end
+
+class Bundler::Resolver
+  include ::Bundler::Molinillo::UI
+  include ::Bundler::Molinillo::SpecificationProvider
+  def index_for(dependency); end
+
+  def initialize(index, source_requirements, base, gem_version_promoter, additional_base_requirements, platforms); end
+
+  def relevant_sources_for_vertex(vertex); end
+
+  def start(requirements); end
+end
+
+class Bundler::Resolver::SpecGroup
+  include ::Bundler::GemHelpers
+  def ==(other); end
+
+  def activate_platform!(platform); end
+
+  def dependencies_for_activated_platforms(); end
+
+  def eql?(other); end
+
+  def for?(platform); end
+
+  def ignores_bundler_dependencies(); end
+
+  def ignores_bundler_dependencies=(ignores_bundler_dependencies); end
+
+  def initialize(all_specs); end
+
+  def name(); end
+
+  def name=(name); end
+
+  def source(); end
+
+  def source=(source); end
+
+  def to_specs(); end
+
+  def version(); end
+
+  def version=(version); end
+end
+
+class Bundler::Resolver::SpecGroup
+end
+
+class Bundler::Resolver
+  def self.platform_sort_key(platform); end
+
+  def self.resolve(requirements, index, source_requirements=T.unsafe(nil), base=T.unsafe(nil), gem_version_promoter=T.unsafe(nil), additional_base_requirements=T.unsafe(nil), platforms=T.unsafe(nil)); end
+
+  def self.sort_platforms(platforms); end
 end
 
 class Bundler::Retry
@@ -592,14 +2651,373 @@ class Bundler::Retry
   def self.default_retries(); end
 end
 
+module Bundler::RubyDsl
+  def ruby(*ruby_version); end
+end
+
+module Bundler::RubyDsl
+end
+
 class Bundler::RubyGemsGemInstaller
 end
 
 class Bundler::RubyGemsGemInstaller
+end
+
+class Bundler::RubyVersion
+  def ==(other); end
+
+  def diff(other); end
+
+  def engine(); end
+
+  def engine_gem_version(); end
+
+  def engine_versions(); end
+
+  def exact?(); end
+
+  def gem_version(); end
+
+  def host(); end
+
+  def initialize(versions, patchlevel, engine, engine_version); end
+
+  def patchlevel(); end
+
+  def single_version_string(); end
+
+  def to_gem_version_with_patchlevel(); end
+
+  def to_s(versions=T.unsafe(nil)); end
+
+  def versions(); end
+
+  def versions_string(versions); end
+  PATTERN = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::RubyVersion
+  def self.from_string(string); end
+
+  def self.system(); end
+end
+
+class Bundler::RubyVersionMismatch
+  def status_code(); end
+end
+
+class Bundler::RubyVersionMismatch
+end
+
+class Bundler::RubygemsIntegration
+  def backport_base_dir(); end
+
+  def backport_cache_file(); end
+
+  def backport_segment_generation(); end
+
+  def backport_spec_file(); end
+
+  def backport_yaml_initialize(); end
+
+  def bin_path(gem, bin, ver); end
+
+  def binstubs_call_gem?(); end
+
+  def build(spec, skip_validation=T.unsafe(nil)); end
+
+  def build_args(); end
+
+  def build_args=(args); end
+
+  def build_gem(gem_dir, spec); end
+
+  def clear_paths(); end
+
+  def config_map(); end
+
+  def configuration(); end
+
+  def download_gem(spec, uri, path); end
+
+  def ext_lock(); end
+
+  def fetch_all_remote_specs(remote); end
+
+  def fetch_prerelease_specs(); end
+
+  def fetch_specs(all, pre, &blk); end
+
+  def gem_bindir(); end
+
+  def gem_cache(); end
+
+  def gem_dir(); end
+
+  def gem_from_path(path, policy=T.unsafe(nil)); end
+
+  def gem_path(); end
+
+  def inflate(obj); end
+
+  def install_with_build_args(args); end
+
+  def load_path_insert_index(); end
+
+  def load_plugin_files(files); end
+
+  def load_plugins(); end
+
+  def loaded_gem_paths(); end
+
+  def loaded_specs(name); end
+
+  def mark_loaded(spec); end
+
+  def marshal_spec_dir(); end
+
+  def method_visibility(klass, method); end
+
+  def path(obj); end
+
+  def path_separator(); end
+
+  def platforms(); end
+
+  def post_reset_hooks(); end
+
+  def preserve_paths(); end
+
+  def provides?(req_str); end
+
+  def read_binary(path); end
+
+  def redefine_method(klass, method, unbound_method=T.unsafe(nil), &block); end
+
+  def replace_bin_path(specs, specs_by_name); end
+
+  def replace_entrypoints(specs); end
+
+  def replace_gem(specs, specs_by_name); end
+
+  def replace_refresh(); end
+
+  def repository_subdirectories(); end
+
+  def reset(); end
+
+  def reverse_rubygems_kernel_mixin(); end
+
+  def ruby_engine(); end
+
+  def security_policies(); end
+
+  def security_policy_keys(); end
+
+  def set_installed_by_version(spec, installed_by_version=T.unsafe(nil)); end
+
+  def sources(); end
+
+  def sources=(val); end
+
+  def spec_cache_dirs(); end
+
+  def spec_default_gem?(spec); end
+
+  def spec_extension_dir(spec); end
+
+  def spec_from_gem(path, policy=T.unsafe(nil)); end
+
+  def spec_matches_for_glob(spec, glob); end
+
+  def spec_missing_extensions?(spec, default=T.unsafe(nil)); end
+
+  def stub_set_spec(stub, spec); end
+
+  def stub_source_index(specs); end
+
+  def stubs_provide_full_functionality?(); end
+
+  def suffix_pattern(); end
+
+  def ui=(obj); end
+
+  def undo_replacements(); end
+
+  def user_home(); end
+
+  def validate(spec); end
+
+  def version(); end
+
+  def with_build_args(args); end
+  EXT_LOCK = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::RubygemsIntegration::AlmostModern
+end
+
+class Bundler::RubygemsIntegration::AlmostModern
+end
+
+class Bundler::RubygemsIntegration::Ancient
+end
+
+class Bundler::RubygemsIntegration::Ancient
+end
+
+class Bundler::RubygemsIntegration::Future
+  def all_specs(); end
+
+  def fetch_specs(source, remote, name); end
+
+  def find_name(name); end
+
+  def gem_remote_fetcher(); end
+
+  def stub_rubygems(specs); end
+end
+
+class Bundler::RubygemsIntegration::Future
+end
+
+class Bundler::RubygemsIntegration::Legacy
+  def all_specs(); end
+
+  def find_name(name); end
+
+  def stub_rubygems(specs); end
+end
+
+class Bundler::RubygemsIntegration::Legacy
+end
+
+class Bundler::RubygemsIntegration::Modern
+  def all_specs(); end
+
+  def find_name(name); end
+
+  def stub_rubygems(specs); end
+end
+
+class Bundler::RubygemsIntegration::Modern
 end
 
 class Bundler::RubygemsIntegration::MoreFuture
-  def default_stubs(); end
+  def backport_ext_builder_monitor(); end
+
+  def use_gemdeps(gemfile); end
+end
+
+class Bundler::RubygemsIntegration::MoreFuture
+end
+
+class Bundler::RubygemsIntegration::MoreModern
+end
+
+class Bundler::RubygemsIntegration::MoreModern
+end
+
+class Bundler::RubygemsIntegration::Transitional
+end
+
+class Bundler::RubygemsIntegration::Transitional
+end
+
+class Bundler::RubygemsIntegration
+  def self.provides?(req_str); end
+
+  def self.version(); end
+end
+
+class Bundler::Runtime
+  include ::Bundler::SharedHelpers
+  def cache(custom_path=T.unsafe(nil)); end
+
+  def clean(dry_run=T.unsafe(nil)); end
+
+  def current_dependencies(); end
+
+  def dependencies(); end
+
+  def gems(); end
+
+  def initialize(root, definition); end
+
+  def lock(opts=T.unsafe(nil)); end
+
+  def prune_cache(cache_path); end
+
+  def requested_specs(); end
+
+  def require(*groups); end
+
+  def requires(); end
+
+  def setup(*groups); end
+
+  def specs(); end
+  REQUIRE_ERRORS = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::Runtime
+end
+
+class Bundler::SecurityError
+  def status_code(); end
+end
+
+class Bundler::SecurityError
+end
+
+class Bundler::Settings
+  def [](name); end
+
+  def all(); end
+
+  def allow_sudo?(); end
+
+  def app_cache_path(); end
+
+  def credentials_for(uri); end
+
+  def gem_mirrors(); end
+
+  def ignore_config?(); end
+
+  def initialize(root=T.unsafe(nil)); end
+
+  def key_for(key); end
+
+  def local_overrides(); end
+
+  def locations(key); end
+
+  def mirror_for(uri); end
+
+  def path(); end
+
+  def pretty_values_for(exposed_key); end
+
+  def set_command_option(key, value); end
+
+  def set_command_option_if_given(key, value); end
+
+  def set_global(key, value); end
+
+  def set_local(key, value); end
+
+  def temporary(update); end
+
+  def validate!(); end
+  ARRAY_KEYS = ::T.let(nil, ::T.untyped)
+  BOOL_KEYS = ::T.let(nil, ::T.untyped)
+  CONFIG_REGEX = ::T.let(nil, ::T.untyped)
+  DEFAULT_CONFIG = ::T.let(nil, ::T.untyped)
+  NORMALIZE_URI_OPTIONS_PATTERN = ::T.let(nil, ::T.untyped)
+  NUMBER_KEYS = ::T.let(nil, ::T.untyped)
+  PER_URI_OPTIONS = ::T.let(nil, ::T.untyped)
 end
 
 class Bundler::Settings::Mirror
@@ -637,6 +3055,40 @@ end
 class Bundler::Settings::Mirrors
 end
 
+class Bundler::Settings::Path
+  def append_ruby_scope(); end
+
+  def append_ruby_scope=(_); end
+
+  def base_path(); end
+
+  def base_path_relative_to_pwd(); end
+
+  def default_install_uses_path(); end
+
+  def default_install_uses_path=(_); end
+
+  def explicit_path(); end
+
+  def explicit_path=(_); end
+
+  def path(); end
+
+  def system_path(); end
+
+  def system_path=(_); end
+
+  def use_system_gems?(); end
+
+  def validate!(); end
+end
+
+class Bundler::Settings::Path
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
 class Bundler::Settings::Validator
 end
 
@@ -661,8 +3113,431 @@ class Bundler::Settings::Validator
   def self.validate!(key, value, settings); end
 end
 
+class Bundler::Settings
+  def self.normalize_uri(uri); end
+end
+
+module Bundler::SharedHelpers
+  def chdir(dir, &blk); end
+
+  def const_get_safely(constant_name, namespace); end
+
+  def default_bundle_dir(); end
+
+  def default_gemfile(); end
+
+  def default_lockfile(); end
+
+  def digest(name); end
+
+  def ensure_same_dependencies(spec, old_deps, new_deps); end
+
+  def filesystem_access(path, action=T.unsafe(nil), &block); end
+
+  def in_bundle?(); end
+
+  def major_deprecation(major_version, message); end
+
+  def md5_available?(); end
+
+  def pretty_dependency(dep, print_source=T.unsafe(nil)); end
+
+  def print_major_deprecations!(); end
+
+  def pwd(); end
+
+  def root(); end
+
+  def set_bundle_environment(); end
+
+  def set_env(key, value); end
+
+  def trap(signal, override=T.unsafe(nil), &block); end
+
+  def with_clean_git_env(&block); end
+
+  def write_to_gemfile(gemfile_path, contents); end
+end
+
+module Bundler::SharedHelpers
+  extend ::Bundler::SharedHelpers
+end
+
+class Bundler::Source
+  def can_lock?(spec); end
+
+  def dependency_names(); end
+
+  def dependency_names=(dependency_names); end
+
+  def dependency_names_to_double_check(); end
+
+  def double_check_for(*_); end
+
+  def extension_cache_path(spec); end
+
+  def include?(other); end
+
+  def path?(); end
+
+  def unmet_deps(); end
+
+  def version_message(spec); end
+end
+
+class Bundler::Source::Gemspec
+  def as_path_source(); end
+
+  def gemspec(); end
+end
+
+class Bundler::Source::Gemspec
+end
+
+class Bundler::Source::Git
+  def allow_git_ops?(); end
+
+  def branch(); end
+
+  def cache_path(); end
+
+  def extension_dir_name(); end
+
+  def install_path(); end
+
+  def local_override!(path); end
+
+  def ref(); end
+
+  def revision(); end
+
+  def specs(*_); end
+
+  def submodules(); end
+
+  def unlock!(); end
+
+  def uri(); end
+end
+
+class Bundler::Source::Git
+end
+
+class Bundler::Source::Metadata
+  def ==(other); end
+
+  def cached!(); end
+
+  def eql?(other); end
+
+  def install(spec, _opts=T.unsafe(nil)); end
+
+  def options(); end
+
+  def remote!(); end
+
+  def specs(); end
+end
+
+class Bundler::Source::Metadata
+end
+
+class Bundler::Source::Path
+  def ==(other); end
+
+  def app_cache_dirname(); end
+
+  def cache(spec, custom_path=T.unsafe(nil)); end
+
+  def cached!(); end
+
+  def eql?(other); end
+
+  def expanded_original_path(); end
+
+  def initialize(options); end
+
+  def install(spec, options=T.unsafe(nil)); end
+
+  def local_specs(*_); end
+
+  def name(); end
+
+  def name=(name); end
+
+  def options(); end
+
+  def original_path(); end
+
+  def path(); end
+
+  def remote!(); end
+
+  def root(); end
+
+  def root_path(); end
+
+  def specs(); end
+
+  def to_lock(); end
+
+  def version(); end
+
+  def version=(version); end
+  DEFAULT_GLOB = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::Source::Path
+  def self.from_lock(options); end
+end
+
+class Bundler::Source::Rubygems
+  def ==(other); end
+
+  def add_remote(source); end
+
+  def api_fetchers(); end
+
+  def builtin_gem?(spec); end
+
+  def cache(spec, custom_path=T.unsafe(nil)); end
+
+  def cache_path(); end
+
+  def cached!(); end
+
+  def cached_built_in_gem(spec); end
+
+  def cached_gem(spec); end
+
+  def cached_path(spec); end
+
+  def cached_specs(); end
+
+  def caches(); end
+
+  def credless_remotes(); end
+
+  def double_check_for(unmet_dependency_names); end
+
+  def eql?(other); end
+
+  def equivalent_remotes?(other_remotes); end
+
+  def fetch_gem(spec); end
+
+  def fetch_names(fetchers, dependency_names, index, override_dupes); end
+
+  def fetchers(); end
+
+  def include?(o); end
+
+  def initialize(options=T.unsafe(nil)); end
+
+  def install(spec, opts=T.unsafe(nil)); end
+
+  def installed?(spec); end
+
+  def installed_specs(); end
+
+  def loaded_from(spec); end
+
+  def name(); end
+
+  def normalize_uri(uri); end
+
+  def options(); end
+
+  def remote!(); end
+
+  def remote_specs(); end
+
+  def remotes(); end
+
+  def remotes_for_spec(spec); end
+
+  def remove_auth(remote); end
+
+  def replace_remotes(other_remotes, allow_equivalent=T.unsafe(nil)); end
+
+  def requires_sudo?(); end
+
+  def rubygems_dir(); end
+
+  def specs(); end
+
+  def suppress_configured_credentials(remote); end
+
+  def to_lock(); end
+  API_REQUEST_LIMIT = ::T.let(nil, ::T.untyped)
+  API_REQUEST_SIZE = ::T.let(nil, ::T.untyped)
+end
+
+class Bundler::Source::Rubygems
+  def self.from_lock(options); end
+end
+
+class Bundler::Source
+end
+
+class Bundler::SourceList
+  def add_git_source(options=T.unsafe(nil)); end
+
+  def add_path_source(options=T.unsafe(nil)); end
+
+  def add_plugin_source(source, options=T.unsafe(nil)); end
+
+  def add_rubygems_remote(uri); end
+
+  def add_rubygems_source(options=T.unsafe(nil)); end
+
+  def all_sources(); end
+
+  def cached!(); end
+
+  def default_source(); end
+
+  def get(source); end
+
+  def git_sources(); end
+
+  def global_rubygems_source(); end
+
+  def global_rubygems_source=(uri); end
+
+  def lock_sources(); end
+
+  def metadata_source(); end
+
+  def path_sources(); end
+
+  def plugin_sources(); end
+
+  def remote!(); end
+
+  def replace_sources!(replacement_sources); end
+
+  def rubygems_primary_remotes(); end
+
+  def rubygems_remotes(); end
+
+  def rubygems_sources(); end
+end
+
+class Bundler::SourceList
+end
+
 class Bundler::SpecSet
   include ::Enumerable
+  include ::TSort
+  def <<(spec); end
+
+  def [](key); end
+
+  def []=(key, value); end
+
+  def each(&b); end
+
+  def empty?(); end
+
+  def find_by_name_and_platform(name, platform); end
+
+  def for(dependencies, skip=T.unsafe(nil), check=T.unsafe(nil), match_current_platform=T.unsafe(nil), raise_on_missing=T.unsafe(nil)); end
+
+  def initialize(specs); end
+
+  def length(); end
+
+  def materialize(deps, missing_specs=T.unsafe(nil)); end
+
+  def materialized_for_all_platforms(); end
+
+  def merge(set); end
+
+  def size(); end
+
+  def sort!(); end
+
+  def to_a(); end
+
+  def to_hash(); end
+
+  def valid_for?(deps); end
+
+  def what_required(spec); end
+end
+
+class Bundler::SpecSet
+end
+
+class Bundler::StubSpecification
+  def activated(); end
+
+  def activated=(activated); end
+
+  def default_gem(); end
+
+  def full_gem_path(); end
+
+  def full_require_paths(); end
+
+  def ignored(); end
+
+  def ignored=(ignored); end
+
+  def load_paths(); end
+
+  def loaded_from(); end
+
+  def matches_for_glob(glob); end
+
+  def missing_extensions?(); end
+
+  def raw_require_paths(); end
+
+  def source=(source); end
+
+  def stub(); end
+
+  def stub=(stub); end
+
+  def to_yaml(); end
+end
+
+class Bundler::StubSpecification
+  def self.from_stub(stub); end
+end
+
+class Bundler::SudoNotPermittedError
+  def status_code(); end
+end
+
+class Bundler::SudoNotPermittedError
+end
+
+class Bundler::TemporaryResourceError
+end
+
+class Bundler::TemporaryResourceError
+end
+
+class Bundler::ThreadCreationError
+  def status_code(); end
+end
+
+class Bundler::ThreadCreationError
+end
+
+module Bundler::UI
+end
+
+class Bundler::UI::RGProxy
+  def initialize(ui); end
+
+  def say(message); end
+end
+
+class Bundler::UI::RGProxy
 end
 
 class Bundler::UI::Shell
@@ -705,6 +3580,68 @@ class Bundler::UI::Shell
 end
 
 class Bundler::UI::Shell
+end
+
+class Bundler::UI::Silent
+  def add_color(string, color); end
+
+  def ask(message); end
+
+  def confirm(message, newline=T.unsafe(nil)); end
+
+  def debug(message, newline=T.unsafe(nil)); end
+
+  def debug?(); end
+
+  def error(message, newline=T.unsafe(nil)); end
+
+  def info(message, newline=T.unsafe(nil)); end
+
+  def level(name=T.unsafe(nil)); end
+
+  def level=(name); end
+
+  def no?(); end
+
+  def quiet?(); end
+
+  def shell=(shell); end
+
+  def silence(); end
+
+  def trace(message, newline=T.unsafe(nil), force=T.unsafe(nil)); end
+
+  def unprinted_warnings(); end
+
+  def warn(message, newline=T.unsafe(nil)); end
+
+  def yes?(msg); end
+end
+
+class Bundler::UI::Silent
+end
+
+module Bundler::UI
+end
+
+module Bundler::URICredentialsFilter
+end
+
+module Bundler::URICredentialsFilter
+  def self.credential_filtered_string(str_to_filter, uri); end
+
+  def self.credential_filtered_uri(uri_to_anonymize); end
+end
+
+class Bundler::VersionConflict
+  def conflicts(); end
+
+  def initialize(conflicts, msg=T.unsafe(nil)); end
+
+  def status_code(); end
+end
+
+class Bundler::VersionConflict
 end
 
 module Bundler::VersionRanges
@@ -771,6 +3708,149 @@ module Bundler::VersionRanges
   def self.for_many(requirements); end
 end
 
+class Bundler::VirtualProtocolError
+  def status_code(); end
+end
+
+class Bundler::VirtualProtocolError
+end
+
+module Bundler::YAMLSerializer
+  ARRAY_REGEX = ::T.let(nil, ::T.untyped)
+  HASH_REGEX = ::T.let(nil, ::T.untyped)
+end
+
+module Bundler::YAMLSerializer
+  def self.dump(hash); end
+
+  def self.load(str); end
+end
+
+class Bundler::YamlSyntaxError
+  def initialize(orig_exception, msg); end
+
+  def orig_exception(); end
+
+  def status_code(); end
+end
+
+class Bundler::YamlSyntaxError
+end
+
+module Bundler
+  def self.app_cache(custom_path=T.unsafe(nil)); end
+
+  def self.app_config_path(); end
+
+  def self.bin_path(); end
+
+  def self.bundle_path(); end
+
+  def self.bundler_major_version(); end
+
+  def self.clean_env(); end
+
+  def self.clean_exec(*args); end
+
+  def self.clean_system(*args); end
+
+  def self.clear_gemspec_cache(); end
+
+  def self.configure(); end
+
+  def self.configured_bundle_path(); end
+
+  def self.current_ruby(); end
+
+  def self.default_bundle_dir(); end
+
+  def self.default_gemfile(); end
+
+  def self.default_lockfile(); end
+
+  def self.definition(unlock=T.unsafe(nil)); end
+
+  def self.environment(); end
+
+  def self.feature_flag(); end
+
+  def self.frozen_bundle?(); end
+
+  def self.git_present?(); end
+
+  def self.home(); end
+
+  def self.install_path(); end
+
+  def self.load_gemspec(file, validate=T.unsafe(nil)); end
+
+  def self.load_gemspec_uncached(file, validate=T.unsafe(nil)); end
+
+  def self.load_marshal(data); end
+
+  def self.local_platform(); end
+
+  def self.locked_gems(); end
+
+  def self.mkdir_p(path, options=T.unsafe(nil)); end
+
+  def self.original_env(); end
+
+  def self.read_file(file); end
+
+  def self.require(*groups); end
+
+  def self.require_thor_actions(); end
+
+  def self.requires_sudo?(); end
+
+  def self.reset!(); end
+
+  def self.reset_paths!(); end
+
+  def self.reset_rubygems!(); end
+
+  def self.rm_rf(path); end
+
+  def self.root(); end
+
+  def self.ruby_scope(); end
+
+  def self.rubygems(); end
+
+  def self.settings(); end
+
+  def self.setup(*groups); end
+
+  def self.specs_path(); end
+
+  def self.sudo(str); end
+
+  def self.system_bindir(); end
+
+  def self.tmp(name=T.unsafe(nil)); end
+
+  def self.tmp_home_path(login, warning); end
+
+  def self.ui(); end
+
+  def self.ui=(ui); end
+
+  def self.use_system_gems?(); end
+
+  def self.user_bundle_path(dir=T.unsafe(nil)); end
+
+  def self.user_cache(); end
+
+  def self.user_home(); end
+
+  def self.which(executable); end
+
+  def self.with_clean_env(); end
+
+  def self.with_original_env(); end
+end
+
 module CGI::HtmlExtension
   def a(href=T.unsafe(nil)); end
 
@@ -821,6 +3901,8 @@ module CGI::HtmlExtension
 end
 
 class Class
+  def any_instance(); end
+
   def json_creatable?(); end
 end
 
@@ -832,15 +3914,10 @@ class Complex
   def self.rectangular(*_); end
 end
 
-ConditionVariable = Thread::ConditionVariable
-
 module Coverage
-  def self.line_stub(file); end
-
   def self.peek_result(); end
 
   def self.running?(); end
-
 end
 
 class Date::Infinity
@@ -871,6 +3948,7 @@ class Delegator
   def protected_methods(all=T.unsafe(nil)); end
 
   def public_methods(all=T.unsafe(nil)); end
+  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
 end
 
 class Delegator
@@ -901,6 +3979,15 @@ module DidYouMean::Correctable
   def spell_checker(); end
 
   def to_s(); end
+end
+
+class DidYouMean::DeprecatedIgnoredCallers
+  def +(*_); end
+
+  def <<(*_); end
+end
+
+class DidYouMean::DeprecatedIgnoredCallers
 end
 
 module DidYouMean::Jaro
@@ -936,7 +4023,6 @@ class DidYouMean::MethodNameChecker
   def method_names(); end
 
   def receiver(); end
-  RB_RESERVED_WORDS = ::T.let(nil, ::T.untyped)
 end
 
 class DidYouMean::NullChecker
@@ -972,20 +4058,13 @@ class DidYouMean::VariableNameChecker
   def method_names(); end
 
   def name(); end
-  RB_RESERVED_WORDS = ::T.let(nil, ::T.untyped)
+  RB_PREDEFINED_OBJECTS = ::T.let(nil, ::T.untyped)
 end
 
 module DidYouMean
   def self.formatter(); end
 
   def self.formatter=(formatter); end
-end
-
-class Dir
-  def children(); end
-
-  def each_child(); end
-
 end
 
 class Dir
@@ -1096,15 +4175,11 @@ class Encoding
 end
 
 module Enumerable
-  def chain(*_); end
-
   def chunk(); end
 
   def chunk_while(); end
 
   def each_entry(*_); end
-
-  def filter(); end
 
   def grep_v(_); end
 
@@ -1124,33 +4199,7 @@ module Enumerable
 end
 
 class Enumerator
-  def +(_); end
-
   def each_with_index(); end
-
-end
-
-class Enumerator::ArithmeticSequence
-  def begin(); end
-
-  def each(&blk); end
-
-  def end(); end
-
-  def exclude_end?(); end
-
-  def last(*_); end
-
-  def step(); end
-end
-
-class Enumerator::ArithmeticSequence
-end
-
-class Enumerator::Chain
-end
-
-class Enumerator::Chain
 end
 
 class Enumerator::Generator
@@ -1169,35 +4218,48 @@ class Enumerator::Lazy
   def slice_when(*_); end
 end
 
-Errno::EAUTH = Errno::NOERROR
+class Errno::EAUTH
+  Errno = ::T.let(nil, ::T.untyped)
+end
 
-Errno::EBADARCH = Errno::NOERROR
+class Errno::EAUTH
+end
 
-Errno::EBADEXEC = Errno::NOERROR
+class Errno::EBADRPC
+  Errno = ::T.let(nil, ::T.untyped)
+end
 
-Errno::EBADMACHO = Errno::NOERROR
-
-Errno::EBADRPC = Errno::NOERROR
+class Errno::EBADRPC
+end
 
 Errno::ECAPMODE = Errno::NOERROR
 
-Errno::EDEADLOCK = Errno::EDEADLK
-
-Errno::EDEVERR = Errno::NOERROR
+Errno::EDEADLOCK = Errno::NOERROR
 
 Errno::EDOOFUS = Errno::NOERROR
 
-Errno::EFTYPE = Errno::NOERROR
+class Errno::EFTYPE
+  Errno = ::T.let(nil, ::T.untyped)
+end
+
+class Errno::EFTYPE
+end
 
 Errno::EIPSEC = Errno::NOERROR
 
-Errno::ELAST = Errno::NOERROR
+class Errno::ENEEDAUTH
+  Errno = ::T.let(nil, ::T.untyped)
+end
 
-Errno::ENEEDAUTH = Errno::NOERROR
+class Errno::ENEEDAUTH
+end
 
-Errno::ENOATTR = Errno::NOERROR
+class Errno::ENOATTR
+  Errno = ::T.let(nil, ::T.untyped)
+end
 
-Errno::ENOPOLICY = Errno::NOERROR
+class Errno::ENOATTR
+end
 
 Errno::ENOTCAPABLE = Errno::NOERROR
 
@@ -1208,21 +4270,40 @@ end
 class Errno::ENOTSUP
 end
 
-Errno::EPROCLIM = Errno::NOERROR
+class Errno::EPROCLIM
+  Errno = ::T.let(nil, ::T.untyped)
+end
 
-Errno::EPROCUNAVAIL = Errno::NOERROR
+class Errno::EPROCLIM
+end
 
-Errno::EPROGMISMATCH = Errno::NOERROR
+class Errno::EPROCUNAVAIL
+  Errno = ::T.let(nil, ::T.untyped)
+end
 
-Errno::EPROGUNAVAIL = Errno::NOERROR
+class Errno::EPROCUNAVAIL
+end
 
-Errno::EPWROFF = Errno::NOERROR
+class Errno::EPROGMISMATCH
+  Errno = ::T.let(nil, ::T.untyped)
+end
 
-Errno::EQFULL = Errno::NOERROR
+class Errno::EPROGMISMATCH
+end
 
-Errno::ERPCMISMATCH = Errno::NOERROR
+class Errno::EPROGUNAVAIL
+  Errno = ::T.let(nil, ::T.untyped)
+end
 
-Errno::ESHLIBVERS = Errno::NOERROR
+class Errno::EPROGUNAVAIL
+end
+
+class Errno::ERPCMISMATCH
+  Errno = ::T.let(nil, ::T.untyped)
+end
+
+class Errno::ERPCMISMATCH
+end
 
 class Etc::Group
   def gid(); end
@@ -1252,9 +4333,17 @@ class Etc::Group
 end
 
 class Etc::Passwd
+  def change(); end
+
+  def change=(_); end
+
   def dir(); end
 
   def dir=(_); end
+
+  def expire(); end
+
+  def expire=(_); end
 
   def gecos(); end
 
@@ -1276,6 +4365,10 @@ class Etc::Passwd
 
   def shell=(_); end
 
+  def uclass(); end
+
+  def uclass=(_); end
+
   def uid(); end
 
   def uid=(_); end
@@ -1290,55 +4383,12 @@ class Etc::Passwd
   def self.members(); end
 end
 
-module Etc
-  def self.confstr(_); end
-
-  def self.endgrent(); end
-
-  def self.endpwent(); end
-
-  def self.getgrent(); end
-
-  def self.getgrgid(*_); end
-
-  def self.getgrnam(_); end
-
-  def self.getlogin(); end
-
-  def self.getpwent(); end
-
-  def self.getpwnam(_); end
-
-  def self.getpwuid(*_); end
-
-  def self.group(); end
-
-  def self.nprocessors(); end
-
-  def self.passwd(); end
-
-  def self.setgrent(); end
-
-  def self.setpwent(); end
-
-  def self.sysconf(_); end
-
-  def self.sysconfdir(); end
-
-  def self.systmpdir(); end
-
-  def self.uname(); end
-end
-
 class Exception
-  def full_message(*_); end
-
+  def full_message(); end
 end
 
 class Exception
   def self.exception(*_); end
-
-  def self.to_tty?(); end
 end
 
 class ExitCalledError
@@ -1375,166 +4425,40 @@ class File
   def self.lutime(*_); end
 
   def self.mkfifo(*_); end
-
 end
 
 FileList = Rake::FileList
-
-module FileTest
-  def self.blockdev?(_); end
-
-  def self.chardev?(_); end
-
-  def self.directory?(_); end
-
-  def self.empty?(_); end
-
-  def self.executable?(_); end
-
-  def self.executable_real?(_); end
-
-  def self.exist?(_); end
-
-  def self.exists?(_); end
-
-  def self.file?(_); end
-
-  def self.grpowned?(_); end
-
-  def self.identical?(_, _1); end
-
-  def self.owned?(_); end
-
-  def self.pipe?(_); end
-
-  def self.readable?(_); end
-
-  def self.readable_real?(_); end
-
-  def self.setgid?(_); end
-
-  def self.setuid?(_); end
-
-  def self.size(_); end
-
-  def self.size?(_); end
-
-  def self.socket?(_); end
-
-  def self.sticky?(_); end
-
-  def self.symlink?(_); end
-
-  def self.world_readable?(_); end
-
-  def self.world_writable?(_); end
-
-  def self.writable?(_); end
-
-  def self.writable_real?(_); end
-
-  def self.zero?(_); end
-end
 
 module FileUtils
   include ::FileUtils::StreamUtils_
   LN_SUPPORTED = ::T.let(nil, ::T.untyped)
   RUBY = ::T.let(nil, ::T.untyped)
-  VERSION = ::T.let(nil, ::T.untyped)
 end
 
 module FileUtils::DryRun
-  include ::FileUtils::LowMethods
   include ::FileUtils
   include ::FileUtils::StreamUtils_
+  include ::FileUtils::LowMethods
 end
 
 module FileUtils::DryRun
   extend ::FileUtils::DryRun
-  extend ::FileUtils::LowMethods
   extend ::FileUtils
   extend ::FileUtils::StreamUtils_
-end
-
-class FileUtils::Entry_
-  def blockdev?(); end
-
-  def chardev?(); end
-
-  def chmod(mode); end
-
-  def chown(uid, gid); end
-
-  def copy(dest); end
-
-  def copy_file(dest); end
-
-  def copy_metadata(path); end
-
-  def dereference?(); end
-
-  def directory?(); end
-
-  def door?(); end
-
-  def entries(); end
-
-  def exist?(); end
-
-  def file?(); end
-
-  def initialize(a, b=T.unsafe(nil), deref=T.unsafe(nil)); end
-
-  def link(dest); end
-
-  def lstat(); end
-
-  def lstat!(); end
-
-  def path(); end
-
-  def pipe?(); end
-
-  def platform_support(); end
-
-  def postorder_traverse(); end
-
-  def prefix(); end
-
-  def preorder_traverse(); end
-
-  def rel(); end
-
-  def remove(); end
-
-  def remove_dir1(); end
-
-  def remove_file(); end
-
-  def socket?(); end
-
-  def stat(); end
-
-  def stat!(); end
-
-  def symlink?(); end
-
-  def traverse(); end
-
-  def wrap_traverse(pre, post); end
+  extend ::FileUtils::LowMethods
 end
 
 module FileUtils::NoWrite
-  include ::FileUtils::LowMethods
   include ::FileUtils
   include ::FileUtils::StreamUtils_
+  include ::FileUtils::LowMethods
 end
 
 module FileUtils::NoWrite
   extend ::FileUtils::NoWrite
-  extend ::FileUtils::LowMethods
   extend ::FileUtils
   extend ::FileUtils::StreamUtils_
+  extend ::FileUtils::LowMethods
 end
 
 module FileUtils::Verbose
@@ -1550,101 +4474,6 @@ end
 
 module FileUtils
   extend ::FileUtils::StreamUtils_
-  def self.cd(dir, verbose: T.unsafe(nil), &block); end
-
-  def self.chdir(dir, verbose: T.unsafe(nil), &block); end
-
-  def self.chmod(mode, list, noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.chmod_R(mode, list, noop: T.unsafe(nil), verbose: T.unsafe(nil), force: T.unsafe(nil)); end
-
-  def self.chown(user, group, list, noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.chown_R(user, group, list, noop: T.unsafe(nil), verbose: T.unsafe(nil), force: T.unsafe(nil)); end
-
-  def self.cmp(a, b); end
-
-  def self.collect_method(opt); end
-
-  def self.commands(); end
-
-  def self.compare_file(a, b); end
-
-  def self.compare_stream(a, b); end
-
-  def self.copy(src, dest, preserve: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.copy_entry(src, dest, preserve=T.unsafe(nil), dereference_root=T.unsafe(nil), remove_destination=T.unsafe(nil)); end
-
-  def self.copy_file(src, dest, preserve=T.unsafe(nil), dereference=T.unsafe(nil)); end
-
-  def self.copy_stream(src, dest); end
-
-  def self.cp(src, dest, preserve: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.cp_lr(src, dest, noop: T.unsafe(nil), verbose: T.unsafe(nil), dereference_root: T.unsafe(nil), remove_destination: T.unsafe(nil)); end
-
-  def self.getwd(); end
-
-  def self.have_option?(mid, opt); end
-
-  def self.identical?(a, b); end
-
-  def self.install(src, dest, mode: T.unsafe(nil), owner: T.unsafe(nil), group: T.unsafe(nil), preserve: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.link(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.link_entry(src, dest, dereference_root=T.unsafe(nil), remove_destination=T.unsafe(nil)); end
-
-  def self.ln(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.ln_s(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.ln_sf(src, dest, noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.makedirs(list, mode: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.mkdir(list, mode: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.mkpath(list, mode: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.move(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil), secure: T.unsafe(nil)); end
-
-  def self.mv(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil), secure: T.unsafe(nil)); end
-
-  def self.options(); end
-
-  def self.options_of(mid); end
-
-  def self.private_module_function(name); end
-
-  def self.pwd(); end
-
-  def self.remove(list, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.remove_dir(path, force=T.unsafe(nil)); end
-
-  def self.remove_entry(path, force=T.unsafe(nil)); end
-
-  def self.remove_entry_secure(path, force=T.unsafe(nil)); end
-
-  def self.remove_file(path, force=T.unsafe(nil)); end
-
-  def self.rm(list, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.rm_f(list, noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.rm_rf(list, noop: T.unsafe(nil), verbose: T.unsafe(nil), secure: T.unsafe(nil)); end
-
-  def self.rmdir(list, parents: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.rmtree(list, noop: T.unsafe(nil), verbose: T.unsafe(nil), secure: T.unsafe(nil)); end
-
-  def self.safe_unlink(list, noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.symlink(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
-
-  def self.uptodate?(new, old_list); end
 end
 
 class Float
@@ -1663,7 +4492,6 @@ module Forwardable
   def delegate(hash); end
 
   def instance_delegate(hash); end
-  VERSION = ::T.let(nil, ::T.untyped)
 end
 
 module Forwardable
@@ -1694,16 +4522,3877 @@ module GC
   def self.stress=(stress); end
 
   def self.verify_internal_consistency(); end
+end
 
-  def self.verify_transient_heap_internal_consistency(); end
+module Gem
+  ConfigMap = ::T.let(nil, ::T.untyped)
+  RbConfigPriorities = ::T.let(nil, ::T.untyped)
+  RubyGemsPackageVersion = ::T.let(nil, ::T.untyped)
+  RubyGemsVersion = ::T.let(nil, ::T.untyped)
+  USE_BUNDLER_FOR_GEMDEPS = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::AvailableSet
+  include ::Enumerable
+  def <<(o); end
+
+  def add(spec, source); end
+
+  def all_specs(); end
+
+  def each(&blk); end
+
+  def each_spec(); end
+
+  def empty?(); end
+
+  def find_all(req); end
+
+  def inject_into_list(dep_list); end
+
+  def match_platform!(); end
+
+  def pick_best!(); end
+
+  def prefetch(reqs); end
+
+  def remote(); end
+
+  def remote=(remote); end
+
+  def remove_installed!(dep); end
+
+  def set(); end
+
+  def size(); end
+
+  def sorted(); end
+
+  def source_for(spec); end
+
+  def to_request_set(development=T.unsafe(nil)); end
+end
+
+class Gem::AvailableSet::Tuple
+  def source(); end
+
+  def source=(_); end
+
+  def spec(); end
+
+  def spec=(_); end
+end
+
+class Gem::AvailableSet::Tuple
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class Gem::AvailableSet
+end
+
+class Gem::BasicSpecification
+  def activated?(); end
+
+  def base_dir(); end
+
+  def base_dir=(base_dir); end
+
+  def contains_requirable_file?(file); end
+
+  def datadir(); end
+
+  def default_gem?(); end
+
+  def extension_dir(); end
+
+  def extension_dir=(extension_dir); end
+
+  def extensions_dir(); end
+
+  def full_gem_path(); end
+
+  def full_gem_path=(full_gem_path); end
+
+  def full_name(); end
+
+  def full_require_paths(); end
+
+  def gem_build_complete_path(); end
+
+  def gem_dir(); end
+
+  def gems_dir(); end
+
+  def ignored=(ignored); end
+
+  def internal_init(); end
+
+  def lib_dirs_glob(); end
+
+  def loaded_from(); end
+
+  def loaded_from=(loaded_from); end
+
+  def matches_for_glob(glob); end
+
+  def name(); end
+
+  def platform(); end
+
+  def raw_require_paths(); end
+
+  def require_paths(); end
+
+  def source_paths(); end
+
+  def stubbed?(); end
+
+  def this(); end
+
+  def to_fullpath(path); end
+
+  def to_spec(); end
+
+  def version(); end
+end
+
+class Gem::BasicSpecification
+  def self.default_specifications_dir(); end
+end
+
+module Gem::BundlerVersionFinder
+end
+
+module Gem::BundlerVersionFinder
+  def self.bundler_version(); end
+
+  def self.bundler_version_with_reason(); end
+
+  def self.compatible?(spec); end
+
+  def self.filter!(specs); end
+
+  def self.missing_version_message(); end
+
+  def self.without_filtering(); end
+end
+
+class Gem::Command
+  include ::Gem::UserInteraction
+  include ::Gem::DefaultUserInteraction
+  def add_extra_args(args); end
+
+  def add_option(*opts, &handler); end
+
+  def arguments(); end
+
+  def begins?(long, short); end
+
+  def command(); end
+
+  def defaults(); end
+
+  def defaults=(defaults); end
+
+  def defaults_str(); end
+
+  def description(); end
+
+  def execute(); end
+
+  def get_all_gem_names(); end
+
+  def get_all_gem_names_and_versions(); end
+
+  def get_one_gem_name(); end
+
+  def get_one_optional_argument(); end
+
+  def handle_options(args); end
+
+  def handles?(args); end
+
+  def initialize(command, summary=T.unsafe(nil), defaults=T.unsafe(nil)); end
+
+  def invoke(*args); end
+
+  def invoke_with_build_args(args, build_args); end
+
+  def merge_options(new_options); end
+
+  def options(); end
+
+  def program_name(); end
+
+  def program_name=(program_name); end
+
+  def remove_option(name); end
+
+  def show_help(); end
+
+  def show_lookup_failure(gem_name, version, errors, domain); end
+
+  def summary(); end
+
+  def summary=(summary); end
+
+  def usage(); end
+
+  def when_invoked(&block); end
+  HELP = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Command
+  def self.add_common_option(*args, &handler); end
+
+  def self.add_specific_extra_args(cmd, args); end
+
+  def self.build_args(); end
+
+  def self.build_args=(value); end
+
+  def self.common_options(); end
+
+  def self.extra_args(); end
+
+  def self.extra_args=(value); end
+
+  def self.specific_extra_args(cmd); end
+
+  def self.specific_extra_args_hash(); end
+end
+
+module Gem::Commands
+end
+
+module Gem::Commands
+end
+
+class Gem::ConfigFile
+  include ::Gem::UserInteraction
+  include ::Gem::DefaultUserInteraction
+  def ==(other); end
+
+  def [](key); end
+
+  def []=(key, value); end
+
+  def api_keys(); end
+
+  def args(); end
+
+  def backtrace(); end
+
+  def backtrace=(backtrace); end
+
+  def bulk_threshold(); end
+
+  def bulk_threshold=(bulk_threshold); end
+
+  def check_credentials_permissions(); end
+
+  def config_file_name(); end
+
+  def credentials_path(); end
+
+  def disable_default_gem_server(); end
+
+  def disable_default_gem_server=(disable_default_gem_server); end
+
+  def each(&block); end
+
+  def handle_arguments(arg_list); end
+
+  def home(); end
+
+  def home=(home); end
+
+  def initialize(args); end
+
+  def load_api_keys(); end
+
+  def load_file(filename); end
+
+  def path(); end
+
+  def path=(path); end
+
+  def really_verbose(); end
+
+  def rubygems_api_key(); end
+
+  def rubygems_api_key=(api_key); end
+
+  def set_api_key(host, api_key); end
+
+  def sources(); end
+
+  def sources=(sources); end
+
+  def ssl_ca_cert(); end
+
+  def ssl_ca_cert=(ssl_ca_cert); end
+
+  def ssl_client_cert(); end
+
+  def ssl_verify_mode(); end
+
+  def to_yaml(); end
+
+  def unset_api_key!(); end
+
+  def update_sources(); end
+
+  def update_sources=(update_sources); end
+
+  def verbose(); end
+
+  def verbose=(verbose); end
+
+  def write(); end
+  DEFAULT_BACKTRACE = ::T.let(nil, ::T.untyped)
+  DEFAULT_BULK_THRESHOLD = ::T.let(nil, ::T.untyped)
+  DEFAULT_UPDATE_SOURCES = ::T.let(nil, ::T.untyped)
+  DEFAULT_VERBOSITY = ::T.let(nil, ::T.untyped)
+  OPERATING_SYSTEM_DEFAULTS = ::T.let(nil, ::T.untyped)
+  PLATFORM_DEFAULTS = ::T.let(nil, ::T.untyped)
+  SYSTEM_CONFIG_PATH = ::T.let(nil, ::T.untyped)
+  SYSTEM_WIDE_CONFIG_FILE = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::ConfigFile
+end
+
+class Gem::ConflictError
+  def conflicts(); end
+
+  def initialize(target, conflicts); end
+
+  def target(); end
+end
+
+class Gem::ConsoleUI
+  def initialize(); end
+end
+
+class Gem::ConsoleUI
+end
+
+module Gem::DefaultUserInteraction
+  def ui(); end
+
+  def ui=(new_ui); end
+
+  def use_ui(new_ui, &block); end
+end
+
+module Gem::DefaultUserInteraction
+  def self.ui(); end
+
+  def self.ui=(new_ui); end
+
+  def self.use_ui(new_ui); end
+end
+
+class Gem::Dependency
+  def ==(other); end
+
+  def ===(other); end
+
+  def =~(other); end
+
+  def all_sources(); end
+
+  def all_sources=(all_sources); end
+
+  def encode_with(coder); end
+
+  def eql?(other); end
+
+  def groups(); end
+
+  def groups=(groups); end
+
+  def initialize(name, *requirements); end
+
+  def latest_version?(); end
+
+  def match?(obj, version=T.unsafe(nil), allow_prerelease=T.unsafe(nil)); end
+
+  def matches_spec?(spec); end
+
+  def matching_specs(platform_only=T.unsafe(nil)); end
+
+  def merge(other); end
+
+  def name(); end
+
+  def name=(name); end
+
+  def prerelease=(prerelease); end
+
+  def prerelease?(); end
+
+  def requirement(); end
+
+  def requirements_list(); end
+
+  def runtime?(); end
+
+  def source(); end
+
+  def source=(source); end
+
+  def specific?(); end
+
+  def to_lock(); end
+
+  def to_spec(); end
+
+  def to_specs(); end
+
+  def to_yaml_properties(); end
+
+  def type(); end
+end
+
+class Gem::DependencyInstaller
+  include ::Gem::UserInteraction
+  include ::Gem::DefaultUserInteraction
+  def _deprecated_gems_to_install(); end
+
+  def add_found_dependencies(to_do, dependency_list); end
+
+  def available_set_for(dep_or_name, version); end
+
+  def consider_local?(); end
+
+  def consider_remote?(); end
+
+  def document(); end
+
+  def errors(); end
+
+  def find_gems_with_sources(dep, best_only=T.unsafe(nil)); end
+
+  def find_spec_by_name_and_version(gem_name, version=T.unsafe(nil), prerelease=T.unsafe(nil)); end
+
+  def gather_dependencies(); end
+
+  def gems_to_install(*args, &block); end
+
+  def in_background(what); end
+
+  def initialize(options=T.unsafe(nil)); end
+
+  def install(dep_or_name, version=T.unsafe(nil)); end
+
+  def install_development_deps(); end
+
+  def installed_gems(); end
+
+  def resolve_dependencies(dep_or_name, version); end
+  DEFAULT_OPTIONS = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::DependencyInstaller
+  extend ::Gem::Deprecate
+end
+
+class Gem::DependencyList
+  include ::Enumerable
+  include ::TSort
+  def add(*gemspecs); end
+
+  def clear(); end
+
+  def dependency_order(); end
+
+  def development(); end
+
+  def development=(development); end
+
+  def each(&block); end
+
+  def find_name(full_name); end
+
+  def initialize(development=T.unsafe(nil)); end
+
+  def ok?(); end
+
+  def ok_to_remove?(full_name, check_dev=T.unsafe(nil)); end
+
+  def remove_by_name(full_name); end
+
+  def remove_specs_unsatisfied_by(dependencies); end
+
+  def spec_predecessors(); end
+
+  def specs(); end
+
+  def tsort_each_node(&block); end
+
+  def why_not_ok?(quick=T.unsafe(nil)); end
+end
+
+class Gem::DependencyList
+  def self.from_specs(); end
+end
+
+class Gem::DependencyResolutionError
+  def conflict(); end
+
+  def conflicting_dependencies(); end
+
+  def initialize(conflict); end
+end
+
+Gem::DependencyResolver = Gem::Resolver
+
+module Gem::Deprecate
+  def self.deprecate(name, repl, year, month); end
+
+  def self.skip(); end
+
+  def self.skip=(v); end
+
+  def self.skip_during(); end
+end
+
+class Gem::Exception
+  def source_exception(); end
+
+  def source_exception=(source_exception); end
+end
+
+module Gem::Ext
+end
+
+class Gem::Ext::BuildError
+end
+
+class Gem::Ext::BuildError
+end
+
+class Gem::Ext::Builder
+  include ::Gem::UserInteraction
+  include ::Gem::DefaultUserInteraction
+  def build_args(); end
+
+  def build_args=(build_args); end
+
+  def build_error(build_dir, output, backtrace=T.unsafe(nil)); end
+
+  def build_extension(extension, dest_path); end
+
+  def build_extensions(); end
+
+  def builder_for(extension); end
+
+  def initialize(spec, build_args=T.unsafe(nil)); end
+
+  def write_gem_make_out(output); end
+  CHDIR_MONITOR = ::T.let(nil, ::T.untyped)
+  CHDIR_MUTEX = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Ext::Builder
+  def self.class_name(); end
+
+  def self.make(dest_path, results); end
+
+  def self.redirector(); end
+
+  def self.run(command, results, command_name=T.unsafe(nil)); end
+end
+
+class Gem::Ext::CmakeBuilder
+end
+
+class Gem::Ext::CmakeBuilder
+  def self.build(extension, directory, dest_path, results, args=T.unsafe(nil), lib_dir=T.unsafe(nil)); end
+end
+
+class Gem::Ext::ConfigureBuilder
+end
+
+class Gem::Ext::ConfigureBuilder
+  def self.build(extension, directory, dest_path, results, args=T.unsafe(nil), lib_dir=T.unsafe(nil)); end
+end
+
+class Gem::Ext::ExtConfBuilder
+end
+
+Gem::Ext::ExtConfBuilder::FileEntry = FileUtils::Entry_
+
+class Gem::Ext::ExtConfBuilder
+  def self.build(extension, directory, dest_path, results, args=T.unsafe(nil), lib_dir=T.unsafe(nil)); end
+
+  def self.get_relative_path(path); end
+end
+
+class Gem::Ext::RakeBuilder
+end
+
+class Gem::Ext::RakeBuilder
+  def self.build(extension, directory, dest_path, results, args=T.unsafe(nil), lib_dir=T.unsafe(nil)); end
+end
+
+module Gem::Ext
+end
+
+class Gem::FilePermissionError
+  def directory(); end
+
+  def initialize(directory); end
+end
+
+class Gem::FormatException
+  def file_path(); end
+
+  def file_path=(file_path); end
+end
+
+class Gem::GemNotInHomeException
+  def spec(); end
+
+  def spec=(spec); end
+end
+
+class Gem::ImpossibleDependenciesError
+  def build_message(); end
+
+  def conflicts(); end
+
+  def dependency(); end
+
+  def initialize(request, conflicts); end
+
+  def request(); end
+end
+
+class Gem::Installer
+  include ::Gem::UserInteraction
+  include ::Gem::DefaultUserInteraction
+  def app_script_text(bin_file_name); end
+
+  def bin_dir(); end
+
+  def build_extensions(); end
+
+  def build_root(); end
+
+  def check_executable_overwrite(filename); end
+
+  def check_that_user_bin_dir_is_in_path(); end
+
+  def default_spec_file(); end
+
+  def dir(); end
+
+  def ensure_dependencies_met(); end
+
+  def ensure_dependency(spec, dependency); end
+
+  def ensure_loadable_spec(); end
+
+  def ensure_required_ruby_version_met(); end
+
+  def ensure_required_rubygems_version_met(); end
+
+  def extension_build_error(build_dir, output, backtrace=T.unsafe(nil)); end
+
+  def extract_bin(); end
+
+  def extract_files(); end
+
+  def formatted_program_filename(filename); end
+
+  def gem(); end
+
+  def gem_dir(); end
+
+  def gem_home(); end
+
+  def generate_bin(); end
+
+  def generate_bin_script(filename, bindir); end
+
+  def generate_bin_symlink(filename, bindir); end
+
+  def generate_windows_script(filename, bindir); end
+
+  def initialize(package, options=T.unsafe(nil)); end
+
+  def install(); end
+
+  def installation_satisfies_dependency?(dependency); end
+
+  def installed_specs(); end
+
+  def options(); end
+
+  def pre_install_checks(); end
+
+  def process_options(); end
+
+  def run_post_build_hooks(); end
+
+  def run_post_install_hooks(); end
+
+  def run_pre_install_hooks(); end
+
+  def shebang(bin_file_name); end
+
+  def spec(); end
+
+  def spec_file(); end
+
+  def unpack(directory); end
+
+  def verify_gem_home(unpack=T.unsafe(nil)); end
+
+  def verify_spec_name(); end
+
+  def windows_stub_script(bindir, bin_file_name); end
+
+  def write_build_info_file(); end
+
+  def write_cache_file(); end
+
+  def write_default_spec(); end
+
+  def write_spec(); end
+  ENV_PATHS = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Installer
+  def self.at(path, options=T.unsafe(nil)); end
+
+  def self.exec_format(); end
+
+  def self.exec_format=(exec_format); end
+
+  def self.for_spec(spec, options=T.unsafe(nil)); end
+
+  def self.install_lock(); end
+
+  def self.path_warning(); end
+
+  def self.path_warning=(path_warning); end
+end
+
+class Gem::Licenses
+  IDENTIFIERS = ::T.let(nil, ::T.untyped)
+  NONSTANDARD = ::T.let(nil, ::T.untyped)
+  REGEXP = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Licenses
+  extend ::Gem::Text
+  def self.match?(license); end
+
+  def self.suggestions(license); end
+end
+
+class Gem::List
+  def each(&blk); end
+
+  def initialize(value=T.unsafe(nil), tail=T.unsafe(nil)); end
+
+  def prepend(value); end
+
+  def tail(); end
+
+  def tail=(tail); end
+
+  def to_a(); end
+
+  def value(); end
+
+  def value=(value); end
+end
+
+class Gem::List
+  def self.prepend(list, value); end
+end
+
+class Gem::LoadError
+  def name(); end
+
+  def name=(name); end
+
+  def requirement(); end
+
+  def requirement=(requirement); end
+end
+
+class Gem::MissingSpecError
+  def initialize(name, requirement); end
+end
+
+class Gem::MissingSpecVersionError
+  def initialize(name, requirement, specs); end
+
+  def specs(); end
+end
+
+class Gem::NameTuple
+  include ::Comparable
+  def ==(other); end
+
+  def eql?(other); end
+
+  def full_name(); end
+
+  def initialize(name, version, platform=T.unsafe(nil)); end
+
+  def match_platform?(); end
+
+  def name(); end
+
+  def platform(); end
+
+  def prerelease?(); end
+
+  def spec_name(); end
+
+  def to_a(); end
+
+  def version(); end
+end
+
+class Gem::NameTuple
+  def self.from_list(list); end
+
+  def self.null(); end
+
+  def self.to_basic(list); end
+end
+
+class Gem::Package
+  include ::Gem::UserInteraction
+  include ::Gem::DefaultUserInteraction
+  def add_checksums(tar); end
+
+  def add_contents(tar); end
+
+  def add_files(tar); end
+
+  def add_metadata(tar); end
+
+  def build(skip_validation=T.unsafe(nil)); end
+
+  def build_time(); end
+
+  def build_time=(build_time); end
+
+  def checksums(); end
+
+  def contents(); end
+
+  def copy_to(path); end
+
+  def digest(entry); end
+
+  def extract_files(destination_dir, pattern=T.unsafe(nil)); end
+
+  def extract_tar_gz(io, destination_dir, pattern=T.unsafe(nil)); end
+
+  def files(); end
+
+  def gzip_to(io); end
+
+  def initialize(gem, security_policy); end
+
+  def install_location(filename, destination_dir); end
+
+  def load_spec(entry); end
+
+  def open_tar_gz(io); end
+
+  def read_checksums(gem); end
+
+  def security_policy(); end
+
+  def security_policy=(security_policy); end
+
+  def setup_signer(); end
+
+  def spec(); end
+
+  def spec=(spec); end
+
+  def verify(); end
+
+  def verify_checksums(digests, checksums); end
+
+  def verify_entry(entry); end
+
+  def verify_files(gem); end
+
+  def verify_gz(entry); end
+end
+
+class Gem::Package::DigestIO
+  def digests(); end
+
+  def initialize(io, digests); end
+
+  def write(data); end
+end
+
+class Gem::Package::DigestIO
+  def self.wrap(io, digests); end
+end
+
+class Gem::Package::Error
+end
+
+class Gem::Package::Error
+end
+
+class Gem::Package::FileSource
+  def initialize(path); end
+
+  def path(); end
+
+  def present?(); end
+
+  def start(); end
+
+  def with_read_io(&block); end
+
+  def with_write_io(&block); end
+end
+
+class Gem::Package::FileSource
+end
+
+class Gem::Package::FormatError
+  def initialize(message, source=T.unsafe(nil)); end
+
+  def path(); end
+end
+
+class Gem::Package::FormatError
+end
+
+class Gem::Package::IOSource
+  def initialize(io); end
+
+  def io(); end
+
+  def path(); end
+
+  def present?(); end
+
+  def start(); end
+
+  def with_read_io(); end
+
+  def with_write_io(); end
+end
+
+class Gem::Package::IOSource
+end
+
+class Gem::Package::NonSeekableIO
+end
+
+class Gem::Package::NonSeekableIO
+end
+
+class Gem::Package::Old
+  def extract_files(destination_dir); end
+
+  def file_list(io); end
+
+  def read_until_dashes(io); end
+
+  def skip_ruby(io); end
+end
+
+class Gem::Package::Old
+end
+
+class Gem::Package::PathError
+  def initialize(destination, destination_dir); end
+end
+
+class Gem::Package::PathError
+end
+
+class Gem::Package::Source
+end
+
+class Gem::Package::Source
+end
+
+class Gem::Package::TarHeader
+  def ==(other); end
+
+  def checksum(); end
+
+  def devmajor(); end
+
+  def devminor(); end
+
+  def empty?(); end
+
+  def gid(); end
+
+  def gname(); end
+
+  def initialize(vals); end
+
+  def linkname(); end
+
+  def magic(); end
+
+  def mode(); end
+
+  def mtime(); end
+
+  def name(); end
+
+  def prefix(); end
+
+  def size(); end
+
+  def typeflag(); end
+
+  def uid(); end
+
+  def uname(); end
+
+  def update_checksum(); end
+
+  def version(); end
+  FIELDS = ::T.let(nil, ::T.untyped)
+  PACK_FORMAT = ::T.let(nil, ::T.untyped)
+  UNPACK_FORMAT = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Package::TarHeader
+  def self.from(stream); end
+end
+
+class Gem::Package::TarInvalidError
+end
+
+class Gem::Package::TarInvalidError
+end
+
+class Gem::Package::TarReader
+  include ::Enumerable
+  def close(); end
+
+  def each(&blk); end
+
+  def each_entry(); end
+
+  def initialize(io); end
+
+  def rewind(); end
+
+  def seek(name); end
+end
+
+class Gem::Package::TarReader::Entry
+  def bytes_read(); end
+
+  def check_closed(); end
+
+  def close(); end
+
+  def closed?(); end
+
+  def directory?(); end
+
+  def eof?(); end
+
+  def file?(); end
+
+  def full_name(); end
+
+  def getc(); end
+
+  def header(); end
+
+  def initialize(header, io); end
+
+  def pos(); end
+
+  def read(len=T.unsafe(nil)); end
+
+  def readpartial(len=T.unsafe(nil)); end
+
+  def rewind(); end
+
+  def symlink?(); end
+end
+
+class Gem::Package::TarReader::Entry
+end
+
+class Gem::Package::TarReader::UnexpectedEOF
+end
+
+class Gem::Package::TarReader::UnexpectedEOF
+end
+
+class Gem::Package::TarReader
+  def self.new(io); end
+end
+
+class Gem::Package::TarWriter
+  def add_file(name, mode); end
+
+  def add_file_digest(name, mode, digest_algorithms); end
+
+  def add_file_signed(name, mode, signer); end
+
+  def add_file_simple(name, mode, size); end
+
+  def add_symlink(name, target, mode); end
+
+  def check_closed(); end
+
+  def close(); end
+
+  def closed?(); end
+
+  def flush(); end
+
+  def initialize(io); end
+
+  def mkdir(name, mode); end
+
+  def split_name(name); end
+end
+
+class Gem::Package::TarWriter::BoundedStream
+  def initialize(io, limit); end
+
+  def limit(); end
+
+  def write(data); end
+
+  def written(); end
+end
+
+class Gem::Package::TarWriter::BoundedStream
+end
+
+class Gem::Package::TarWriter::FileOverflow
+end
+
+class Gem::Package::TarWriter::FileOverflow
+end
+
+class Gem::Package::TarWriter::RestrictedStream
+  def initialize(io); end
+
+  def write(data); end
+end
+
+class Gem::Package::TarWriter::RestrictedStream
+end
+
+class Gem::Package::TarWriter
+  def self.new(io); end
+end
+
+class Gem::Package::TooLongFileName
+end
+
+class Gem::Package::TooLongFileName
+end
+
+class Gem::Package
+  def self.build(spec, skip_validation=T.unsafe(nil)); end
+
+  def self.new(gem, security_policy=T.unsafe(nil)); end
+end
+
+class Gem::PathSupport
+  def home(); end
+
+  def initialize(env); end
+
+  def path(); end
+
+  def spec_cache_dir(); end
+end
+
+class Gem::Platform
+  def ==(other); end
+
+  def ===(other); end
+
+  def =~(other); end
+
+  def cpu(); end
+
+  def cpu=(cpu); end
+
+  def eql?(other); end
+
+  def initialize(arch); end
+
+  def os(); end
+
+  def os=(os); end
+
+  def to_a(); end
+
+  def version(); end
+
+  def version=(version); end
+  JAVA = ::T.let(nil, ::T.untyped)
+  MINGW = ::T.let(nil, ::T.untyped)
+  MSWIN = ::T.let(nil, ::T.untyped)
+  MSWIN64 = ::T.let(nil, ::T.untyped)
+  X64_MINGW = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Platform
+  def self.installable?(spec); end
+
+  def self.local(); end
+
+  def self.match(platform); end
+
+  def self.new(arch); end
+end
+
+class Gem::PlatformMismatch
+  def add_platform(platform); end
+
+  def initialize(name, version); end
+
+  def name(); end
+
+  def platforms(); end
+
+  def version(); end
+
+  def wordy(); end
+end
+
+class Gem::RemoteFetcher
+  include ::Gem::UserInteraction
+  include ::Gem::DefaultUserInteraction
+  def api_endpoint(uri); end
+
+  def cache_update_path(uri, path=T.unsafe(nil), update=T.unsafe(nil)); end
+
+  def close_all(); end
+
+  def correct_for_windows_path(path); end
+
+  def download(spec, source_uri, install_dir=T.unsafe(nil)); end
+
+  def download_to_cache(dependency); end
+
+  def fetch_file(uri, *_); end
+
+  def fetch_http(uri, last_modified=T.unsafe(nil), head=T.unsafe(nil), depth=T.unsafe(nil)); end
+
+  def fetch_https(uri, last_modified=T.unsafe(nil), head=T.unsafe(nil), depth=T.unsafe(nil)); end
+
+  def fetch_path(uri, mtime=T.unsafe(nil), head=T.unsafe(nil)); end
+
+  def fetch_s3(uri, mtime=T.unsafe(nil), head=T.unsafe(nil)); end
+
+  def fetch_size(uri); end
+
+  def headers(); end
+
+  def headers=(headers); end
+
+  def https?(uri); end
+
+  def initialize(proxy=T.unsafe(nil), dns=T.unsafe(nil), headers=T.unsafe(nil)); end
+
+  def request(uri, request_class, last_modified=T.unsafe(nil)); end
+
+  def s3_expiration(); end
+
+  def sign_s3_url(uri, expiration=T.unsafe(nil)); end
+  BASE64_URI_TRANSLATE = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::RemoteFetcher
+  def self.fetcher(); end
+end
+
+class Gem::Request
+  include ::Gem::UserInteraction
+  include ::Gem::DefaultUserInteraction
+  def cert_files(); end
+
+  def connection_for(uri); end
+
+  def fetch(); end
+
+  def initialize(uri, request_class, last_modified, pool); end
+
+  def perform_request(request); end
+
+  def proxy_uri(); end
+
+  def reset(connection); end
+
+  def user_agent(); end
+end
+
+class Gem::Request::ConnectionPools
+  def close_all(); end
+
+  def initialize(proxy_uri, cert_files); end
+
+  def pool_for(uri); end
+end
+
+class Gem::Request::ConnectionPools
+  def self.client(); end
+
+  def self.client=(client); end
+end
+
+class Gem::Request::HTTPPool
+  def cert_files(); end
+
+  def checkin(connection); end
+
+  def checkout(); end
+
+  def close_all(); end
+
+  def initialize(http_args, cert_files, proxy_uri); end
+
+  def proxy_uri(); end
+end
+
+class Gem::Request::HTTPPool
+end
+
+class Gem::Request::HTTPSPool
+end
+
+class Gem::Request::HTTPSPool
+end
+
+class Gem::Request
+  extend ::Gem::UserInteraction
+  extend ::Gem::DefaultUserInteraction
+  def self.configure_connection_for_https(connection, cert_files); end
+
+  def self.create_with_proxy(uri, request_class, last_modified, proxy); end
+
+  def self.get_cert_files(); end
+
+  def self.get_proxy_from_env(scheme=T.unsafe(nil)); end
+
+  def self.proxy_uri(proxy); end
+
+  def self.verify_certificate(store_context); end
+
+  def self.verify_certificate_message(error_number, cert); end
+end
+
+class Gem::RequestSet
+  include ::TSort
+  def always_install(); end
+
+  def always_install=(always_install); end
+
+  def dependencies(); end
+
+  def development(); end
+
+  def development=(development); end
+
+  def development_shallow(); end
+
+  def development_shallow=(development_shallow); end
+
+  def errors(); end
+
+  def gem(name, *reqs); end
+
+  def git_set(); end
+
+  def ignore_dependencies(); end
+
+  def ignore_dependencies=(ignore_dependencies); end
+
+  def import(deps); end
+
+  def initialize(*deps); end
+
+  def install(options, &block); end
+
+  def install_dir(); end
+
+  def install_from_gemdeps(options, &block); end
+
+  def install_into(dir, force=T.unsafe(nil), options=T.unsafe(nil)); end
+
+  def load_gemdeps(path, without_groups=T.unsafe(nil), installing=T.unsafe(nil)); end
+
+  def prerelease(); end
+
+  def prerelease=(prerelease); end
+
+  def remote(); end
+
+  def remote=(remote); end
+
+  def resolve(set=T.unsafe(nil)); end
+
+  def resolve_current(); end
+
+  def resolver(); end
+
+  def sets(); end
+
+  def soft_missing(); end
+
+  def soft_missing=(soft_missing); end
+
+  def sorted_requests(); end
+
+  def source_set(); end
+
+  def specs(); end
+
+  def specs_in(dir); end
+
+  def tsort_each_node(&block); end
+
+  def vendor_set(); end
+end
+
+Gem::RequestSet::GemDepedencyAPI = Gem::RequestSet::GemDependencyAPI
+
+class Gem::RequestSet::GemDependencyAPI
+  def dependencies(); end
+
+  def find_gemspec(name, path); end
+
+  def gem(name, *requirements); end
+
+  def gem_deps_file(); end
+
+  def gem_git_reference(options); end
+
+  def gemspec(options=T.unsafe(nil)); end
+
+  def git(repository); end
+
+  def git_set(); end
+
+  def git_source(name, &callback); end
+
+  def group(*groups); end
+
+  def initialize(set, path); end
+
+  def installing=(installing); end
+
+  def load(); end
+
+  def platform(*platforms); end
+
+  def platforms(*platforms); end
+
+  def requires(); end
+
+  def ruby(version, options=T.unsafe(nil)); end
+
+  def source(url); end
+
+  def vendor_set(); end
+
+  def without_groups(); end
+
+  def without_groups=(without_groups); end
+  ENGINE_MAP = ::T.let(nil, ::T.untyped)
+  PLATFORM_MAP = ::T.let(nil, ::T.untyped)
+  VERSION_MAP = ::T.let(nil, ::T.untyped)
+  WINDOWS = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::RequestSet::GemDependencyAPI
+end
+
+class Gem::RequestSet::Lockfile
+  def add_DEPENDENCIES(out); end
+
+  def add_GEM(out, spec_groups); end
+
+  def add_GIT(out, git_requests); end
+
+  def add_PATH(out, path_requests); end
+
+  def add_PLATFORMS(out); end
+
+  def initialize(request_set, gem_deps_file, dependencies); end
+
+  def platforms(); end
+
+  def relative_path_from(dest, base); end
+
+  def spec_groups(); end
+
+  def write(); end
+end
+
+class Gem::RequestSet::Lockfile::ParseError
+  def column(); end
+
+  def initialize(message, column, line, path); end
+
+  def line(); end
+
+  def path(); end
+end
+
+class Gem::RequestSet::Lockfile::ParseError
+end
+
+class Gem::RequestSet::Lockfile::Parser
+  def get(expected_types=T.unsafe(nil), expected_value=T.unsafe(nil)); end
+
+  def initialize(tokenizer, set, platforms, filename=T.unsafe(nil)); end
+
+  def parse(); end
+
+  def parse_DEPENDENCIES(); end
+
+  def parse_GEM(); end
+
+  def parse_GIT(); end
+
+  def parse_PATH(); end
+
+  def parse_PLATFORMS(); end
+
+  def parse_dependency(name, op); end
+end
+
+class Gem::RequestSet::Lockfile::Parser
+end
+
+class Gem::RequestSet::Lockfile::Tokenizer
+  def empty?(); end
+
+  def initialize(input, filename=T.unsafe(nil), line=T.unsafe(nil), pos=T.unsafe(nil)); end
+
+  def make_parser(set, platforms); end
+
+  def next_token(); end
+
+  def peek(); end
+
+  def shift(); end
+
+  def skip(type); end
+
+  def to_a(); end
+
+  def token_pos(byte_offset); end
+
+  def unshift(token); end
+  EOF = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::RequestSet::Lockfile::Tokenizer::Token
+  def column(); end
+
+  def column=(_); end
+
+  def line(); end
+
+  def line=(_); end
+
+  def type(); end
+
+  def type=(_); end
+
+  def value(); end
+
+  def value=(_); end
+end
+
+class Gem::RequestSet::Lockfile::Tokenizer::Token
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class Gem::RequestSet::Lockfile::Tokenizer
+  def self.from_file(file); end
+end
+
+class Gem::RequestSet::Lockfile
+  def self.build(request_set, gem_deps_file, dependencies=T.unsafe(nil)); end
+
+  def self.requests_to_deps(requests); end
+end
+
+class Gem::RequestSet
+end
+
+class Gem::Requirement
+  def ==(other); end
+
+  def ===(version); end
+
+  def =~(version); end
+
+  def as_list(); end
+
+  def concat(new); end
+
+  def encode_with(coder); end
+
+  def exact?(); end
+
+  def for_lockfile(); end
+
+  def init_with(coder); end
+
+  def initialize(*requirements); end
+
+  def marshal_dump(); end
+
+  def marshal_load(array); end
+
+  def none?(); end
+
+  def prerelease?(); end
+
+  def requirements(); end
+
+  def satisfied_by?(version); end
+
+  def specific?(); end
+
+  def to_yaml_properties(); end
+
+  def yaml_initialize(tag, vals); end
+  DefaultRequirement = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Requirement
+  def self.create(*inputs); end
+
+  def self.default(); end
+
+  def self.parse(obj); end
+
+  def self.source_set(); end
+end
+
+class Gem::Resolver
+  include ::Gem::Resolver::Molinillo::UI
+  include ::Gem::Resolver::Molinillo::SpecificationProvider
+  def activation_request(dep, possible); end
+
+  def development(); end
+
+  def development=(development); end
+
+  def development_shallow(); end
+
+  def development_shallow=(development_shallow); end
+
+  def explain(stage, *data); end
+
+  def explain_list(stage); end
+
+  def find_possible(dependency); end
+
+  def ignore_dependencies(); end
+
+  def ignore_dependencies=(ignore_dependencies); end
+
+  def initialize(needed, set=T.unsafe(nil)); end
+
+  def missing(); end
+
+  def requests(s, act, reqs=T.unsafe(nil)); end
+
+  def resolve(); end
+
+  def select_local_platforms(specs); end
+
+  def skip_gems(); end
+
+  def skip_gems=(skip_gems); end
+
+  def soft_missing(); end
+
+  def soft_missing=(soft_missing); end
+
+  def stats(); end
+  DEBUG_RESOLVER = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Resolver::APISet
+  def dep_uri(); end
+
+  def initialize(dep_uri=T.unsafe(nil)); end
+
+  def prefetch_now(); end
+
+  def source(); end
+
+  def uri(); end
+
+  def versions(name); end
+end
+
+class Gem::Resolver::APISet
+end
+
+class Gem::Resolver::APISpecification
+  def ==(other); end
+
+  def initialize(set, api_data); end
+end
+
+class Gem::Resolver::APISpecification
+end
+
+class Gem::Resolver::ActivationRequest
+  def ==(other); end
+
+  def development?(); end
+
+  def download(path); end
+
+  def full_name(); end
+
+  def full_spec(); end
+
+  def initialize(spec, request, others_possible=T.unsafe(nil)); end
+
+  def installed?(); end
+
+  def name(); end
+
+  def others_possible?(); end
+
+  def parent(); end
+
+  def request(); end
+
+  def spec(); end
+
+  def version(); end
+end
+
+class Gem::Resolver::ActivationRequest
+end
+
+class Gem::Resolver::BestSet
+  def initialize(sources=T.unsafe(nil)); end
+
+  def pick_sets(); end
+
+  def replace_failed_api_set(error); end
+end
+
+class Gem::Resolver::BestSet
+end
+
+class Gem::Resolver::ComposedSet
+  def initialize(*sets); end
+
+  def prerelease=(allow_prerelease); end
+
+  def remote=(remote); end
+
+  def sets(); end
+end
+
+class Gem::Resolver::ComposedSet
+end
+
+class Gem::Resolver::Conflict
+  def ==(other); end
+
+  def activated(); end
+
+  def conflicting_dependencies(); end
+
+  def dependency(); end
+
+  def explain(); end
+
+  def explanation(); end
+
+  def failed_dep(); end
+
+  def for_spec?(spec); end
+
+  def initialize(dependency, activated, failed_dep=T.unsafe(nil)); end
+
+  def request_path(current); end
+
+  def requester(); end
+end
+
+class Gem::Resolver::Conflict
+end
+
+class Gem::Resolver::CurrentSet
+end
+
+class Gem::Resolver::CurrentSet
+end
+
+Gem::Resolver::DependencyConflict = Gem::Resolver::Conflict
+
+class Gem::Resolver::DependencyRequest
+  def ==(other); end
+
+  def dependency(); end
+
+  def development?(); end
+
+  def explicit?(); end
+
+  def implicit?(); end
+
+  def initialize(dependency, requester); end
+
+  def match?(spec, allow_prerelease=T.unsafe(nil)); end
+
+  def matches_spec?(spec); end
+
+  def name(); end
+
+  def request_context(); end
+
+  def requester(); end
+
+  def requirement(); end
+
+  def type(); end
+end
+
+class Gem::Resolver::DependencyRequest
+end
+
+class Gem::Resolver::GitSet
+  def add_git_gem(name, repository, reference, submodules); end
+
+  def add_git_spec(name, version, repository, reference, submodules); end
+
+  def need_submodules(); end
+
+  def repositories(); end
+
+  def root_dir(); end
+
+  def root_dir=(root_dir); end
+
+  def specs(); end
+end
+
+class Gem::Resolver::GitSet
+end
+
+class Gem::Resolver::GitSpecification
+  def ==(other); end
+
+  def add_dependency(dependency); end
+end
+
+class Gem::Resolver::GitSpecification
+end
+
+class Gem::Resolver::IndexSet
+  def initialize(source=T.unsafe(nil)); end
+end
+
+class Gem::Resolver::IndexSet
+end
+
+class Gem::Resolver::IndexSpecification
+  def initialize(set, name, version, source, platform); end
+end
+
+class Gem::Resolver::IndexSpecification
+end
+
+class Gem::Resolver::InstalledSpecification
+  def ==(other); end
+end
+
+class Gem::Resolver::InstalledSpecification
+end
+
+class Gem::Resolver::InstallerSet
+  def add_always_install(dependency); end
+
+  def add_local(dep_name, spec, source); end
+
+  def always_install(); end
+
+  def consider_local?(); end
+
+  def consider_remote?(); end
+
+  def ignore_dependencies(); end
+
+  def ignore_dependencies=(ignore_dependencies); end
+
+  def ignore_installed(); end
+
+  def ignore_installed=(ignore_installed); end
+
+  def initialize(domain); end
+
+  def load_spec(name, ver, platform, source); end
+
+  def local?(dep_name); end
+
+  def prerelease=(allow_prerelease); end
+
+  def remote=(remote); end
+
+  def remote_set(); end
+end
+
+class Gem::Resolver::InstallerSet
+end
+
+class Gem::Resolver::LocalSpecification
+end
+
+class Gem::Resolver::LocalSpecification
+end
+
+class Gem::Resolver::LockSet
+  def add(name, version, platform); end
+
+  def initialize(sources); end
+
+  def load_spec(name, version, platform, source); end
+
+  def specs(); end
+end
+
+class Gem::Resolver::LockSet
+end
+
+class Gem::Resolver::LockSpecification
+  def add_dependency(dependency); end
+
+  def initialize(set, name, version, sources, platform); end
+
+  def sources(); end
+end
+
+class Gem::Resolver::LockSpecification
+end
+
+module Gem::Resolver::Molinillo
+  VERSION = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Resolver::Molinillo::CircularDependencyError
+  def dependencies(); end
+
+  def initialize(nodes); end
+end
+
+class Gem::Resolver::Molinillo::CircularDependencyError
+end
+
+module Gem::Resolver::Molinillo::Delegates
+end
+
+module Gem::Resolver::Molinillo::Delegates::ResolutionState
+  def activated(); end
+
+  def conflicts(); end
+
+  def depth(); end
+
+  def name(); end
+
+  def possibilities(); end
+
+  def requirement(); end
+
+  def requirements(); end
+end
+
+module Gem::Resolver::Molinillo::Delegates::ResolutionState
+end
+
+module Gem::Resolver::Molinillo::Delegates::SpecificationProvider
+  def allow_missing?(dependency); end
+
+  def dependencies_for(specification); end
+
+  def name_for(dependency); end
+
+  def name_for_explicit_dependency_source(); end
+
+  def name_for_locking_dependency_source(); end
+
+  def requirement_satisfied_by?(requirement, activated, spec); end
+
+  def search_for(dependency); end
+
+  def sort_dependencies(dependencies, activated, conflicts); end
+end
+
+module Gem::Resolver::Molinillo::Delegates::SpecificationProvider
+end
+
+module Gem::Resolver::Molinillo::Delegates
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph
+  include ::Enumerable
+  include ::TSort
+  def ==(other); end
+
+  def add_child_vertex(name, payload, parent_names, requirement); end
+
+  def add_edge(origin, destination, requirement); end
+
+  def add_vertex(name, payload, root=T.unsafe(nil)); end
+
+  def delete_edge(edge); end
+
+  def detach_vertex_named(name); end
+
+  def each(&blk); end
+
+  def log(); end
+
+  def rewind_to(tag); end
+
+  def root_vertex_named(name); end
+
+  def set_payload(name, payload); end
+
+  def tag(tag); end
+
+  def to_dot(options=T.unsafe(nil)); end
+
+  def tsort_each_child(vertex, &block); end
+
+  def vertex_named(name); end
+
+  def vertices(); end
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::Action
+  def down(graph); end
+
+  def next(); end
+
+  def next=(_); end
+
+  def previous(); end
+
+  def previous=(previous); end
+
+  def up(graph); end
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::Action
+  def self.action_name(); end
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::AddEdgeNoCircular
+  def destination(); end
+
+  def initialize(origin, destination, requirement); end
+
+  def make_edge(graph); end
+
+  def origin(); end
+
+  def requirement(); end
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::AddEdgeNoCircular
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::AddVertex
+  def initialize(name, payload, root); end
+
+  def name(); end
+
+  def payload(); end
+
+  def root(); end
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::AddVertex
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::DeleteEdge
+  def destination_name(); end
+
+  def initialize(origin_name, destination_name, requirement); end
+
+  def make_edge(graph); end
+
+  def origin_name(); end
+
+  def requirement(); end
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::DeleteEdge
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::DetachVertexNamed
+  def initialize(name); end
+
+  def name(); end
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::DetachVertexNamed
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::Edge
+  def destination(); end
+
+  def destination=(_); end
+
+  def origin(); end
+
+  def origin=(_); end
+
+  def requirement(); end
+
+  def requirement=(_); end
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::Edge
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::Log
+  def add_edge_no_circular(graph, origin, destination, requirement); end
+
+  def add_vertex(graph, name, payload, root); end
+
+  def delete_edge(graph, origin_name, destination_name, requirement); end
+
+  def detach_vertex_named(graph, name); end
+
+  def each(&blk); end
+
+  def pop!(graph); end
+
+  def reverse_each(); end
+
+  def rewind_to(graph, tag); end
+
+  def set_payload(graph, name, payload); end
+
+  def tag(graph, tag); end
 end
 
 class Gem::Resolver::Molinillo::DependencyGraph::Log
   extend ::Enumerable
 end
 
+class Gem::Resolver::Molinillo::DependencyGraph::SetPayload
+  def initialize(name, payload); end
+
+  def name(); end
+
+  def payload(); end
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::SetPayload
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::Tag
+  def down(_graph); end
+
+  def initialize(tag); end
+
+  def tag(); end
+
+  def up(_graph); end
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::Tag
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::Vertex
+  def ==(other); end
+
+  def ancestor?(other); end
+
+  def descendent?(other); end
+
+  def eql?(other); end
+
+  def explicit_requirements(); end
+
+  def incoming_edges(); end
+
+  def incoming_edges=(incoming_edges); end
+
+  def initialize(name, payload); end
+
+  def is_reachable_from?(other); end
+
+  def name(); end
+
+  def name=(name); end
+
+  def outgoing_edges(); end
+
+  def outgoing_edges=(outgoing_edges); end
+
+  def path_to?(other); end
+
+  def payload(); end
+
+  def payload=(payload); end
+
+  def predecessors(); end
+
+  def recursive_predecessors(); end
+
+  def recursive_successors(); end
+
+  def requirements(); end
+
+  def root(); end
+
+  def root=(root); end
+
+  def root?(); end
+
+  def shallow_eql?(other); end
+
+  def successors(); end
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph::Vertex
+end
+
+class Gem::Resolver::Molinillo::DependencyGraph
+  def self.tsort(vertices); end
+end
+
+class Gem::Resolver::Molinillo::DependencyState
+  def pop_possibility_state(); end
+end
+
+class Gem::Resolver::Molinillo::DependencyState
+end
+
+class Gem::Resolver::Molinillo::NoSuchDependencyError
+  def dependency(); end
+
+  def dependency=(dependency); end
+
+  def initialize(dependency, required_by=T.unsafe(nil)); end
+
+  def required_by(); end
+
+  def required_by=(required_by); end
+end
+
+class Gem::Resolver::Molinillo::NoSuchDependencyError
+end
+
+class Gem::Resolver::Molinillo::PossibilityState
+end
+
+class Gem::Resolver::Molinillo::PossibilityState
+end
+
+class Gem::Resolver::Molinillo::ResolutionState
+  def activated(); end
+
+  def activated=(_); end
+
+  def conflicts(); end
+
+  def conflicts=(_); end
+
+  def depth(); end
+
+  def depth=(_); end
+
+  def name(); end
+
+  def name=(_); end
+
+  def possibilities(); end
+
+  def possibilities=(_); end
+
+  def requirement(); end
+
+  def requirement=(_); end
+
+  def requirements(); end
+
+  def requirements=(_); end
+end
+
+class Gem::Resolver::Molinillo::ResolutionState
+  def self.[](*_); end
+
+  def self.empty(); end
+
+  def self.members(); end
+end
+
+class Gem::Resolver::Molinillo::Resolver
+  def initialize(specification_provider, resolver_ui); end
+
+  def resolve(requested, base=T.unsafe(nil)); end
+
+  def resolver_ui(); end
+
+  def specification_provider(); end
+end
+
+class Gem::Resolver::Molinillo::Resolver::Resolution
+  include ::Gem::Resolver::Molinillo::Delegates::ResolutionState
+  include ::Gem::Resolver::Molinillo::Delegates::SpecificationProvider
+  def base(); end
+
+  def initialize(specification_provider, resolver_ui, requested, base); end
+
+  def iteration_rate=(iteration_rate); end
+
+  def original_requested(); end
+
+  def resolve(); end
+
+  def resolver_ui(); end
+
+  def specification_provider(); end
+
+  def started_at=(started_at); end
+
+  def states=(states); end
+end
+
+class Gem::Resolver::Molinillo::Resolver::Resolution::Conflict
+  def activated_by_name(); end
+
+  def activated_by_name=(_); end
+
+  def existing(); end
+
+  def existing=(_); end
+
+  def locked_requirement(); end
+
+  def locked_requirement=(_); end
+
+  def possibility(); end
+
+  def possibility=(_); end
+
+  def requirement(); end
+
+  def requirement=(_); end
+
+  def requirement_trees(); end
+
+  def requirement_trees=(_); end
+
+  def requirements(); end
+
+  def requirements=(_); end
+end
+
+class Gem::Resolver::Molinillo::Resolver::Resolution::Conflict
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class Gem::Resolver::Molinillo::Resolver::Resolution
+end
+
+class Gem::Resolver::Molinillo::Resolver
+end
+
+class Gem::Resolver::Molinillo::ResolverError
+end
+
+class Gem::Resolver::Molinillo::ResolverError
+end
+
+module Gem::Resolver::Molinillo::SpecificationProvider
+  def allow_missing?(dependency); end
+
+  def dependencies_for(specification); end
+
+  def name_for(dependency); end
+
+  def name_for_explicit_dependency_source(); end
+
+  def name_for_locking_dependency_source(); end
+
+  def requirement_satisfied_by?(requirement, activated, spec); end
+
+  def search_for(dependency); end
+
+  def sort_dependencies(dependencies, activated, conflicts); end
+end
+
+module Gem::Resolver::Molinillo::SpecificationProvider
+end
+
+module Gem::Resolver::Molinillo::UI
+  def after_resolution(); end
+
+  def before_resolution(); end
+
+  def debug(depth=T.unsafe(nil)); end
+
+  def debug?(); end
+
+  def indicate_progress(); end
+
+  def output(); end
+
+  def progress_rate(); end
+end
+
+module Gem::Resolver::Molinillo::UI
+end
+
+class Gem::Resolver::Molinillo::VersionConflict
+  def conflicts(); end
+
+  def initialize(conflicts); end
+end
+
+class Gem::Resolver::Molinillo::VersionConflict
+end
+
+module Gem::Resolver::Molinillo
+end
+
+class Gem::Resolver::RequirementList
+  include ::Enumerable
+  def add(req); end
+
+  def each(&blk); end
+
+  def empty?(); end
+
+  def next5(); end
+
+  def remove(); end
+
+  def size(); end
+end
+
+class Gem::Resolver::RequirementList
+end
+
+class Gem::Resolver::Set
+  def errors(); end
+
+  def errors=(errors); end
+
+  def find_all(req); end
+
+  def prefetch(reqs); end
+
+  def prerelease(); end
+
+  def prerelease=(prerelease); end
+
+  def remote(); end
+
+  def remote=(remote); end
+
+  def remote?(); end
+end
+
+class Gem::Resolver::Set
+end
+
+class Gem::Resolver::SourceSet
+  def add_source_gem(name, source); end
+end
+
+class Gem::Resolver::SourceSet
+end
+
+class Gem::Resolver::SpecSpecification
+  def initialize(set, spec, source=T.unsafe(nil)); end
+end
+
+class Gem::Resolver::SpecSpecification
+end
+
+class Gem::Resolver::Specification
+  def dependencies(); end
+
+  def fetch_development_dependencies(); end
+
+  def full_name(); end
+
+  def install(options=T.unsafe(nil)); end
+
+  def installable_platform?(); end
+
+  def local?(); end
+
+  def name(); end
+
+  def platform(); end
+
+  def set(); end
+
+  def source(); end
+
+  def spec(); end
+
+  def version(); end
+end
+
+class Gem::Resolver::Specification
+end
+
+class Gem::Resolver::Stats
+  def backtracking!(); end
+
+  def display(); end
+
+  def iteration!(); end
+
+  def record_depth(stack); end
+
+  def record_requirements(reqs); end
+
+  def requirement!(); end
+  PATTERN = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Resolver::Stats
+end
+
+class Gem::Resolver::VendorSet
+  def add_vendor_gem(name, directory); end
+
+  def load_spec(name, version, platform, source); end
+
+  def specs(); end
+end
+
+class Gem::Resolver::VendorSet
+end
+
+class Gem::Resolver::VendorSpecification
+  def ==(other); end
+end
+
+class Gem::Resolver::VendorSpecification
+end
+
+class Gem::Resolver
+  def self.compose_sets(*sets); end
+
+  def self.for_current_gems(needed); end
+end
+
+class Gem::RuntimeRequirementNotMetError
+  def suggestion(); end
+
+  def suggestion=(suggestion); end
+end
+
+class Gem::RuntimeRequirementNotMetError
+end
+
+module Gem::Security
+  AlmostNoSecurity = ::T.let(nil, ::T.untyped)
+  DIGEST_NAME = ::T.let(nil, ::T.untyped)
+  EXTENSIONS = ::T.let(nil, ::T.untyped)
+  HighSecurity = ::T.let(nil, ::T.untyped)
+  KEY_CIPHER = ::T.let(nil, ::T.untyped)
+  KEY_LENGTH = ::T.let(nil, ::T.untyped)
+  LowSecurity = ::T.let(nil, ::T.untyped)
+  MediumSecurity = ::T.let(nil, ::T.untyped)
+  NoSecurity = ::T.let(nil, ::T.untyped)
+  ONE_DAY = ::T.let(nil, ::T.untyped)
+  ONE_YEAR = ::T.let(nil, ::T.untyped)
+  Policies = ::T.let(nil, ::T.untyped)
+  SigningPolicy = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Security::DIGEST_ALGORITHM
+  def initialize(data=T.unsafe(nil)); end
+end
+
+class Gem::Security::DIGEST_ALGORITHM
+  def self.digest(data); end
+
+  def self.hexdigest(data); end
+end
+
+class Gem::Security::Exception
+end
+
+class Gem::Security::Exception
+end
+
+class Gem::Security::KEY_ALGORITHM
+  def d(); end
+
+  def d=(d); end
+
+  def dmp1(); end
+
+  def dmp1=(dmp1); end
+
+  def dmq1(); end
+
+  def dmq1=(dmq1); end
+
+  def e(); end
+
+  def e=(e); end
+
+  def export(*_); end
+
+  def initialize(*_); end
+
+  def iqmp(); end
+
+  def iqmp=(iqmp); end
+
+  def n(); end
+
+  def n=(n); end
+
+  def p(); end
+
+  def p=(p); end
+
+  def params(); end
+
+  def private?(); end
+
+  def private_decrypt(*_); end
+
+  def private_encrypt(*_); end
+
+  def public?(); end
+
+  def public_decrypt(*_); end
+
+  def public_encrypt(*_); end
+
+  def public_key(); end
+
+  def q(); end
+
+  def q=(q); end
+
+  def set_crt_params(_, _1, _2); end
+
+  def set_factors(_, _1); end
+
+  def set_key(_, _1, _2); end
+
+  def sign_pss(*_); end
+
+  def to_der(); end
+
+  def to_pem(*_); end
+
+  def to_s(*_); end
+
+  def to_text(); end
+
+  def verify_pss(*_); end
+  NO_PADDING = ::T.let(nil, ::T.untyped)
+  PKCS1_OAEP_PADDING = ::T.let(nil, ::T.untyped)
+  PKCS1_PADDING = ::T.let(nil, ::T.untyped)
+  SSLV23_PADDING = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Security::KEY_ALGORITHM
+  def self.generate(*_); end
+end
+
+class Gem::Security::Policy
+  include ::Gem::UserInteraction
+  include ::Gem::DefaultUserInteraction
+  def check_cert(signer, issuer, time); end
+
+  def check_chain(chain, time); end
+
+  def check_data(public_key, digest, signature, data); end
+
+  def check_key(signer, key); end
+
+  def check_root(chain, time); end
+
+  def check_trust(chain, digester, trust_dir); end
+
+  def initialize(name, policy=T.unsafe(nil), opt=T.unsafe(nil)); end
+
+  def name(); end
+
+  def only_signed(); end
+
+  def only_signed=(only_signed); end
+
+  def only_trusted(); end
+
+  def only_trusted=(only_trusted); end
+
+  def subject(certificate); end
+
+  def verify(chain, key=T.unsafe(nil), digests=T.unsafe(nil), signatures=T.unsafe(nil), full_name=T.unsafe(nil)); end
+
+  def verify_chain(); end
+
+  def verify_chain=(verify_chain); end
+
+  def verify_data(); end
+
+  def verify_data=(verify_data); end
+
+  def verify_root(); end
+
+  def verify_root=(verify_root); end
+
+  def verify_signatures(spec, digests, signatures); end
+
+  def verify_signer(); end
+
+  def verify_signer=(verify_signer); end
+end
+
+class Gem::Security::Policy
+end
+
+class Gem::Security::Signer
+  def cert_chain(); end
+
+  def cert_chain=(cert_chain); end
+
+  def digest_algorithm(); end
+
+  def digest_name(); end
+
+  def extract_name(cert); end
+
+  def initialize(key, cert_chain, passphrase=T.unsafe(nil)); end
+
+  def key(); end
+
+  def key=(key); end
+
+  def load_cert_chain(); end
+
+  def re_sign_key(); end
+
+  def sign(data); end
+end
+
+class Gem::Security::Signer
+end
+
+class Gem::Security::TrustDir
+  def cert_path(certificate); end
+
+  def dir(); end
+
+  def each_certificate(); end
+
+  def initialize(dir, permissions=T.unsafe(nil)); end
+
+  def issuer_of(certificate); end
+
+  def load_certificate(certificate_file); end
+
+  def name_path(name); end
+
+  def trust_cert(certificate); end
+
+  def verify(); end
+  DEFAULT_PERMISSIONS = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Security::TrustDir
+end
+
+module Gem::Security
+  def self.alt_name_or_x509_entry(certificate, x509_entry); end
+
+  def self.create_cert(subject, key, age=T.unsafe(nil), extensions=T.unsafe(nil), serial=T.unsafe(nil)); end
+
+  def self.create_cert_email(email, key, age=T.unsafe(nil), extensions=T.unsafe(nil)); end
+
+  def self.create_cert_self_signed(subject, key, age=T.unsafe(nil), extensions=T.unsafe(nil), serial=T.unsafe(nil)); end
+
+  def self.create_key(length=T.unsafe(nil), algorithm=T.unsafe(nil)); end
+
+  def self.email_to_name(email_address); end
+
+  def self.re_sign(expired_certificate, private_key, age=T.unsafe(nil), extensions=T.unsafe(nil)); end
+
+  def self.reset(); end
+
+  def self.sign(certificate, signing_key, signing_cert, age=T.unsafe(nil), extensions=T.unsafe(nil), serial=T.unsafe(nil)); end
+
+  def self.trust_dir(); end
+
+  def self.trusted_certificates(&block); end
+
+  def self.write(pemmable, path, permissions=T.unsafe(nil), passphrase=T.unsafe(nil), cipher=T.unsafe(nil)); end
+end
+
+class Gem::SilentUI
+  def initialize(); end
+end
+
+class Gem::SilentUI
+end
+
+class Gem::Source
+  include ::Comparable
+  def ==(other); end
+
+  def api_uri(); end
+
+  def cache_dir(uri); end
+
+  def dependency_resolver_set(); end
+
+  def download(spec, dir=T.unsafe(nil)); end
+
+  def eql?(other); end
+
+  def fetch_spec(name_tuple); end
+
+  def initialize(uri); end
+
+  def load_specs(type); end
+
+  def update_cache?(); end
+
+  def uri(); end
+  FILES = ::T.let(nil, ::T.untyped)
+end
+
+class Gem::Source::Git
+  def base_dir(); end
+
+  def cache(); end
+
+  def checkout(); end
+
+  def dir_shortref(); end
+
+  def download(full_spec, path); end
+
+  def initialize(name, repository, reference, submodules=T.unsafe(nil)); end
+
+  def install_dir(); end
+
+  def name(); end
+
+  def need_submodules(); end
+
+  def reference(); end
+
+  def remote(); end
+
+  def remote=(remote); end
+
+  def repo_cache_dir(); end
+
+  def repository(); end
+
+  def rev_parse(); end
+
+  def root_dir(); end
+
+  def root_dir=(root_dir); end
+
+  def specs(); end
+
+  def uri_hash(); end
+end
+
+class Gem::Source::Git
+end
+
+class Gem::Source::Installed
+  def download(spec, path); end
+
+  def initialize(); end
+end
+
+class Gem::Source::Installed
+end
+
+class Gem::Source::Local
+  def download(spec, cache_dir=T.unsafe(nil)); end
+
+  def fetch_spec(name); end
+
+  def find_gem(gem_name, version=T.unsafe(nil), prerelease=T.unsafe(nil)); end
+
+  def initialize(); end
+end
+
+class Gem::Source::Local
+end
+
+class Gem::Source::Lock
+  def initialize(source); end
+
+  def wrapped(); end
+end
+
+class Gem::Source::Lock
+end
+
+class Gem::Source::SpecificFile
+  def fetch_spec(name); end
+
+  def initialize(file); end
+
+  def load_specs(*a); end
+
+  def path(); end
+
+  def spec(); end
+end
+
+class Gem::Source::SpecificFile
+end
+
+class Gem::Source::Vendor
+  def initialize(path); end
+end
+
+class Gem::Source::Vendor
+end
+
+class Gem::Source
+end
+
+class Gem::SourceFetchProblem
+  def error(); end
+
+  def exception(); end
+
+  def initialize(source, error); end
+
+  def source(); end
+
+  def wordy(); end
+end
+
+class Gem::SourceList
+  include ::Enumerable
+  def <<(obj); end
+
+  def ==(other); end
+
+  def clear(); end
+
+  def delete(source); end
+
+  def each(&blk); end
+
+  def each_source(&b); end
+
+  def empty?(); end
+
+  def first(); end
+
+  def include?(other); end
+
+  def replace(other); end
+
+  def sources(); end
+
+  def to_a(); end
+
+  def to_ary(); end
+end
+
+class Gem::SourceList
+  def self.from(ary); end
+end
+
+class Gem::SpecFetcher
+  include ::Gem::UserInteraction
+  include ::Gem::DefaultUserInteraction
+  include ::Gem::Text
+  def available_specs(type); end
+
+  def detect(type=T.unsafe(nil)); end
+
+  def initialize(sources=T.unsafe(nil)); end
+
+  def latest_specs(); end
+
+  def prerelease_specs(); end
+
+  def search_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
+
+  def sources(); end
+
+  def spec_for_dependency(dependency, matching_platform=T.unsafe(nil)); end
+
+  def specs(); end
+
+  def suggest_gems_from_name(gem_name, type=T.unsafe(nil)); end
+
+  def tuples_for(source, type, gracefully_ignore=T.unsafe(nil)); end
+end
+
+class Gem::SpecFetcher
+  def self.fetcher(); end
+
+  def self.fetcher=(fetcher); end
+end
+
+class Gem::SpecificGemNotFoundException
+  def errors(); end
+
+  def initialize(name, version, errors=T.unsafe(nil)); end
+
+  def name(); end
+
+  def version(); end
+end
+
+class Gem::Specification
+  include ::Bundler::MatchPlatform
+  include ::Bundler::GemHelpers
+  def ==(other); end
+
+  def _dump(limit); end
+
+  def abbreviate(); end
+
+  def activate(); end
+
+  def activate_dependencies(); end
+
+  def activated(); end
+
+  def activated=(activated); end
+
+  def add_bindir(executables); end
+
+  def add_dependency(gem, *requirements); end
+
+  def add_development_dependency(gem, *requirements); end
+
+  def add_runtime_dependency(gem, *requirements); end
+
+  def add_self_to_load_path(); end
+
+  def author(); end
+
+  def author=(o); end
+
+  def authors(); end
+
+  def authors=(value); end
+
+  def autorequire(); end
+
+  def autorequire=(autorequire); end
+
+  def bin_dir(); end
+
+  def bin_file(name); end
+
+  def bindir(); end
+
+  def bindir=(bindir); end
+
+  def build_args(); end
+
+  def build_extensions(); end
+
+  def build_info_dir(); end
+
+  def build_info_file(); end
+
+  def bundled_gem_in_old_ruby?(); end
+
+  def cache_dir(); end
+
+  def cache_file(); end
+
+  def cert_chain(); end
+
+  def cert_chain=(cert_chain); end
+
+  def conficts_when_loaded_with?(list_of_specs); end
+
+  def conflicts(); end
+
+  def date(); end
+
+  def date=(date); end
+
+  def default_executable(); end
+
+  def default_executable=(default_executable); end
+
+  def default_value(name); end
+
+  def dependencies(); end
+
+  def dependent_gems(); end
+
+  def dependent_specs(); end
+
+  def description(); end
+
+  def description=(str); end
+
+  def development_dependencies(); end
+
+  def doc_dir(type=T.unsafe(nil)); end
+
+  def email(); end
+
+  def email=(email); end
+
+  def encode_with(coder); end
+
+  def eql?(other); end
+
+  def executable(); end
+
+  def executable=(o); end
+
+  def executables(); end
+
+  def executables=(value); end
+
+  def extensions(); end
+
+  def extensions=(extensions); end
+
+  def extra_rdoc_files(); end
+
+  def extra_rdoc_files=(files); end
+
+  def file_name(); end
+
+  def files(); end
+
+  def files=(files); end
+
+  def for_cache(); end
+
+  def git_version(); end
+
+  def groups(); end
+
+  def has_conflicts?(); end
+
+  def has_rdoc(); end
+
+  def has_rdoc=(ignored); end
+
+  def has_rdoc?(); end
+
+  def has_test_suite?(); end
+
+  def has_unit_tests?(); end
+
+  def homepage(); end
+
+  def homepage=(homepage); end
+
+  def init_with(coder); end
+
+  def initialize(name=T.unsafe(nil), version=T.unsafe(nil)); end
+
+  def installed_by_version(); end
+
+  def installed_by_version=(version); end
+
+  def lib_files(); end
+
+  def license(); end
+
+  def license=(o); end
+
+  def licenses(); end
+
+  def licenses=(licenses); end
+
+  def load_paths(); end
+
+  def location(); end
+
+  def location=(location); end
+
+  def mark_version(); end
+
+  def metadata(); end
+
+  def metadata=(metadata); end
+
+  def method_missing(sym, *a, &b); end
+
+  def missing_extensions?(); end
+
+  def name=(name); end
+
+  def name_tuple(); end
+
+  def nondevelopment_dependencies(); end
+
+  def normalize(); end
+
+  def original_name(); end
+
+  def original_platform(); end
+
+  def original_platform=(original_platform); end
+
+  def platform=(platform); end
+
+  def post_install_message(); end
+
+  def post_install_message=(post_install_message); end
+
+  def raise_if_conflicts(); end
+
+  def rdoc_options(); end
+
+  def rdoc_options=(options); end
+
+  def relative_loaded_from(); end
+
+  def relative_loaded_from=(relative_loaded_from); end
+
+  def remote(); end
+
+  def remote=(remote); end
+
+  def require_path(); end
+
+  def require_path=(path); end
+
+  def require_paths=(val); end
+
+  def required_ruby_version(); end
+
+  def required_ruby_version=(req); end
+
+  def required_rubygems_version(); end
+
+  def required_rubygems_version=(req); end
+
+  def requirements(); end
+
+  def requirements=(req); end
+
+  def reset_nil_attributes_to_default(); end
+
+  def rg_extension_dir(); end
+
+  def rg_full_gem_path(); end
+
+  def rg_loaded_from(); end
+
+  def ri_dir(); end
+
+  def rubyforge_project(); end
+
+  def rubyforge_project=(rubyforge_project); end
+
+  def rubygems_version(); end
+
+  def rubygems_version=(rubygems_version); end
+
+  def runtime_dependencies(); end
+
+  def sanitize(); end
+
+  def sanitize_string(string); end
+
+  def satisfies_requirement?(dependency); end
+
+  def signing_key(); end
+
+  def signing_key=(signing_key); end
+
+  def sort_obj(); end
+
+  def source(); end
+
+  def source=(source); end
+
+  def spec_dir(); end
+
+  def spec_file(); end
+
+  def spec_name(); end
+
+  def specification_version(); end
+
+  def specification_version=(specification_version); end
+
+  def summary(); end
+
+  def summary=(str); end
+
+  def test_file(); end
+
+  def test_file=(file); end
+
+  def test_files(); end
+
+  def test_files=(files); end
+
+  def to_gemfile(path=T.unsafe(nil)); end
+
+  def to_ruby(); end
+
+  def to_ruby_for_cache(); end
+
+  def to_yaml(opts=T.unsafe(nil)); end
+
+  def traverse(trail=T.unsafe(nil), visited=T.unsafe(nil), &block); end
+
+  def validate(packaging=T.unsafe(nil)); end
+
+  def validate_dependencies(); end
+
+  def validate_metadata(); end
+
+  def validate_permissions(); end
+
+  def version=(version); end
+
+  def warning(statement); end
+
+  def yaml_initialize(tag, vals); end
+  DateLike = ::T.let(nil, ::T.untyped)
+  DateTimeFormat = ::T.let(nil, ::T.untyped)
+  INITIALIZE_CODE_FOR_DEFAULTS = ::T.let(nil, ::T.untyped)
+end
+
 class Gem::Specification
   extend ::Enumerable
+  extend ::Gem::Deprecate
+  def self._all(); end
+
+  def self._clear_load_cache(); end
+
+  def self._latest_specs(specs, prerelease=T.unsafe(nil)); end
+
+  def self._load(str); end
+
+  def self._resort!(specs); end
+
+  def self.add_spec(spec); end
+
+  def self.add_specs(*specs); end
+
+  def self.all(); end
+
+  def self.all=(specs); end
+
+  def self.all_names(); end
+
+  def self.array_attributes(); end
+
+  def self.attribute_names(); end
+
+  def self.dirs(); end
+
+  def self.dirs=(dirs); end
+
+  def self.each(&blk); end
+
+  def self.each_gemspec(dirs); end
+
+  def self.each_spec(dirs); end
+
+  def self.find_active_stub_by_path(path); end
+
+  def self.find_all_by_full_name(full_name); end
+
+  def self.find_all_by_name(name, *requirements); end
+
+  def self.find_by_name(name, *requirements); end
+
+  def self.find_by_path(path); end
+
+  def self.find_in_unresolved(path); end
+
+  def self.find_in_unresolved_tree(path); end
+
+  def self.find_inactive_by_path(path); end
+
+  def self.from_yaml(input); end
+
+  def self.latest_specs(prerelease=T.unsafe(nil)); end
+
+  def self.load(file); end
+
+  def self.load_defaults(); end
+
+  def self.non_nil_attributes(); end
+
+  def self.normalize_yaml_input(input); end
+
+  def self.outdated(); end
+
+  def self.outdated_and_latest_version(); end
+
+  def self.remove_spec(spec); end
+
+  def self.required_attribute?(name); end
+
+  def self.required_attributes(); end
+
+  def self.reset(); end
+
+  def self.stubs(); end
+
+  def self.stubs_for(name); end
+
+  def self.unresolved_deps(); end
+end
+
+class Gem::StreamUI
+  def _gets_noecho(); end
+
+  def alert(statement, question=T.unsafe(nil)); end
+
+  def alert_error(statement, question=T.unsafe(nil)); end
+
+  def alert_warning(statement, question=T.unsafe(nil)); end
+
+  def ask(question); end
+
+  def ask_for_password(question); end
+
+  def ask_yes_no(question, default=T.unsafe(nil)); end
+
+  def backtrace(exception); end
+
+  def choose_from_list(question, list); end
+
+  def close(); end
+
+  def debug(statement); end
+
+  def download_reporter(*args); end
+
+  def errs(); end
+
+  def initialize(in_stream, out_stream, err_stream=T.unsafe(nil), usetty=T.unsafe(nil)); end
+
+  def ins(); end
+
+  def outs(); end
+
+  def progress_reporter(*args); end
+
+  def require_io_console(); end
+
+  def say(statement=T.unsafe(nil)); end
+
+  def terminate_interaction(status=T.unsafe(nil)); end
+
+  def tty?(); end
+end
+
+class Gem::StreamUI
+end
+
+class Gem::StubSpecification
+  def build_extensions(); end
+
+  def extensions(); end
+
+  def initialize(filename, base_dir, gems_dir, default_gem); end
+
+  def missing_extensions?(); end
+
+  def valid?(); end
+end
+
+class Gem::StubSpecification::StubLine
+  def extensions(); end
+
+  def full_name(); end
+
+  def initialize(data, extensions); end
+
+  def name(); end
+
+  def platform(); end
+
+  def require_paths(); end
+
+  def version(); end
+end
+
+class Gem::StubSpecification
+  def self.default_gemspec_stub(filename, base_dir, gems_dir); end
+
+  def self.gemspec_stub(filename, base_dir, gems_dir); end
+end
+
+class Gem::SystemExitException
+  def exit_code(); end
+
+  def exit_code=(exit_code); end
+
+  def initialize(exit_code); end
+end
+
+module Gem::Text
+  def clean_text(text); end
+
+  def format_text(text, wrap, indent=T.unsafe(nil)); end
+
+  def levenshtein_distance(str1, str2); end
+
+  def min3(a, b, c); end
+
+  def truncate_text(text, description, max_length=T.unsafe(nil)); end
+end
+
+module Gem::Text
+end
+
+Gem::UnsatisfiableDepedencyError = Gem::UnsatisfiableDependencyError
+
+class Gem::UnsatisfiableDependencyError
+  def dependency(); end
+
+  def errors(); end
+
+  def errors=(errors); end
+
+  def initialize(dep, platform_mismatch=T.unsafe(nil)); end
+
+  def name(); end
+
+  def version(); end
+end
+
+class Gem::UriFormatter
+  def escape(); end
+
+  def initialize(uri); end
+
+  def normalize(); end
+
+  def unescape(); end
+
+  def uri(); end
+end
+
+class Gem::UriFormatter
+end
+
+module Gem::UserInteraction
+  include ::Gem::DefaultUserInteraction
+  def alert(statement, question=T.unsafe(nil)); end
+
+  def alert_error(statement, question=T.unsafe(nil)); end
+
+  def alert_warning(statement, question=T.unsafe(nil)); end
+
+  def ask(question); end
+
+  def ask_for_password(prompt); end
+
+  def ask_yes_no(question, default=T.unsafe(nil)); end
+
+  def choose_from_list(question, list); end
+
+  def say(statement=T.unsafe(nil)); end
+
+  def terminate_interaction(exit_code=T.unsafe(nil)); end
+
+  def verbose(msg=T.unsafe(nil)); end
+end
+
+module Gem::UserInteraction
+end
+
+module Gem::Util
+  NULL_DEVICE = ::T.let(nil, ::T.untyped)
+end
+
+module Gem::Util
+  def self.gunzip(data); end
+
+  def self.gzip(data); end
+
+  def self.inflate(data); end
+
+  def self.popen(*command); end
+
+  def self.silent_system(*command); end
+
+  def self.traverse_parents(directory, &block); end
+end
+
+class Gem::Version
+  def _segments(); end
+
+  def _split_segments(); end
+
+  def _version(); end
+
+  def approximate_recommendation(); end
+
+  def bump(); end
+
+  def canonical_segments(); end
+
+  def encode_with(coder); end
+
+  def eql?(other); end
+
+  def init_with(coder); end
+
+  def marshal_dump(); end
+
+  def marshal_load(array); end
+
+  def prerelease?(); end
+
+  def release(); end
+
+  def segments(); end
+
+  def to_yaml_properties(); end
+
+  def version(); end
+
+  def yaml_initialize(tag, map); end
+end
+
+Gem::Version::Requirement = Gem::Requirement
+
+class Gem::Version
+  def self.correct?(version); end
+
+  def self.create(input); end
+
+  def self.new(version); end
+end
+
+module Gem
+  def self._deprecated_datadir(gem_name); end
+
+  def self.activate_bin_path(name, *args); end
+
+  def self.default_ext_dir_for(base_dir); end
+
+  def self.default_gems_use_full_paths?(); end
+
+  def self.default_spec_cache_dir(); end
+
+  def self.deflate(data); end
+
+  def self.detect_gemdeps(path=T.unsafe(nil)); end
+
+  def self.dir(); end
+
+  def self.done_installing(&hook); end
+
+  def self.done_installing_hooks(); end
+
+  def self.ensure_default_gem_subdirectories(dir=T.unsafe(nil), mode=T.unsafe(nil)); end
+
+  def self.ensure_gem_subdirectories(dir=T.unsafe(nil), mode=T.unsafe(nil)); end
+
+  def self.ensure_subdirectories(dir, mode, subdirs); end
+
+  def self.env_requirement(gem_name); end
+
+  def self.extension_api_version(); end
+
+  def self.find_files(glob, check_load_path=T.unsafe(nil)); end
+
+  def self.find_files_from_load_path(glob); end
+
+  def self.find_latest_files(glob, check_load_path=T.unsafe(nil)); end
+
+  def self.find_unresolved_default_spec(path); end
+
+  def self.finish_resolve(*_); end
+
+  def self.gemdeps(); end
+
+  def self.gunzip(data); end
+
+  def self.gzip(data); end
+
+  def self.host(); end
+
+  def self.host=(host); end
+
+  def self.inflate(data); end
+
+  def self.install(name, version=T.unsafe(nil), *options); end
+
+  def self.install_extension_in_lib(); end
+
+  def self.latest_rubygems_version(); end
+
+  def self.latest_spec_for(name); end
+
+  def self.latest_version_for(name); end
+
+  def self.load_env_plugins(); end
+
+  def self.load_path_insert_index(); end
+
+  def self.load_plugin_files(plugins); end
+
+  def self.load_plugins(); end
+
+  def self.load_yaml(); end
+
+  def self.loaded_specs(); end
+
+  def self.location_of_caller(depth=T.unsafe(nil)); end
+
+  def self.marshal_version(); end
+
+  def self.needs(); end
+
+  def self.path(); end
+
+  def self.path_separator(); end
+
+  def self.paths(); end
+
+  def self.paths=(env); end
+
+  def self.platform_defaults(); end
+
+  def self.platforms(); end
+
+  def self.platforms=(platforms); end
+
+  def self.post_build(&hook); end
+
+  def self.post_build_hooks(); end
+
+  def self.post_install(&hook); end
+
+  def self.post_install_hooks(); end
+
+  def self.post_reset(&hook); end
+
+  def self.post_reset_hooks(); end
+
+  def self.post_uninstall(&hook); end
+
+  def self.post_uninstall_hooks(); end
+
+  def self.pre_install(&hook); end
+
+  def self.pre_install_hooks(); end
+
+  def self.pre_reset(&hook); end
+
+  def self.pre_reset_hooks(); end
+
+  def self.pre_uninstall(&hook); end
+
+  def self.pre_uninstall_hooks(); end
+
+  def self.prefix(); end
+
+  def self.read_binary(path); end
+
+  def self.refresh(); end
+
+  def self.register_default_spec(spec); end
+
+  def self.remove_unresolved_default_spec(spec); end
+
+  def self.ruby(); end
+
+  def self.ruby_api_version(); end
+
+  def self.ruby_engine(); end
+
+  def self.ruby_version(); end
+
+  def self.rubygems_version(); end
+
+  def self.sources(); end
+
+  def self.sources=(new_sources); end
+
+  def self.spec_cache_dir(); end
+
+  def self.suffix_pattern(); end
+
+  def self.suffixes(); end
+
+  def self.time(msg, width=T.unsafe(nil), display=T.unsafe(nil)); end
+
+  def self.try_activate(path); end
+
+  def self.ui(); end
+
+  def self.use_gemdeps(path=T.unsafe(nil)); end
+
+  def self.use_paths(home, *paths); end
+
+  def self.user_dir(); end
+
+  def self.user_home(); end
+
+  def self.vendor_dir(); end
+
+  def self.win_platform?(); end
+
+  def self.write_binary(path, data); end
 end
 
 class Hash
@@ -1728,13 +8417,11 @@ class Hash
 
   def fetch_values(*_); end
 
-  def filter!(); end
-
   def flatten(*_); end
 
   def index(_); end
 
-  def merge!(*_); end
+  def merge!(_); end
 
   def replace(_); end
 
@@ -1752,7 +8439,7 @@ class Hash
 
   def transform_values!(); end
 
-  def update(*_); end
+  def update(_); end
 end
 
 class Hash
@@ -1795,7 +8482,6 @@ class IO
   def self.foreach(*_); end
 
   def self.pipe(*_); end
-
 end
 
 class IPAddr
@@ -1918,8 +8604,6 @@ class Integer
   def pow(*_); end
 
   def to_bn(); end
-
-  GMP_VERSION = ::T.let(nil, ::T.untyped)
 end
 
 class Integer
@@ -1950,9 +8634,6 @@ module Kernel
   def pretty_inspect(); end
 
   def respond_to?(*_); end
-
-  def then(); end
-
 end
 
 module Kernel
@@ -1978,42 +8659,6 @@ end
 
 module Marshal
   def self.restore(*_); end
-end
-
-class MatchData
-  def named_captures(); end
-end
-
-class Method
-  def <<(_); end
-
-  def ===(*_); end
-
-  def >>(_); end
-
-  def [](*_); end
-
-  def arity(); end
-
-  def clone(); end
-
-  def curry(*_); end
-
-  def name(); end
-
-  def original_name(); end
-
-  def owner(); end
-
-  def parameters(); end
-
-  def receiver(); end
-
-  def source_location(); end
-
-  def super_method(); end
-
-  def unbind(); end
 end
 
 Methods = T::Private::Methods
@@ -2076,8 +8721,6 @@ module MonitorMixin
   def self.extend_object(obj); end
 end
 
-Mutex = Thread::Mutex
-
 class NameError
   include ::DidYouMean::Correctable
   def name(); end
@@ -2091,26 +8734,14 @@ class NilClass
 end
 
 class NoMethodError
-  include ::DidYouMean::Correctable
   def args(); end
 
   def private_call?(); end
 end
 
-class Numeric
-  def finite?(); end
-
-  def infinite?(); end
-
-  def negative?(); end
-
-  def positive?(); end
-
-end
-
 class Object
-  include ::PP::ObjectMixin
   include ::JSON::Ext::Generator::GeneratorMethods::Object
+  include ::PP::ObjectMixin
   ARGF = ::T.let(nil, ::T.untyped)
   ARGV = ::T.let(nil, ::T.untyped)
   CROSS_COMPILING = ::T.let(nil, ::T.untyped)
@@ -2165,80 +8796,48 @@ module ObjectSpace
   def self.undefine_finalizer(_); end
 end
 
-OptParse = OptionParser
-
-class OptionParser
-  def def_head_option(*opts, &block); end
-
-  def def_option(*opts, &block); end
-
-  def def_tail_option(*opts, &block); end
-
-  def set_banner(_); end
-
-  def set_program_name(_); end
-
-  def set_summary_indent(_); end
-
-  def set_summary_width(_); end
-  ArgumentStyle = ::T.let(nil, ::T.untyped)
-  COMPSYS_HEADER = ::T.let(nil, ::T.untyped)
-  DecimalInteger = ::T.let(nil, ::T.untyped)
-  DecimalNumeric = ::T.let(nil, ::T.untyped)
-  DefaultList = ::T.let(nil, ::T.untyped)
-  NO_ARGUMENT = ::T.let(nil, ::T.untyped)
-  NoArgument = ::T.let(nil, ::T.untyped)
-  OPTIONAL_ARGUMENT = ::T.let(nil, ::T.untyped)
-  OctalInteger = ::T.let(nil, ::T.untyped)
-  Officious = ::T.let(nil, ::T.untyped)
-  OptionalArgument = ::T.let(nil, ::T.untyped)
-  REQUIRED_ARGUMENT = ::T.let(nil, ::T.untyped)
-  RequiredArgument = ::T.let(nil, ::T.untyped)
-  SPLAT_PROC = ::T.let(nil, ::T.untyped)
+class Parlour::ConflictResolver
+  extend ::T::Private::Methods::MethodHooks
+  extend ::T::Private::Methods::SingletonMethodHooks
 end
 
-module OptionParser::Acceptables
-  DecimalInteger = ::T.let(nil, ::T.untyped)
-  DecimalNumeric = ::T.let(nil, ::T.untyped)
-  OctalInteger = ::T.let(nil, ::T.untyped)
+module Parlour::Debugging::Tree
+  extend ::T::Private::Methods::MethodHooks
+  extend ::T::Private::Methods::SingletonMethodHooks
 end
 
-class OptionParser::AmbiguousArgument
-  Reason = ::T.let(nil, ::T.untyped)
-end
-
-class OptionParser::AmbiguousOption
-  Reason = ::T.let(nil, ::T.untyped)
-end
-
-class OptionParser::InvalidArgument
-  Reason = ::T.let(nil, ::T.untyped)
-end
-
-class OptionParser::InvalidOption
-  Reason = ::T.let(nil, ::T.untyped)
-end
-
-class OptionParser::MissingArgument
-  Reason = ::T.let(nil, ::T.untyped)
-end
-
-class OptionParser::NeedlessArgument
-  Reason = ::T.let(nil, ::T.untyped)
-end
-
-class OptionParser::ParseError
-  Reason = ::T.let(nil, ::T.untyped)
+module Parlour::Debugging
+  extend ::T::Private::Methods::MethodHooks
+  extend ::T::Private::Methods::SingletonMethodHooks
 end
 
 class Parlour::Plugin
   extend ::T::Private::Abstract::Hooks
   extend ::T::InterfaceWrapper::Helpers
+  extend ::T::Private::Methods::MethodHooks
+  extend ::T::Private::Methods::SingletonMethodHooks
+end
+
+class Parlour::RbiGenerator::Options
+  extend ::T::Private::Methods::MethodHooks
+  extend ::T::Private::Methods::SingletonMethodHooks
+end
+
+class Parlour::RbiGenerator::Parameter
+  extend ::T::Private::Methods::MethodHooks
+  extend ::T::Private::Methods::SingletonMethodHooks
 end
 
 class Parlour::RbiGenerator::RbiObject
   extend ::T::Private::Abstract::Hooks
   extend ::T::InterfaceWrapper::Helpers
+  extend ::T::Private::Methods::MethodHooks
+  extend ::T::Private::Methods::SingletonMethodHooks
+end
+
+class Parlour::RbiGenerator
+  extend ::T::Private::Methods::MethodHooks
+  extend ::T::Private::Methods::SingletonMethodHooks
 end
 
 class Pathname
@@ -2249,26 +8848,24 @@ class Pathname
   def glob(*_); end
 
   def make_symlink(_); end
-
 end
 
 class Proc
-  def <<(_); end
-
   def ===(*_); end
 
-  def >>(_); end
-
   def clone(); end
-
-  def lambda?(); end
 
   def yield(*_); end
 end
 
+module Process
+  CLOCK_MONOTONIC_RAW_APPROX = ::T.let(nil, ::T.untyped)
+  CLOCK_UPTIME_RAW = ::T.let(nil, ::T.untyped)
+  CLOCK_UPTIME_RAW_APPROX = ::T.let(nil, ::T.untyped)
+end
+
 module Process::Sys
   def self.getegid(); end
-
 end
 
 class Process::Tms
@@ -2299,10 +8896,7 @@ module Process
   def self.last_status(); end
 
   def self.setpgrp(); end
-
 end
-
-Queue = Thread::Queue
 
 module RSpec
   MODULES_TO_AUTOLOAD = ::T.let(nil, ::T.untyped)
@@ -2332,9 +8926,25 @@ class RSpec::Core::ConfigurationOptions
   UNPROCESSABLE_OPTIONS = ::T.let(nil, ::T.untyped)
 end
 
+class RSpec::Core::DidYouMean
+  def call(); end
+
+  def initialize(relative_file_name); end
+
+  def relative_file_name(); end
+end
+
+class RSpec::Core::DidYouMean
+end
+
 RSpec::Core::Example::AllExceptionsExcludingDangerousOnesOnRubiesThatAllowIt = RSpec::Support::AllExceptionsExceptOnesWeMustNotRescue
 
 class RSpec::Core::ExampleGroup
+  include ::RSpec::Core::MockingAdapters::RSpec
+  include ::RSpec::Mocks::ExampleMethods
+  include ::RSpec::Mocks::ArgumentMatchers
+  include ::RSpec::Mocks::ExampleMethods::ExpectHost
+  include ::RSpec::Matchers
   INSTANCE_VARIABLE_TO_IGNORE = ::T.let(nil, ::T.untyped)
 end
 
@@ -2437,6 +9047,8 @@ class RSpec::Core::Formatters::DocumentationFormatter
   def example_passed(passed); end
 
   def example_pending(pending); end
+
+  def example_started(_notification); end
 end
 
 class RSpec::Core::Formatters::DocumentationFormatter
@@ -2444,6 +9056,17 @@ end
 
 class RSpec::Core::Formatters::ExceptionPresenter
   PENDING_DETAIL_FORMATTER = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Core::Formatters::FailureListFormatter
+  def dump_profile(_profile); end
+
+  def example_failed(failure); end
+
+  def message(_message); end
+end
+
+class RSpec::Core::Formatters::FailureListFormatter
 end
 
 class RSpec::Core::Formatters::FallbackMessageFormatter
@@ -2541,6 +9164,29 @@ module RSpec::Core::Metadata
   RESERVED_KEYS = ::T.let(nil, ::T.untyped)
 end
 
+module RSpec::Core::MockingAdapters
+end
+
+module RSpec::Core::MockingAdapters::RSpec
+  include ::RSpec::Mocks::ExampleMethods
+  include ::RSpec::Mocks::ArgumentMatchers
+  include ::RSpec::Mocks::ExampleMethods::ExpectHost
+  def setup_mocks_for_rspec(); end
+
+  def teardown_mocks_for_rspec(); end
+
+  def verify_mocks_for_rspec(); end
+end
+
+module RSpec::Core::MockingAdapters::RSpec
+  def self.configuration(); end
+
+  def self.framework_name(); end
+end
+
+module RSpec::Core::MockingAdapters
+end
+
 class RSpec::Core::Ordering::Random
   MAX_32_BIT = ::T.let(nil, ::T.untyped)
 end
@@ -2565,6 +9211,7 @@ class RSpec::Core::Profiler
 end
 
 class RSpec::Core::Reporter
+  def exit_early(exit_code); end
   RSPEC_NOTIFICATIONS = ::T.let(nil, ::T.untyped)
 end
 
@@ -2636,6 +9283,3115 @@ module RSpec::Core::Version
   STRING = ::T.let(nil, ::T.untyped)
 end
 
+module RSpec::Expectations
+end
+
+class RSpec::Expectations::BlockExpectationTarget
+  def not_to(matcher, message=T.unsafe(nil), &block); end
+
+  def to(matcher, message=T.unsafe(nil), &block); end
+
+  def to_not(matcher, message=T.unsafe(nil), &block); end
+end
+
+class RSpec::Expectations::BlockExpectationTarget
+end
+
+class RSpec::Expectations::BlockSnippetExtractor
+  def body_content_lines(); end
+
+  def initialize(proc, method_name); end
+
+  def method_name(); end
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::AmbiguousTargetError
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::AmbiguousTargetError
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::BlockLocator
+  def beginning_line_number(); end
+
+  def beginning_line_number=(_); end
+
+  def body_content_locations(); end
+
+  def method_call_location(); end
+
+  def method_name(); end
+
+  def method_name=(_); end
+
+  def source(); end
+
+  def source=(_); end
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::BlockLocator
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::BlockTokenExtractor
+  def beginning_line_number(); end
+
+  def beginning_line_number=(_); end
+
+  def body_tokens(); end
+
+  def method_name(); end
+
+  def method_name=(_); end
+
+  def source(); end
+
+  def source=(_); end
+
+  def state(); end
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::BlockTokenExtractor
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::Error
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::Error
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::TargetNotFoundError
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::TargetNotFoundError
+end
+
+class RSpec::Expectations::BlockSnippetExtractor
+  def self.try_extracting_single_line_body_of(proc, method_name); end
+end
+
+class RSpec::Expectations::Configuration
+  def add_should_and_should_not_to(*modules); end
+
+  def backtrace_formatter(); end
+
+  def backtrace_formatter=(backtrace_formatter); end
+
+  def color?(); end
+
+  def false_positives_handler(); end
+
+  def include_chain_clauses_in_custom_matcher_descriptions=(include_chain_clauses_in_custom_matcher_descriptions); end
+
+  def include_chain_clauses_in_custom_matcher_descriptions?(); end
+
+  def max_formatted_output_length=(length); end
+
+  def on_potential_false_positives(); end
+
+  def on_potential_false_positives=(behavior); end
+
+  def reset_syntaxes_to_default(); end
+
+  def syntax(); end
+
+  def syntax=(values); end
+
+  def warn_about_potential_false_positives=(boolean); end
+
+  def warn_about_potential_false_positives?(); end
+  FALSE_POSITIVE_BEHAVIOURS = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Expectations::Configuration::NullBacktraceFormatter
+end
+
+module RSpec::Expectations::Configuration::NullBacktraceFormatter
+  def self.format_backtrace(backtrace); end
+end
+
+class RSpec::Expectations::Configuration
+end
+
+module RSpec::Expectations::ExpectationHelper
+end
+
+module RSpec::Expectations::ExpectationHelper
+  def self.check_message(msg); end
+
+  def self.handle_failure(matcher, message, failure_message_method); end
+
+  def self.modern_matcher_from(matcher); end
+
+  def self.with_matcher(handler, matcher, message); end
+end
+
+class RSpec::Expectations::ExpectationNotMetError
+end
+
+class RSpec::Expectations::ExpectationNotMetError
+end
+
+class RSpec::Expectations::ExpectationTarget
+  include ::RSpec::Expectations::ExpectationTarget::InstanceMethods
+  def initialize(value); end
+
+  def target(); end
+end
+
+module RSpec::Expectations::ExpectationTarget::InstanceMethods
+  def not_to(matcher=T.unsafe(nil), message=T.unsafe(nil), &block); end
+
+  def to(matcher=T.unsafe(nil), message=T.unsafe(nil), &block); end
+
+  def to_not(matcher=T.unsafe(nil), message=T.unsafe(nil), &block); end
+end
+
+module RSpec::Expectations::ExpectationTarget::InstanceMethods
+end
+
+module RSpec::Expectations::ExpectationTarget::UndefinedValue
+end
+
+module RSpec::Expectations::ExpectationTarget::UndefinedValue
+end
+
+class RSpec::Expectations::ExpectationTarget
+  def self.for(value, block); end
+end
+
+class RSpec::Expectations::FailureAggregator
+  def aggregate(); end
+
+  def block_label(); end
+
+  def call(failure, options); end
+
+  def failures(); end
+
+  def initialize(block_label, metadata); end
+
+  def metadata(); end
+
+  def other_errors(); end
+end
+
+class RSpec::Expectations::FailureAggregator
+end
+
+RSpec::Expectations::LegacyMacherAdapter = RSpec::Expectations::LegacyMatcherAdapter
+
+class RSpec::Expectations::LegacyMatcherAdapter
+  def initialize(matcher); end
+end
+
+class RSpec::Expectations::LegacyMatcherAdapter::RSpec1
+  def failure_message(); end
+
+  def failure_message_when_negated(); end
+end
+
+class RSpec::Expectations::LegacyMatcherAdapter::RSpec1
+  def self.interface_matches?(matcher); end
+end
+
+class RSpec::Expectations::LegacyMatcherAdapter::RSpec2
+  def failure_message(); end
+
+  def failure_message_when_negated(); end
+end
+
+class RSpec::Expectations::LegacyMatcherAdapter::RSpec2
+  def self.interface_matches?(matcher); end
+end
+
+class RSpec::Expectations::LegacyMatcherAdapter
+  def self.wrap(matcher); end
+end
+
+class RSpec::Expectations::MultipleExpectationsNotMetError
+  include ::RSpec::Core::MultipleExceptionError::InterfaceTag
+  def aggregation_block_label(); end
+
+  def aggregation_metadata(); end
+
+  def all_exceptions(); end
+
+  def exception_count_description(); end
+
+  def failures(); end
+
+  def initialize(failure_aggregator); end
+
+  def other_errors(); end
+
+  def summary(); end
+end
+
+class RSpec::Expectations::MultipleExpectationsNotMetError
+end
+
+class RSpec::Expectations::NegativeExpectationHandler
+end
+
+class RSpec::Expectations::NegativeExpectationHandler
+  def self.does_not_match?(matcher, actual, &block); end
+
+  def self.handle_matcher(actual, initial_matcher, message=T.unsafe(nil), &block); end
+
+  def self.opposite_should_method(); end
+
+  def self.should_method(); end
+
+  def self.verb(); end
+end
+
+class RSpec::Expectations::PositiveExpectationHandler
+end
+
+class RSpec::Expectations::PositiveExpectationHandler
+  def self.handle_matcher(actual, initial_matcher, message=T.unsafe(nil), &block); end
+
+  def self.opposite_should_method(); end
+
+  def self.should_method(); end
+
+  def self.verb(); end
+end
+
+module RSpec::Expectations::Syntax
+end
+
+module RSpec::Expectations::Syntax
+  def self.default_should_host(); end
+
+  def self.disable_expect(syntax_host=T.unsafe(nil)); end
+
+  def self.disable_should(syntax_host=T.unsafe(nil)); end
+
+  def self.enable_expect(syntax_host=T.unsafe(nil)); end
+
+  def self.enable_should(syntax_host=T.unsafe(nil)); end
+
+  def self.expect_enabled?(syntax_host=T.unsafe(nil)); end
+
+  def self.should_enabled?(syntax_host=T.unsafe(nil)); end
+
+  def self.warn_about_should!(); end
+
+  def self.warn_about_should_unless_configured(method_name); end
+end
+
+module RSpec::Expectations::Version
+  STRING = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Expectations::Version
+end
+
+module RSpec::Expectations
+  def self.configuration(); end
+
+  def self.differ(); end
+
+  def self.fail_with(message, expected=T.unsafe(nil), actual=T.unsafe(nil)); end
+end
+
+module RSpec::Matchers
+  def a_block_changing(*args, &block); end
+
+  def a_block_outputting(*args, &block); end
+
+  def a_block_raising(*args, &block); end
+
+  def a_block_throwing(*args, &block); end
+
+  def a_block_yielding_control(*args, &block); end
+
+  def a_block_yielding_successive_args(*args, &block); end
+
+  def a_block_yielding_with_args(*args, &block); end
+
+  def a_block_yielding_with_no_args(*args, &block); end
+
+  def a_collection_containing_exactly(*args, &block); end
+
+  def a_collection_ending_with(*args, &block); end
+
+  def a_collection_including(*args, &block); end
+
+  def a_collection_starting_with(*args, &block); end
+
+  def a_falsey_value(*args, &block); end
+
+  def a_falsy_value(*args, &block); end
+
+  def a_hash_including(*args, &block); end
+
+  def a_kind_of(*args, &block); end
+
+  def a_nil_value(*args, &block); end
+
+  def a_range_covering(*args, &block); end
+
+  def a_string_ending_with(*args, &block); end
+
+  def a_string_including(*args, &block); end
+
+  def a_string_matching(*args, &block); end
+
+  def a_string_starting_with(*args, &block); end
+
+  def a_truthy_value(*args, &block); end
+
+  def a_value(*args, &block); end
+
+  def a_value_between(*args, &block); end
+
+  def a_value_within(*args, &block); end
+
+  def aggregate_failures(label=T.unsafe(nil), metadata=T.unsafe(nil), &block); end
+
+  def all(expected); end
+
+  def an_instance_of(*args, &block); end
+
+  def an_object_eq_to(*args, &block); end
+
+  def an_object_eql_to(*args, &block); end
+
+  def an_object_equal_to(*args, &block); end
+
+  def an_object_existing(*args, &block); end
+
+  def an_object_having_attributes(*args, &block); end
+
+  def an_object_matching(*args, &block); end
+
+  def an_object_responding_to(*args, &block); end
+
+  def an_object_satisfying(*args, &block); end
+
+  def be(*args); end
+
+  def be_a(klass); end
+
+  def be_a_kind_of(expected); end
+
+  def be_an(klass); end
+
+  def be_an_instance_of(expected); end
+
+  def be_between(min, max); end
+
+  def be_falsey(); end
+
+  def be_falsy(*args, &block); end
+
+  def be_instance_of(expected); end
+
+  def be_kind_of(expected); end
+
+  def be_nil(); end
+
+  def be_truthy(); end
+
+  def be_within(delta); end
+
+  def change(receiver=T.unsafe(nil), message=T.unsafe(nil), &block); end
+
+  def changing(*args, &block); end
+
+  def contain_exactly(*items); end
+
+  def containing_exactly(*args, &block); end
+
+  def cover(*values); end
+
+  def covering(*args, &block); end
+
+  def end_with(*expected); end
+
+  def ending_with(*args, &block); end
+
+  def eq(expected); end
+
+  def eq_to(*args, &block); end
+
+  def eql(expected); end
+
+  def eql_to(*args, &block); end
+
+  def equal(expected); end
+
+  def equal_to(*args, &block); end
+
+  def exist(*args); end
+
+  def existing(*args, &block); end
+
+  def expect(value=T.unsafe(nil), &block); end
+
+  def have_attributes(expected); end
+
+  def having_attributes(*args, &block); end
+
+  def include(*expected); end
+
+  def including(*args, &block); end
+
+  def match(expected); end
+
+  def match_array(items); end
+
+  def match_regex(*args, &block); end
+
+  def matching(*args, &block); end
+
+  def output(expected=T.unsafe(nil)); end
+
+  def raise_error(error=T.unsafe(nil), message=T.unsafe(nil), &block); end
+
+  def raise_exception(error=T.unsafe(nil), message=T.unsafe(nil), &block); end
+
+  def raising(*args, &block); end
+
+  def respond_to(*names); end
+
+  def responding_to(*args, &block); end
+
+  def satisfy(description=T.unsafe(nil), &block); end
+
+  def satisfying(*args, &block); end
+
+  def start_with(*expected); end
+
+  def starting_with(*args, &block); end
+
+  def throw_symbol(expected_symbol=T.unsafe(nil), expected_arg=T.unsafe(nil)); end
+
+  def throwing(*args, &block); end
+
+  def within(*args, &block); end
+
+  def yield_control(); end
+
+  def yield_successive_args(*args); end
+
+  def yield_with_args(*args); end
+
+  def yield_with_no_args(); end
+
+  def yielding_control(*args, &block); end
+
+  def yielding_successive_args(*args, &block); end
+
+  def yielding_with_args(*args, &block); end
+
+  def yielding_with_no_args(*args, &block); end
+  BE_PREDICATE_REGEX = ::T.let(nil, ::T.untyped)
+  DYNAMIC_MATCHER_REGEX = ::T.let(nil, ::T.untyped)
+  HAS_REGEX = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Matchers::AliasedMatcher
+  def description(); end
+
+  def failure_message(); end
+
+  def failure_message_when_negated(); end
+
+  def initialize(base_matcher, description_block); end
+
+  def method_missing(*_); end
+end
+
+class RSpec::Matchers::AliasedMatcher
+end
+
+class RSpec::Matchers::AliasedMatcherWithOperatorSupport
+end
+
+class RSpec::Matchers::AliasedMatcherWithOperatorSupport
+end
+
+class RSpec::Matchers::AliasedNegatedMatcher
+  def does_not_match?(*args, &block); end
+
+  def matches?(*args, &block); end
+end
+
+RSpec::Matchers::AliasedNegatedMatcher::DefaultFailureMessages = RSpec::Matchers::BuiltIn::BaseMatcher::DefaultFailureMessages
+
+class RSpec::Matchers::AliasedNegatedMatcher
+end
+
+module RSpec::Matchers::BuiltIn
+end
+
+class RSpec::Matchers::BuiltIn::All
+  def does_not_match?(_actual); end
+
+  def failed_objects(); end
+
+  def initialize(matcher); end
+
+  def matcher(); end
+end
+
+class RSpec::Matchers::BuiltIn::All
+end
+
+class RSpec::Matchers::BuiltIn::BaseMatcher
+  include ::RSpec::Matchers::Composable
+  include ::RSpec::Matchers::BuiltIn::BaseMatcher::HashFormatting
+  include ::RSpec::Matchers::BuiltIn::BaseMatcher::DefaultFailureMessages
+  def actual(); end
+
+  def actual_formatted(); end
+
+  def description(); end
+
+  def diffable?(); end
+
+  def expected(); end
+
+  def expected_formatted(); end
+
+  def expects_call_stack_jump?(); end
+
+  def initialize(expected=T.unsafe(nil)); end
+
+  def match_unless_raises(*exceptions); end
+
+  def matcher_name(); end
+
+  def matcher_name=(matcher_name); end
+
+  def matches?(actual); end
+
+  def present_ivars(); end
+
+  def rescued_exception(); end
+
+  def supports_block_expectations?(); end
+  UNDEFINED = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Matchers::BuiltIn::BaseMatcher::DefaultFailureMessages
+  def failure_message(); end
+
+  def failure_message_when_negated(); end
+end
+
+module RSpec::Matchers::BuiltIn::BaseMatcher::DefaultFailureMessages
+  def self.has_default_failure_messages?(matcher); end
+end
+
+module RSpec::Matchers::BuiltIn::BaseMatcher::HashFormatting
+end
+
+module RSpec::Matchers::BuiltIn::BaseMatcher::HashFormatting
+  def self.improve_hash_formatting(inspect_string); end
+end
+
+class RSpec::Matchers::BuiltIn::BaseMatcher
+  def self.matcher_name(); end
+end
+
+class RSpec::Matchers::BuiltIn::Be
+  include ::RSpec::Matchers::BuiltIn::BeHelpers
+  def <(operand); end
+
+  def <=(operand); end
+
+  def ==(operand); end
+
+  def ===(operand); end
+
+  def =~(operand); end
+
+  def >(operand); end
+
+  def >=(operand); end
+
+  def initialize(*args); end
+end
+
+class RSpec::Matchers::BuiltIn::Be
+end
+
+class RSpec::Matchers::BuiltIn::BeAKindOf
+end
+
+class RSpec::Matchers::BuiltIn::BeAKindOf
+end
+
+class RSpec::Matchers::BuiltIn::BeAnInstanceOf
+end
+
+class RSpec::Matchers::BuiltIn::BeAnInstanceOf
+end
+
+class RSpec::Matchers::BuiltIn::BeBetween
+  def exclusive(); end
+
+  def inclusive(); end
+
+  def initialize(min, max); end
+end
+
+class RSpec::Matchers::BuiltIn::BeBetween
+end
+
+class RSpec::Matchers::BuiltIn::BeComparedTo
+  include ::RSpec::Matchers::BuiltIn::BeHelpers
+  def initialize(operand, operator); end
+end
+
+class RSpec::Matchers::BuiltIn::BeComparedTo
+end
+
+class RSpec::Matchers::BuiltIn::BeFalsey
+end
+
+class RSpec::Matchers::BuiltIn::BeFalsey
+end
+
+module RSpec::Matchers::BuiltIn::BeHelpers
+end
+
+module RSpec::Matchers::BuiltIn::BeHelpers
+end
+
+class RSpec::Matchers::BuiltIn::BeNil
+end
+
+class RSpec::Matchers::BuiltIn::BeNil
+end
+
+class RSpec::Matchers::BuiltIn::BePredicate
+  include ::RSpec::Matchers::BuiltIn::BeHelpers
+  def does_not_match?(actual, &block); end
+
+  def initialize(*args, &block); end
+
+  def matches?(actual, &block); end
+end
+
+class RSpec::Matchers::BuiltIn::BePredicate
+end
+
+class RSpec::Matchers::BuiltIn::BeTruthy
+end
+
+class RSpec::Matchers::BuiltIn::BeTruthy
+end
+
+class RSpec::Matchers::BuiltIn::BeWithin
+  def initialize(delta); end
+
+  def of(expected); end
+
+  def percent_of(expected); end
+end
+
+class RSpec::Matchers::BuiltIn::BeWithin
+end
+
+class RSpec::Matchers::BuiltIn::Change
+  def by(expected_delta); end
+
+  def by_at_least(minimum); end
+
+  def by_at_most(maximum); end
+
+  def does_not_match?(event_proc); end
+
+  def from(value); end
+
+  def initialize(receiver=T.unsafe(nil), message=T.unsafe(nil), &block); end
+
+  def matches?(event_proc); end
+
+  def to(value); end
+end
+
+class RSpec::Matchers::BuiltIn::Change
+end
+
+class RSpec::Matchers::BuiltIn::Compound
+  def diffable_matcher_list(); end
+
+  def does_not_match?(_actual); end
+
+  def evaluator(); end
+
+  def initialize(matcher_1, matcher_2); end
+
+  def matcher_1(); end
+
+  def matcher_2(); end
+end
+
+class RSpec::Matchers::BuiltIn::Compound::And
+end
+
+class RSpec::Matchers::BuiltIn::Compound::And
+end
+
+class RSpec::Matchers::BuiltIn::Compound::NestedEvaluator
+  def initialize(actual, matcher_1, matcher_2); end
+
+  def matcher_matches?(matcher); end
+end
+
+class RSpec::Matchers::BuiltIn::Compound::NestedEvaluator
+  def self.matcher_expects_call_stack_jump?(matcher); end
+end
+
+class RSpec::Matchers::BuiltIn::Compound::Or
+end
+
+class RSpec::Matchers::BuiltIn::Compound::Or
+end
+
+class RSpec::Matchers::BuiltIn::Compound::SequentialEvaluator
+  def initialize(actual, *_); end
+
+  def matcher_matches?(matcher); end
+end
+
+class RSpec::Matchers::BuiltIn::Compound::SequentialEvaluator
+end
+
+class RSpec::Matchers::BuiltIn::Compound
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly::PairingsMaximizer
+  def actual_to_expected_matched_indexes(); end
+
+  def expected_to_actual_matched_indexes(); end
+
+  def find_best_solution(); end
+
+  def initialize(expected_to_actual_matched_indexes, actual_to_expected_matched_indexes); end
+
+  def solution(); end
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly::PairingsMaximizer::NullSolution
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly::PairingsMaximizer::NullSolution
+  def self.worse_than?(_other); end
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly::PairingsMaximizer::Solution
+  def +(derived_candidate_solution); end
+
+  def candidate?(); end
+
+  def ideal?(); end
+
+  def indeterminate_actual_indexes(); end
+
+  def indeterminate_actual_indexes=(_); end
+
+  def indeterminate_expected_indexes(); end
+
+  def indeterminate_expected_indexes=(_); end
+
+  def unmatched_actual_indexes(); end
+
+  def unmatched_actual_indexes=(_); end
+
+  def unmatched_expected_indexes(); end
+
+  def unmatched_expected_indexes=(_); end
+
+  def unmatched_item_count(); end
+
+  def worse_than?(other); end
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly::PairingsMaximizer::Solution
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly::PairingsMaximizer
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly
+end
+
+class RSpec::Matchers::BuiltIn::Cover
+  def does_not_match?(range); end
+
+  def initialize(*expected); end
+
+  def matches?(range); end
+end
+
+class RSpec::Matchers::BuiltIn::Cover
+end
+
+class RSpec::Matchers::BuiltIn::EndWith
+end
+
+class RSpec::Matchers::BuiltIn::EndWith
+end
+
+class RSpec::Matchers::BuiltIn::Eq
+end
+
+class RSpec::Matchers::BuiltIn::Eq
+end
+
+class RSpec::Matchers::BuiltIn::Eql
+end
+
+class RSpec::Matchers::BuiltIn::Eql
+end
+
+class RSpec::Matchers::BuiltIn::Equal
+  LITERAL_SINGLETONS = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Matchers::BuiltIn::Equal
+end
+
+class RSpec::Matchers::BuiltIn::Exist
+  def does_not_match?(actual); end
+
+  def initialize(*expected); end
+end
+
+class RSpec::Matchers::BuiltIn::Exist::ExistenceTest
+  def actual_exists?(); end
+
+  def valid_test?(); end
+
+  def validity_message(); end
+end
+
+class RSpec::Matchers::BuiltIn::Exist::ExistenceTest
+end
+
+class RSpec::Matchers::BuiltIn::Exist
+end
+
+class RSpec::Matchers::BuiltIn::Has
+  def does_not_match?(actual, &block); end
+
+  def initialize(method_name, *args, &block); end
+
+  def matches?(actual, &block); end
+end
+
+class RSpec::Matchers::BuiltIn::Has
+end
+
+class RSpec::Matchers::BuiltIn::HaveAttributes
+  def does_not_match?(actual); end
+
+  def initialize(expected); end
+
+  def respond_to_failed(); end
+end
+
+class RSpec::Matchers::BuiltIn::HaveAttributes
+end
+
+class RSpec::Matchers::BuiltIn::Include
+  def does_not_match?(actual); end
+
+  def expecteds(); end
+
+  def initialize(*expecteds); end
+end
+
+class RSpec::Matchers::BuiltIn::Include
+end
+
+class RSpec::Matchers::BuiltIn::Match
+  def initialize(expected); end
+
+  def with_captures(*captures); end
+end
+
+class RSpec::Matchers::BuiltIn::Match
+end
+
+class RSpec::Matchers::BuiltIn::NegativeOperatorMatcher
+  def __delegate_operator(actual, operator, expected); end
+end
+
+class RSpec::Matchers::BuiltIn::NegativeOperatorMatcher
+end
+
+class RSpec::Matchers::BuiltIn::OperatorMatcher
+  def !=(_expected); end
+
+  def !~(_expected); end
+
+  def <(expected); end
+
+  def <=(expected); end
+
+  def ==(expected); end
+
+  def ===(expected); end
+
+  def =~(expected); end
+
+  def >(expected); end
+
+  def >=(expected); end
+
+  def description(); end
+
+  def fail_with_message(message); end
+
+  def initialize(actual); end
+end
+
+class RSpec::Matchers::BuiltIn::OperatorMatcher
+  def self.get(klass, operator); end
+
+  def self.register(klass, operator, matcher); end
+
+  def self.registry(); end
+
+  def self.unregister(klass, operator); end
+
+  def self.use_custom_matcher_or_delegate(operator); end
+end
+
+class RSpec::Matchers::BuiltIn::Output
+  def does_not_match?(block); end
+
+  def initialize(expected); end
+
+  def matches?(block); end
+
+  def to_stderr(); end
+
+  def to_stderr_from_any_process(); end
+
+  def to_stdout(); end
+
+  def to_stdout_from_any_process(); end
+end
+
+class RSpec::Matchers::BuiltIn::Output
+end
+
+class RSpec::Matchers::BuiltIn::PositiveOperatorMatcher
+  def __delegate_operator(actual, operator, expected); end
+end
+
+class RSpec::Matchers::BuiltIn::PositiveOperatorMatcher
+end
+
+class RSpec::Matchers::BuiltIn::RaiseError
+  include ::RSpec::Matchers::Composable
+  def description(); end
+
+  def does_not_match?(given_proc); end
+
+  def expects_call_stack_jump?(); end
+
+  def failure_message(); end
+
+  def failure_message_when_negated(); end
+
+  def initialize(expected_error_or_message=T.unsafe(nil), expected_message=T.unsafe(nil), &block); end
+
+  def matches?(given_proc, negative_expectation=T.unsafe(nil), &block); end
+
+  def supports_block_expectations?(); end
+
+  def with_message(expected_message); end
+end
+
+class RSpec::Matchers::BuiltIn::RaiseError
+end
+
+class RSpec::Matchers::BuiltIn::RespondTo
+  def and_any_keywords(); end
+
+  def and_keywords(*keywords); end
+
+  def and_unlimited_arguments(); end
+
+  def argument(); end
+
+  def arguments(); end
+
+  def does_not_match?(actual); end
+
+  def initialize(*names); end
+
+  def with(n); end
+
+  def with_any_keywords(); end
+
+  def with_keywords(*keywords); end
+
+  def with_unlimited_arguments(); end
+end
+
+class RSpec::Matchers::BuiltIn::RespondTo
+end
+
+class RSpec::Matchers::BuiltIn::Satisfy
+  def initialize(description=T.unsafe(nil), &block); end
+
+  def matches?(actual, &block); end
+end
+
+class RSpec::Matchers::BuiltIn::Satisfy
+end
+
+class RSpec::Matchers::BuiltIn::StartOrEndWith
+  def initialize(*expected); end
+end
+
+class RSpec::Matchers::BuiltIn::StartOrEndWith
+end
+
+class RSpec::Matchers::BuiltIn::StartWith
+end
+
+class RSpec::Matchers::BuiltIn::StartWith
+end
+
+class RSpec::Matchers::BuiltIn::ThrowSymbol
+  include ::RSpec::Matchers::Composable
+  def description(); end
+
+  def does_not_match?(given_proc); end
+
+  def expects_call_stack_jump?(); end
+
+  def failure_message(); end
+
+  def failure_message_when_negated(); end
+
+  def initialize(expected_symbol=T.unsafe(nil), expected_arg=T.unsafe(nil)); end
+
+  def matches?(given_proc); end
+
+  def supports_block_expectations?(); end
+end
+
+class RSpec::Matchers::BuiltIn::ThrowSymbol
+end
+
+class RSpec::Matchers::BuiltIn::YieldControl
+  def at_least(number); end
+
+  def at_most(number); end
+
+  def does_not_match?(block); end
+
+  def exactly(number); end
+
+  def initialize(); end
+
+  def matches?(block); end
+
+  def once(); end
+
+  def thrice(); end
+
+  def times(); end
+
+  def twice(); end
+end
+
+class RSpec::Matchers::BuiltIn::YieldControl
+end
+
+class RSpec::Matchers::BuiltIn::YieldSuccessiveArgs
+  def does_not_match?(block); end
+
+  def initialize(*args); end
+
+  def matches?(block); end
+end
+
+class RSpec::Matchers::BuiltIn::YieldSuccessiveArgs
+end
+
+class RSpec::Matchers::BuiltIn::YieldWithArgs
+  def does_not_match?(block); end
+
+  def initialize(*args); end
+
+  def matches?(block); end
+end
+
+class RSpec::Matchers::BuiltIn::YieldWithArgs
+end
+
+class RSpec::Matchers::BuiltIn::YieldWithNoArgs
+  def does_not_match?(block); end
+
+  def matches?(block); end
+end
+
+class RSpec::Matchers::BuiltIn::YieldWithNoArgs
+end
+
+module RSpec::Matchers::BuiltIn
+end
+
+module RSpec::Matchers::Composable
+  def &(matcher); end
+
+  def ===(value); end
+
+  def and(matcher); end
+
+  def or(matcher); end
+
+  def |(matcher); end
+end
+
+module RSpec::Matchers::Composable
+  def self.should_enumerate?(item); end
+
+  def self.surface_descriptions_in(item); end
+
+  def self.unreadable_io?(object); end
+end
+
+module RSpec::Matchers::DSL
+  def alias_matcher(new_name, old_name, options=T.unsafe(nil), &description_override); end
+
+  def define(name, &declarations); end
+
+  def define_negated_matcher(negated_name, base_name, &description_override); end
+
+  def matcher(name, &declarations); end
+end
+
+module RSpec::Matchers::DSL::DefaultImplementations
+  include ::RSpec::Matchers::BuiltIn::BaseMatcher::DefaultFailureMessages
+  def description(); end
+
+  def diffable?(); end
+
+  def expects_call_stack_jump?(); end
+
+  def supports_block_expectations?(); end
+end
+
+module RSpec::Matchers::DSL::DefaultImplementations
+end
+
+module RSpec::Matchers::DSL::Macros
+  def chain(method_name, *attr_names, &definition); end
+
+  def description(&definition); end
+
+  def diffable(); end
+
+  def failure_message(&definition); end
+
+  def failure_message_when_negated(&definition); end
+
+  def match(options=T.unsafe(nil), &match_block); end
+
+  def match_unless_raises(expected_exception=T.unsafe(nil), &match_block); end
+
+  def match_when_negated(options=T.unsafe(nil), &match_block); end
+
+  def supports_block_expectations(); end
+  RAISE_NOTIFIER = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Matchers::DSL::Macros::Deprecated
+  def failure_message_for_should(&definition); end
+
+  def failure_message_for_should_not(&definition); end
+
+  def match_for_should(&definition); end
+
+  def match_for_should_not(&definition); end
+end
+
+module RSpec::Matchers::DSL::Macros::Deprecated
+end
+
+module RSpec::Matchers::DSL::Macros
+end
+
+class RSpec::Matchers::DSL::Matcher
+  include ::RSpec::Matchers::DSL::DefaultImplementations
+  include ::RSpec::Matchers::BuiltIn::BaseMatcher::DefaultFailureMessages
+  include ::RSpec::Matchers
+  include ::RSpec::Matchers::Composable
+  def actual(); end
+
+  def block_arg(); end
+
+  def expected(); end
+
+  def expected_as_array(); end
+
+  def initialize(name, declarations, matcher_execution_context, *expected, &block_arg); end
+
+  def name(); end
+
+  def rescued_exception(); end
+end
+
+class RSpec::Matchers::DSL::Matcher
+  extend ::RSpec::Matchers::DSL::Macros
+  extend ::RSpec::Matchers::DSL::Macros::Deprecated
+end
+
+module RSpec::Matchers::DSL
+end
+
+module RSpec::Matchers::EnglishPhrasing
+end
+
+module RSpec::Matchers::EnglishPhrasing
+  def self.list(obj); end
+
+  def self.split_words(sym); end
+end
+
+class RSpec::Matchers::ExpectedsForMultipleDiffs
+  def initialize(expected_list); end
+
+  def message_with_diff(message, differ, actual); end
+  DEFAULT_DIFF_LABEL = ::T.let(nil, ::T.untyped)
+  DESCRIPTION_MAX_LENGTH = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Matchers::ExpectedsForMultipleDiffs
+  def self.for_many_matchers(matchers); end
+
+  def self.from(expected); end
+end
+
+class RSpec::Matchers::MatcherDelegator
+  include ::RSpec::Matchers::Composable
+  def base_matcher(); end
+
+  def initialize(base_matcher); end
+
+  def method_missing(*args, &block); end
+end
+
+class RSpec::Matchers::MatcherDelegator
+end
+
+module RSpec::Matchers
+  extend ::RSpec::Matchers::DSL
+  def self.alias_matcher(*args, &block); end
+
+  def self.clear_generated_description(); end
+
+  def self.configuration(); end
+
+  def self.generated_description(); end
+
+  def self.is_a_describable_matcher?(obj); end
+
+  def self.is_a_matcher?(obj); end
+
+  def self.last_description(); end
+
+  def self.last_expectation_handler(); end
+
+  def self.last_expectation_handler=(last_expectation_handler); end
+
+  def self.last_matcher(); end
+
+  def self.last_matcher=(last_matcher); end
+end
+
+module RSpec::Mocks
+  DEFAULT_CALLBACK_INVOCATION_STRATEGY = ::T.let(nil, ::T.untyped)
+  IGNORED_BACKTRACE_LINE = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Mocks::AllowanceTarget
+  def expression(); end
+
+  def not_to(matcher, *_args); end
+
+  def to(matcher, &block); end
+
+  def to_not(matcher, *_args); end
+end
+
+class RSpec::Mocks::AllowanceTarget
+end
+
+class RSpec::Mocks::AndReturnImplementation
+  def call(*_args_to_ignore, &_block); end
+
+  def initialize(values_to_return); end
+end
+
+class RSpec::Mocks::AndReturnImplementation
+end
+
+class RSpec::Mocks::AndWrapOriginalImplementation
+  def call(*args, &block); end
+
+  def initial_action=(_value); end
+
+  def initialize(method, block); end
+
+  def inner_action(); end
+
+  def inner_action=(_value); end
+
+  def present?(); end
+
+  def terminal_action=(_value); end
+end
+
+class RSpec::Mocks::AndWrapOriginalImplementation::CannotModifyFurtherError
+end
+
+class RSpec::Mocks::AndWrapOriginalImplementation::CannotModifyFurtherError
+end
+
+class RSpec::Mocks::AndWrapOriginalImplementation
+end
+
+class RSpec::Mocks::AndYieldImplementation
+  def call(*_args_to_ignore, &block); end
+
+  def initialize(args_to_yield, eval_context, error_generator); end
+end
+
+class RSpec::Mocks::AndYieldImplementation
+end
+
+module RSpec::Mocks::AnyInstance
+end
+
+class RSpec::Mocks::AnyInstance::Chain
+  include ::RSpec::Mocks::AnyInstance::Chain::Customizations
+  def constrained_to_any_of?(*constraints); end
+
+  def expectation_fulfilled!(); end
+
+  def initialize(recorder, *args, &block); end
+
+  def matches_args?(*args); end
+
+  def never(); end
+
+  def playback!(instance); end
+end
+
+module RSpec::Mocks::AnyInstance::Chain::Customizations
+  def and_call_original(*args, &block); end
+
+  def and_raise(*args, &block); end
+
+  def and_return(*args, &block); end
+
+  def and_throw(*args, &block); end
+
+  def and_wrap_original(*args, &block); end
+
+  def and_yield(*args, &block); end
+
+  def at_least(*args, &block); end
+
+  def at_most(*args, &block); end
+
+  def exactly(*args, &block); end
+
+  def never(*args, &block); end
+
+  def once(*args, &block); end
+
+  def thrice(*args, &block); end
+
+  def time(*args, &block); end
+
+  def times(*args, &block); end
+
+  def twice(*args, &block); end
+
+  def with(*args, &block); end
+end
+
+module RSpec::Mocks::AnyInstance::Chain::Customizations
+  def self.record(method_name); end
+end
+
+class RSpec::Mocks::AnyInstance::Chain
+end
+
+class RSpec::Mocks::AnyInstance::ErrorGenerator
+  def raise_does_not_implement_error(klass, method_name); end
+
+  def raise_message_already_received_by_other_instance_error(method_name, object_inspect, invoked_instance); end
+
+  def raise_not_supported_with_prepend_error(method_name, problem_mod); end
+
+  def raise_second_instance_received_message_error(unfulfilled_expectations); end
+end
+
+class RSpec::Mocks::AnyInstance::ErrorGenerator
+end
+
+class RSpec::Mocks::AnyInstance::ExpectChainChain
+  def initialize(*args); end
+end
+
+class RSpec::Mocks::AnyInstance::ExpectChainChain
+end
+
+class RSpec::Mocks::AnyInstance::ExpectationChain
+  def expectation_fulfilled?(); end
+
+  def initialize(*args, &block); end
+end
+
+class RSpec::Mocks::AnyInstance::ExpectationChain
+end
+
+class RSpec::Mocks::AnyInstance::FluentInterfaceProxy
+  def initialize(targets); end
+
+  def method_missing(*args, &block); end
+end
+
+class RSpec::Mocks::AnyInstance::FluentInterfaceProxy
+end
+
+class RSpec::Mocks::AnyInstance::MessageChains
+  def [](method_name); end
+
+  def add(method_name, chain); end
+
+  def all_expectations_fulfilled?(); end
+
+  def each_unfulfilled_expectation_matching(method_name, *args); end
+
+  def has_expectation?(method_name); end
+
+  def playback!(instance, method_name); end
+
+  def received_expected_message!(method_name); end
+
+  def remove_stub_chains_for!(method_name); end
+
+  def unfulfilled_expectations(); end
+end
+
+class RSpec::Mocks::AnyInstance::MessageChains
+end
+
+class RSpec::Mocks::AnyInstance::PositiveExpectationChain
+  ExpectationInvocationOrder = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Mocks::AnyInstance::PositiveExpectationChain
+end
+
+class RSpec::Mocks::AnyInstance::Proxy
+  def expect_chain(*chain, &block); end
+
+  def initialize(recorder, target_proxies); end
+
+  def klass(); end
+
+  def should_not_receive(method_name, &block); end
+
+  def should_receive(method_name, &block); end
+
+  def stub(method_name_or_method_map, &block); end
+
+  def stub_chain(*chain, &block); end
+
+  def unstub(method_name); end
+end
+
+class RSpec::Mocks::AnyInstance::Proxy
+end
+
+class RSpec::Mocks::AnyInstance::Recorder
+  def already_observing?(method_name); end
+
+  def build_alias_method_name(method_name); end
+
+  def expect_chain(*method_names_and_optional_return_values, &block); end
+
+  def initialize(klass); end
+
+  def instance_that_received(method_name); end
+
+  def klass(); end
+
+  def message_chains(); end
+
+  def notify_received_message(_object, message, args, _blk); end
+
+  def playback!(instance, method_name); end
+
+  def should_not_receive(method_name, &block); end
+
+  def should_receive(method_name, &block); end
+
+  def stop_all_observation!(); end
+
+  def stop_observing!(method_name); end
+
+  def stub(method_name, &block); end
+
+  def stub_chain(*method_names_and_optional_return_values, &block); end
+
+  def stubs(); end
+
+  def unstub(method_name); end
+
+  def verify(); end
+end
+
+class RSpec::Mocks::AnyInstance::Recorder
+end
+
+class RSpec::Mocks::AnyInstance::StubChain
+  def expectation_fulfilled?(); end
+  EmptyInvocationOrder = ::T.let(nil, ::T.untyped)
+  InvocationOrder = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Mocks::AnyInstance::StubChain
+end
+
+class RSpec::Mocks::AnyInstance::StubChainChain
+  def initialize(*args); end
+end
+
+class RSpec::Mocks::AnyInstance::StubChainChain
+end
+
+module RSpec::Mocks::AnyInstance
+  def self.error_generator(); end
+end
+
+class RSpec::Mocks::AnyInstanceAllowanceTarget
+  def expression(); end
+
+  def not_to(matcher, *_args); end
+
+  def to(matcher, &block); end
+
+  def to_not(matcher, *_args); end
+end
+
+class RSpec::Mocks::AnyInstanceAllowanceTarget
+end
+
+class RSpec::Mocks::AnyInstanceExpectationTarget
+  def expression(); end
+
+  def not_to(matcher, &block); end
+
+  def to(matcher, &block); end
+
+  def to_not(matcher, &block); end
+end
+
+class RSpec::Mocks::AnyInstanceExpectationTarget
+end
+
+class RSpec::Mocks::ArgumentListMatcher
+  def args_match?(*args); end
+
+  def expected_args(); end
+
+  def initialize(*expected_args); end
+
+  def resolve_expected_args_based_on(actual_args); end
+  MATCH_ALL = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Mocks::ArgumentListMatcher
+end
+
+module RSpec::Mocks::ArgumentMatchers
+  def a_kind_of(klass); end
+
+  def an_instance_of(klass); end
+
+  def any_args(); end
+
+  def anything(); end
+
+  def array_including(*args); end
+
+  def boolean(); end
+
+  def duck_type(*args); end
+
+  def hash_excluding(*args); end
+
+  def hash_including(*args); end
+
+  def hash_not_including(*args); end
+
+  def instance_of(klass); end
+
+  def kind_of(klass); end
+
+  def no_args(); end
+end
+
+module RSpec::Mocks::ArgumentMatchers
+  def self.anythingize_lonely_keys(*args); end
+end
+
+class RSpec::Mocks::CallbackInvocationStrategy
+  def call(doubled_module); end
+end
+
+class RSpec::Mocks::CallbackInvocationStrategy
+end
+
+class RSpec::Mocks::CannotSupportArgMutationsError
+end
+
+class RSpec::Mocks::CannotSupportArgMutationsError
+end
+
+class RSpec::Mocks::ClassNewMethodReference
+end
+
+class RSpec::Mocks::ClassNewMethodReference
+  def self.applies_to?(method_name); end
+end
+
+class RSpec::Mocks::ClassVerifyingDouble
+  include ::RSpec::Mocks::ObjectVerifyingDoubleMethods
+  include ::RSpec::Mocks::TestDouble
+  include ::RSpec::Mocks::VerifyingDouble
+end
+
+class RSpec::Mocks::ClassVerifyingDouble
+end
+
+class RSpec::Mocks::Configuration
+  def add_stub_and_should_receive_to(*modules); end
+
+  def allow_message_expectations_on_nil(); end
+
+  def allow_message_expectations_on_nil=(allow_message_expectations_on_nil); end
+
+  def before_verifying_doubles(&block); end
+
+  def color?(); end
+
+  def patch_marshal_to_support_partial_doubles=(val); end
+
+  def reset_syntaxes_to_default(); end
+
+  def syntax(); end
+
+  def syntax=(*values); end
+
+  def temporarily_suppress_partial_double_verification(); end
+
+  def temporarily_suppress_partial_double_verification=(temporarily_suppress_partial_double_verification); end
+
+  def transfer_nested_constants=(transfer_nested_constants); end
+
+  def transfer_nested_constants?(); end
+
+  def verify_doubled_constant_names=(verify_doubled_constant_names); end
+
+  def verify_doubled_constant_names?(); end
+
+  def verify_partial_doubles=(val); end
+
+  def verify_partial_doubles?(); end
+
+  def verifying_double_callbacks(); end
+
+  def when_declaring_verifying_double(&block); end
+
+  def yield_receiver_to_any_instance_implementation_blocks=(yield_receiver_to_any_instance_implementation_blocks); end
+
+  def yield_receiver_to_any_instance_implementation_blocks?(); end
+end
+
+class RSpec::Mocks::Configuration
+end
+
+class RSpec::Mocks::Constant
+  def hidden=(hidden); end
+
+  def hidden?(); end
+
+  def initialize(name); end
+
+  def mutated?(); end
+
+  def name(); end
+
+  def original_value(); end
+
+  def original_value=(original_value); end
+
+  def previously_defined=(previously_defined); end
+
+  def previously_defined?(); end
+
+  def stubbed=(stubbed); end
+
+  def stubbed?(); end
+
+  def valid_name=(valid_name); end
+
+  def valid_name?(); end
+end
+
+class RSpec::Mocks::Constant
+  extend ::RSpec::Support::RecursiveConstMethods
+  def self.original(name); end
+
+  def self.unmutated(name); end
+end
+
+class RSpec::Mocks::ConstantMutator
+end
+
+class RSpec::Mocks::ConstantMutator::BaseMutator
+  include ::RSpec::Support::RecursiveConstMethods
+  def full_constant_name(); end
+
+  def idempotently_reset(); end
+
+  def initialize(full_constant_name, mutated_value, transfer_nested_constants); end
+
+  def original_value(); end
+
+  def to_constant(); end
+end
+
+class RSpec::Mocks::ConstantMutator::BaseMutator
+end
+
+class RSpec::Mocks::ConstantMutator::ConstantHider
+  def mutate(); end
+
+  def reset(); end
+end
+
+class RSpec::Mocks::ConstantMutator::ConstantHider
+end
+
+class RSpec::Mocks::ConstantMutator::DefinedConstantReplacer
+  def initialize(*args); end
+
+  def mutate(); end
+
+  def reset(); end
+
+  def should_transfer_nested_constants?(); end
+
+  def transfer_nested_constants(); end
+
+  def verify_constants_to_transfer!(); end
+end
+
+class RSpec::Mocks::ConstantMutator::DefinedConstantReplacer
+end
+
+class RSpec::Mocks::ConstantMutator::UndefinedConstantSetter
+  def mutate(); end
+
+  def reset(); end
+end
+
+class RSpec::Mocks::ConstantMutator::UndefinedConstantSetter
+end
+
+class RSpec::Mocks::ConstantMutator
+  extend ::RSpec::Support::RecursiveConstMethods
+  def self.hide(constant_name); end
+
+  def self.mutate(mutator); end
+
+  def self.raise_on_invalid_const(); end
+
+  def self.stub(constant_name, value, options=T.unsafe(nil)); end
+end
+
+class RSpec::Mocks::DirectObjectReference
+  def const_to_replace(); end
+
+  def defined?(); end
+
+  def description(); end
+
+  def initialize(object); end
+
+  def target(); end
+
+  def when_loaded(); end
+end
+
+class RSpec::Mocks::DirectObjectReference
+end
+
+class RSpec::Mocks::Double
+  include ::RSpec::Mocks::TestDouble
+end
+
+class RSpec::Mocks::Double
+end
+
+class RSpec::Mocks::ErrorGenerator
+  def default_error_message(expectation, expected_args, actual_args); end
+
+  def describe_expectation(verb, message, expected_received_count, _actual_received_count, args); end
+
+  def expectation_on_nil_message(method_name); end
+
+  def initialize(target=T.unsafe(nil)); end
+
+  def intro(unwrapped=T.unsafe(nil)); end
+
+  def method_call_args_description(args, generic_prefix=T.unsafe(nil), matcher_prefix=T.unsafe(nil)); end
+
+  def opts(); end
+
+  def opts=(opts); end
+
+  def raise_already_invoked_error(message, calling_customization); end
+
+  def raise_cant_constrain_count_for_negated_have_received_error(count_constraint); end
+
+  def raise_double_negation_error(wrapped_expression); end
+
+  def raise_expectation_error(message, expected_received_count, argument_list_matcher, actual_received_count, expectation_count_type, args, backtrace_line=T.unsafe(nil), source_id=T.unsafe(nil)); end
+
+  def raise_expectation_on_mocked_method(method); end
+
+  def raise_expectation_on_nil_error(method_name); end
+
+  def raise_expectation_on_unstubbed_method(method); end
+
+  def raise_expired_test_double_error(); end
+
+  def raise_have_received_disallowed(type, reason); end
+
+  def raise_invalid_arguments_error(verifier); end
+
+  def raise_method_not_stubbed_error(method_name); end
+
+  def raise_missing_block_error(args_to_yield); end
+
+  def raise_missing_default_stub_error(expectation, args_for_multiple_calls); end
+
+  def raise_non_public_error(method_name, visibility); end
+
+  def raise_only_valid_on_a_partial_double(method); end
+
+  def raise_out_of_order_error(message); end
+
+  def raise_similar_message_args_error(expectation, args_for_multiple_calls, backtrace_line=T.unsafe(nil)); end
+
+  def raise_unexpected_message_args_error(expectation, args_for_multiple_calls, source_id=T.unsafe(nil)); end
+
+  def raise_unexpected_message_error(message, args); end
+
+  def raise_unimplemented_error(doubled_module, method_name, object); end
+
+  def raise_verifying_double_not_defined_error(ref); end
+
+  def raise_wrong_arity_error(args_to_yield, signature); end
+end
+
+class RSpec::Mocks::ErrorGenerator
+end
+
+module RSpec::Mocks::ExampleMethods
+  include ::RSpec::Mocks::ArgumentMatchers
+  def allow(target); end
+
+  def allow_any_instance_of(klass); end
+
+  def allow_message_expectations_on_nil(); end
+
+  def class_double(doubled_class, *args); end
+
+  def class_spy(*args); end
+
+  def double(*args); end
+
+  def expect_any_instance_of(klass); end
+
+  def have_received(method_name, &block); end
+
+  def hide_const(constant_name); end
+
+  def instance_double(doubled_class, *args); end
+
+  def instance_spy(*args); end
+
+  def object_double(object_or_name, *args); end
+
+  def object_spy(*args); end
+
+  def receive(method_name, &block); end
+
+  def receive_message_chain(*messages, &block); end
+
+  def receive_messages(message_return_value_hash); end
+
+  def spy(*args); end
+
+  def stub_const(constant_name, value, options=T.unsafe(nil)); end
+
+  def without_partial_double_verification(); end
+end
+
+module RSpec::Mocks::ExampleMethods::ExpectHost
+  def expect(target); end
+end
+
+module RSpec::Mocks::ExampleMethods::ExpectHost
+end
+
+module RSpec::Mocks::ExampleMethods
+  def self.declare_double(type, *args); end
+
+  def self.declare_verifying_double(type, ref, *args); end
+
+  def self.extended(object); end
+
+  def self.included(klass); end
+end
+
+class RSpec::Mocks::ExpectChain
+end
+
+class RSpec::Mocks::ExpectChain
+  def self.expect_chain_on(object, *chain, &blk); end
+end
+
+class RSpec::Mocks::ExpectationTarget
+  include ::RSpec::Mocks::ExpectationTargetMethods
+end
+
+class RSpec::Mocks::ExpectationTarget
+end
+
+module RSpec::Mocks::ExpectationTargetMethods
+  include ::RSpec::Mocks::TargetDelegationInstanceMethods
+  def expression(); end
+
+  def not_to(matcher, &block); end
+
+  def to(matcher, &block); end
+
+  def to_not(matcher, &block); end
+end
+
+module RSpec::Mocks::ExpectationTargetMethods
+  extend ::RSpec::Mocks::TargetDelegationClassMethods
+end
+
+class RSpec::Mocks::ExpiredTestDoubleError
+end
+
+class RSpec::Mocks::ExpiredTestDoubleError
+end
+
+class RSpec::Mocks::Implementation
+  def call(*args, &block); end
+
+  def initial_action(); end
+
+  def initial_action=(initial_action); end
+
+  def inner_action(); end
+
+  def inner_action=(inner_action); end
+
+  def present?(); end
+
+  def terminal_action(); end
+
+  def terminal_action=(terminal_action); end
+end
+
+class RSpec::Mocks::Implementation
+end
+
+class RSpec::Mocks::InstanceMethodReference
+end
+
+class RSpec::Mocks::InstanceMethodReference
+end
+
+class RSpec::Mocks::InstanceMethodStasher
+  def handle_restoration_failures(); end
+
+  def initialize(object, method); end
+
+  def method_is_stashed?(); end
+
+  def original_method(); end
+
+  def restore(); end
+
+  def stash(); end
+end
+
+class RSpec::Mocks::InstanceMethodStasher
+end
+
+class RSpec::Mocks::InstanceVerifyingDouble
+  include ::RSpec::Mocks::TestDouble
+  include ::RSpec::Mocks::VerifyingDouble
+end
+
+class RSpec::Mocks::InstanceVerifyingDouble
+end
+
+class RSpec::Mocks::MarshalExtension
+end
+
+class RSpec::Mocks::MarshalExtension
+  def self.patch!(); end
+
+  def self.unpatch!(); end
+end
+
+module RSpec::Mocks::Matchers
+end
+
+class RSpec::Mocks::Matchers::HaveReceived
+  include ::RSpec::Mocks::Matchers::Matcher
+  def at_least(*args); end
+
+  def at_most(*args); end
+
+  def description(); end
+
+  def does_not_match?(subject); end
+
+  def exactly(*args); end
+
+  def failure_message(); end
+
+  def failure_message_when_negated(); end
+
+  def initialize(method_name, &block); end
+
+  def matches?(subject, &block); end
+
+  def name(); end
+
+  def once(*args); end
+
+  def ordered(*args); end
+
+  def setup_allowance(_subject, &_block); end
+
+  def setup_any_instance_allowance(_subject, &_block); end
+
+  def setup_any_instance_expectation(_subject, &_block); end
+
+  def setup_any_instance_negative_expectation(_subject, &_block); end
+
+  def setup_expectation(subject, &block); end
+
+  def setup_negative_expectation(subject, &block); end
+
+  def thrice(*args); end
+
+  def time(*args); end
+
+  def times(*args); end
+
+  def twice(*args); end
+
+  def with(*args); end
+  ARGS_CONSTRAINTS = ::T.let(nil, ::T.untyped)
+  CONSTRAINTS = ::T.let(nil, ::T.untyped)
+  COUNT_CONSTRAINTS = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Mocks::Matchers::HaveReceived
+end
+
+module RSpec::Mocks::Matchers::Matcher
+end
+
+module RSpec::Mocks::Matchers::Matcher
+end
+
+class RSpec::Mocks::Matchers::Receive
+  include ::RSpec::Mocks::Matchers::Matcher
+  def and_call_original(*args, &block); end
+
+  def and_raise(*args, &block); end
+
+  def and_return(*args, &block); end
+
+  def and_throw(*args, &block); end
+
+  def and_wrap_original(*args, &block); end
+
+  def and_yield(*args, &block); end
+
+  def at_least(*args, &block); end
+
+  def at_most(*args, &block); end
+
+  def description(); end
+
+  def does_not_match?(subject, &block); end
+
+  def exactly(*args, &block); end
+
+  def initialize(message, block); end
+
+  def matches?(subject, &block); end
+
+  def name(); end
+
+  def never(*args, &block); end
+
+  def once(*args, &block); end
+
+  def ordered(*args, &block); end
+
+  def setup_allowance(subject, &block); end
+
+  def setup_any_instance_allowance(subject, &block); end
+
+  def setup_any_instance_expectation(subject, &block); end
+
+  def setup_any_instance_negative_expectation(subject, &block); end
+
+  def setup_expectation(subject, &block); end
+
+  def setup_negative_expectation(subject, &block); end
+
+  def thrice(*args, &block); end
+
+  def time(*args, &block); end
+
+  def times(*args, &block); end
+
+  def twice(*args, &block); end
+
+  def with(*args, &block); end
+end
+
+class RSpec::Mocks::Matchers::Receive::DefaultDescribable
+  def description_for(verb); end
+
+  def initialize(message); end
+end
+
+class RSpec::Mocks::Matchers::Receive::DefaultDescribable
+end
+
+class RSpec::Mocks::Matchers::Receive
+end
+
+class RSpec::Mocks::Matchers::ReceiveMessageChain
+  include ::RSpec::Mocks::Matchers::Matcher
+  def and_call_original(*args, &block); end
+
+  def and_raise(*args, &block); end
+
+  def and_return(*args, &block); end
+
+  def and_throw(*args, &block); end
+
+  def and_yield(*args, &block); end
+
+  def description(); end
+
+  def does_not_match?(*_args); end
+
+  def initialize(chain, &block); end
+
+  def matches?(subject, &block); end
+
+  def name(); end
+
+  def setup_allowance(subject, &block); end
+
+  def setup_any_instance_allowance(subject, &block); end
+
+  def setup_any_instance_expectation(subject, &block); end
+
+  def setup_expectation(subject, &block); end
+
+  def setup_negative_expectation(*_args); end
+
+  def with(*args, &block); end
+end
+
+class RSpec::Mocks::Matchers::ReceiveMessageChain
+end
+
+class RSpec::Mocks::Matchers::ReceiveMessages
+  include ::RSpec::Mocks::Matchers::Matcher
+  def description(); end
+
+  def does_not_match?(_subject); end
+
+  def initialize(message_return_value_hash); end
+
+  def matches?(subject); end
+
+  def name(); end
+
+  def setup_allowance(subject); end
+
+  def setup_any_instance_allowance(subject); end
+
+  def setup_any_instance_expectation(subject); end
+
+  def setup_expectation(subject); end
+
+  def setup_negative_expectation(_subject); end
+
+  def warn_about_block(); end
+end
+
+class RSpec::Mocks::Matchers::ReceiveMessages
+end
+
+module RSpec::Mocks::Matchers
+end
+
+class RSpec::Mocks::MessageChain
+  def block(); end
+
+  def chain(); end
+
+  def initialize(object, *chain, &blk); end
+
+  def object(); end
+
+  def setup_chain(); end
+end
+
+class RSpec::Mocks::MessageChain
+end
+
+class RSpec::Mocks::MessageExpectation
+  include ::RSpec::Mocks::MessageExpectation::ImplementationDetails
+  def and_call_original(); end
+
+  def and_raise(*args); end
+
+  def and_return(first_value, *values); end
+
+  def and_throw(*args); end
+
+  def and_wrap_original(&block); end
+
+  def and_yield(*args, &block); end
+
+  def at_least(n, &block); end
+
+  def at_most(n, &block); end
+
+  def exactly(n, &block); end
+
+  def never(); end
+
+  def once(&block); end
+
+  def ordered(&block); end
+
+  def thrice(&block); end
+
+  def time(&block); end
+
+  def times(&block); end
+
+  def twice(&block); end
+
+  def with(*args, &block); end
+end
+
+module RSpec::Mocks::MessageExpectation::ImplementationDetails
+  def actual_received_count_matters?(); end
+
+  def additional_expected_calls(); end
+
+  def advise(*args); end
+
+  def and_yield_receiver_to_implementation(); end
+
+  def argument_list_matcher=(argument_list_matcher); end
+
+  def called_max_times?(); end
+
+  def description_for(verb); end
+
+  def ensure_expected_ordering_received!(); end
+
+  def error_generator(); end
+
+  def error_generator=(error_generator); end
+
+  def expectation_count_type(); end
+
+  def expected_args(); end
+
+  def expected_from=(expected_from); end
+
+  def expected_messages_received?(); end
+
+  def expected_received_count=(expected_received_count); end
+
+  def generate_error(); end
+
+  def ignoring_args?(); end
+
+  def implementation(); end
+
+  def implementation=(implementation); end
+
+  def increase_actual_received_count!(); end
+
+  def initialize(error_generator, expectation_ordering, expected_from, method_double, type=T.unsafe(nil), opts=T.unsafe(nil), &implementation_block); end
+
+  def invoke(parent_stub, *args, &block); end
+
+  def invoke_without_incrementing_received_count(parent_stub, *args, &block); end
+
+  def matches?(message, *args); end
+
+  def matches_at_least_count?(); end
+
+  def matches_at_most_count?(); end
+
+  def matches_exact_count?(); end
+
+  def matches_name_but_not_args(message, *args); end
+
+  def message(); end
+
+  def negative?(); end
+
+  def negative_expectation_for?(message); end
+
+  def ordered?(); end
+
+  def orig_object(); end
+
+  def raise_out_of_order_error(); end
+
+  def raise_unexpected_message_args_error(args_for_multiple_calls); end
+
+  def safe_invoke(parent_stub, *args, &block); end
+
+  def similar_messages(); end
+
+  def type(); end
+
+  def unadvise(args); end
+
+  def verify_messages_received(); end
+
+  def yield_receiver_to_implementation_block?(); end
+end
+
+module RSpec::Mocks::MessageExpectation::ImplementationDetails
+end
+
+class RSpec::Mocks::MessageExpectation
+end
+
+class RSpec::Mocks::MethodDouble
+  def add_default_stub(*args, &implementation); end
+
+  def add_expectation(error_generator, expectation_ordering, expected_from, opts, &implementation); end
+
+  def add_simple_expectation(method_name, response, error_generator, backtrace_line); end
+
+  def add_simple_stub(method_name, response); end
+
+  def add_stub(error_generator, expectation_ordering, expected_from, opts=T.unsafe(nil), &implementation); end
+
+  def build_expectation(error_generator, expectation_ordering); end
+
+  def clear(); end
+
+  def configure_method(); end
+
+  def define_proxy_method(); end
+
+  def expectations(); end
+
+  def initialize(object, method_name, proxy); end
+
+  def message_expectation_class(); end
+
+  def method_name(); end
+
+  def method_stasher(); end
+
+  def object(); end
+
+  def object_singleton_class(); end
+
+  def original_implementation_callable(); end
+
+  def original_method(); end
+
+  def proxy_method_invoked(_obj, *args, &block); end
+
+  def raise_method_not_stubbed_error(); end
+
+  def remove_stub(); end
+
+  def remove_stub_if_present(); end
+
+  def reset(); end
+
+  def restore_original_method(); end
+
+  def restore_original_visibility(); end
+
+  def save_original_implementation_callable!(); end
+
+  def setup_simple_method_double(method_name, response, collection, error_generator=T.unsafe(nil), backtrace_line=T.unsafe(nil)); end
+
+  def show_frozen_warning(); end
+
+  def stubs(); end
+
+  def verify(); end
+
+  def visibility(); end
+end
+
+class RSpec::Mocks::MethodDouble::RSpecPrependedModule
+end
+
+class RSpec::Mocks::MethodDouble::RSpecPrependedModule
+end
+
+class RSpec::Mocks::MethodDouble
+end
+
+class RSpec::Mocks::MethodReference
+  def defined?(); end
+
+  def implemented?(); end
+
+  def initialize(object_reference, method_name); end
+
+  def unimplemented?(); end
+
+  def visibility(); end
+
+  def with_signature(); end
+end
+
+class RSpec::Mocks::MethodReference
+  def self.for(object_reference, method_name); end
+
+  def self.instance_method_visibility_for(klass, method_name); end
+
+  def self.method_defined_at_any_visibility?(klass, method_name); end
+
+  def self.method_visibility_for(object, method_name); end
+end
+
+class RSpec::Mocks::MockExpectationAlreadyInvokedError
+end
+
+class RSpec::Mocks::MockExpectationAlreadyInvokedError
+end
+
+class RSpec::Mocks::MockExpectationError
+end
+
+class RSpec::Mocks::MockExpectationError
+end
+
+class RSpec::Mocks::NamedObjectReference
+  def const_to_replace(); end
+
+  def defined?(); end
+
+  def description(); end
+
+  def initialize(const_name); end
+
+  def target(); end
+
+  def when_loaded(); end
+end
+
+class RSpec::Mocks::NamedObjectReference
+end
+
+class RSpec::Mocks::NegationUnsupportedError
+end
+
+class RSpec::Mocks::NegationUnsupportedError
+end
+
+class RSpec::Mocks::NestedSpace
+  def initialize(parent); end
+end
+
+class RSpec::Mocks::NestedSpace
+end
+
+class RSpec::Mocks::NoCallbackInvocationStrategy
+  def call(_doubled_module); end
+end
+
+class RSpec::Mocks::NoCallbackInvocationStrategy
+end
+
+class RSpec::Mocks::ObjectMethodReference
+end
+
+class RSpec::Mocks::ObjectMethodReference
+end
+
+class RSpec::Mocks::ObjectReference
+  MODULE_NAME_METHOD = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Mocks::ObjectReference
+  def self.for(object_module_or_name, allow_direct_object_refs=T.unsafe(nil)); end
+end
+
+class RSpec::Mocks::ObjectVerifyingDouble
+  include ::RSpec::Mocks::ObjectVerifyingDoubleMethods
+  include ::RSpec::Mocks::TestDouble
+  include ::RSpec::Mocks::VerifyingDouble
+end
+
+class RSpec::Mocks::ObjectVerifyingDouble
+end
+
+module RSpec::Mocks::ObjectVerifyingDoubleMethods
+  include ::RSpec::Mocks::TestDouble
+  include ::RSpec::Mocks::VerifyingDouble
+  def as_stubbed_const(options=T.unsafe(nil)); end
+end
+
+module RSpec::Mocks::ObjectVerifyingDoubleMethods
+end
+
+class RSpec::Mocks::OrderGroup
+  def clear(); end
+
+  def consume(); end
+
+  def empty?(); end
+
+  def handle_order_constraint(expectation); end
+
+  def invoked(message); end
+
+  def ready_for?(expectation); end
+
+  def register(expectation); end
+
+  def verify_invocation_order(expectation); end
+end
+
+class RSpec::Mocks::OrderGroup
+end
+
+class RSpec::Mocks::OutsideOfExampleError
+end
+
+class RSpec::Mocks::OutsideOfExampleError
+end
+
+class RSpec::Mocks::PartialClassDoubleProxy
+  include ::RSpec::Mocks::PartialClassDoubleProxyMethods
+end
+
+class RSpec::Mocks::PartialClassDoubleProxy
+end
+
+module RSpec::Mocks::PartialClassDoubleProxyMethods
+  def initialize(source_space, *args); end
+
+  def method_double_from_ancestor_for(message); end
+
+  def original_method_handle_for(message); end
+
+  def original_unbound_method_handle_from_ancestor_for(message); end
+
+  def superclass_proxy(); end
+end
+
+module RSpec::Mocks::PartialClassDoubleProxyMethods
+end
+
+class RSpec::Mocks::PartialDoubleProxy
+  def original_method_handle_for(message); end
+
+  def visibility_for(method_name); end
+end
+
+class RSpec::Mocks::PartialDoubleProxy
+end
+
+class RSpec::Mocks::Proxy
+  def add_message_expectation(method_name, opts=T.unsafe(nil), &block); end
+
+  def add_simple_expectation(method_name, response, location); end
+
+  def add_simple_stub(method_name, response); end
+
+  def add_stub(method_name, opts=T.unsafe(nil), &implementation); end
+
+  def build_expectation(method_name); end
+
+  def check_for_unexpected_arguments(expectation); end
+
+  def ensure_implemented(*_args); end
+
+  def has_negative_expectation?(message); end
+
+  def initialize(object, order_group, options=T.unsafe(nil)); end
+
+  def message_received(message, *args, &block); end
+
+  def messages_arg_list(); end
+
+  def method_double_if_exists_for_message(message); end
+
+  def object(); end
+
+  def original_method_handle_for(_message); end
+
+  def prepended_modules_of_singleton_class(); end
+
+  def raise_missing_default_stub_error(expectation, args_for_multiple_calls); end
+
+  def raise_unexpected_message_error(method_name, args); end
+
+  def received_message?(method_name, *args, &block); end
+
+  def record_message_received(message, *args, &block); end
+
+  def remove_stub(method_name); end
+
+  def remove_stub_if_present(method_name); end
+
+  def replay_received_message_on(expectation, &block); end
+
+  def reset(); end
+
+  def verify(); end
+
+  def visibility_for(_method_name); end
+  DEFAULT_MESSAGE_EXPECTATION_OPTS = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Mocks::Proxy::SpecificMessage
+  def ==(expectation); end
+
+  def args(); end
+
+  def args=(_); end
+
+  def message(); end
+
+  def message=(_); end
+
+  def object(); end
+
+  def object=(_); end
+end
+
+class RSpec::Mocks::Proxy::SpecificMessage
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class RSpec::Mocks::Proxy
+  def self.prepended_modules_of(klass); end
+end
+
+class RSpec::Mocks::ProxyForNil
+  def disallow_expectations(); end
+
+  def disallow_expectations=(disallow_expectations); end
+
+  def initialize(order_group); end
+
+  def warn_about_expectations(); end
+
+  def warn_about_expectations=(warn_about_expectations); end
+end
+
+class RSpec::Mocks::ProxyForNil
+end
+
+class RSpec::Mocks::RootSpace
+  def any_instance_proxy_for(*_args); end
+
+  def any_instance_recorder_for(*_args); end
+
+  def any_instance_recorders_from_ancestry_of(_object); end
+
+  def new_scope(); end
+
+  def proxy_for(*_args); end
+
+  def register_constant_mutator(_mutator); end
+
+  def registered?(_object); end
+
+  def reset_all(); end
+
+  def superclass_proxy_for(*_args); end
+
+  def verify_all(); end
+end
+
+class RSpec::Mocks::RootSpace
+end
+
+class RSpec::Mocks::SimpleMessageExpectation
+  def called_max_times?(); end
+
+  def initialize(message, response, error_generator, backtrace_line=T.unsafe(nil)); end
+
+  def invoke(*_); end
+
+  def matches?(message, *_); end
+
+  def unadvise(_); end
+
+  def verify_messages_received(); end
+end
+
+class RSpec::Mocks::SimpleMessageExpectation
+end
+
+class RSpec::Mocks::Space
+  def any_instance_mutex(); end
+
+  def any_instance_proxy_for(klass); end
+
+  def any_instance_recorder_for(klass, only_return_existing=T.unsafe(nil)); end
+
+  def any_instance_recorders(); end
+
+  def any_instance_recorders_from_ancestry_of(object); end
+
+  def constant_mutator_for(name); end
+
+  def ensure_registered(object); end
+
+  def new_scope(); end
+
+  def proxies(); end
+
+  def proxies_of(klass); end
+
+  def proxy_for(object); end
+
+  def proxy_mutex(); end
+
+  def register_constant_mutator(mutator); end
+
+  def registered?(object); end
+
+  def reset_all(); end
+
+  def superclass_proxy_for(klass); end
+
+  def verify_all(); end
+end
+
+class RSpec::Mocks::Space
+end
+
+class RSpec::Mocks::StubChain
+end
+
+class RSpec::Mocks::StubChain
+  def self.stub_chain_on(object, *chain, &blk); end
+end
+
+module RSpec::Mocks::Syntax
+end
+
+module RSpec::Mocks::Syntax
+  def self.default_should_syntax_host(); end
+
+  def self.disable_expect(syntax_host=T.unsafe(nil)); end
+
+  def self.disable_should(syntax_host=T.unsafe(nil)); end
+
+  def self.enable_expect(syntax_host=T.unsafe(nil)); end
+
+  def self.enable_should(syntax_host=T.unsafe(nil)); end
+
+  def self.expect_enabled?(syntax_host=T.unsafe(nil)); end
+
+  def self.should_enabled?(syntax_host=T.unsafe(nil)); end
+
+  def self.warn_about_should!(); end
+
+  def self.warn_unless_should_configured(method_name, replacement=T.unsafe(nil)); end
+end
+
+class RSpec::Mocks::TargetBase
+  include ::RSpec::Mocks::TargetDelegationInstanceMethods
+  def initialize(target); end
+end
+
+class RSpec::Mocks::TargetBase
+  extend ::RSpec::Mocks::TargetDelegationClassMethods
+end
+
+module RSpec::Mocks::TargetDelegationClassMethods
+  def delegate_not_to(matcher_method, options=T.unsafe(nil)); end
+
+  def delegate_to(matcher_method); end
+
+  def disallow_negation(method_name); end
+end
+
+module RSpec::Mocks::TargetDelegationClassMethods
+end
+
+module RSpec::Mocks::TargetDelegationInstanceMethods
+  def target(); end
+end
+
+module RSpec::Mocks::TargetDelegationInstanceMethods
+end
+
+module RSpec::Mocks::TestDouble
+  def ==(other); end
+
+  def __build_mock_proxy_unless_expired(order_group); end
+
+  def __disallow_further_usage!(); end
+
+  def as_null_object(); end
+
+  def freeze(); end
+
+  def initialize(name=T.unsafe(nil), stubs=T.unsafe(nil)); end
+
+  def inspect(); end
+
+  def null_object?(); end
+
+  def respond_to?(message, incl_private=T.unsafe(nil)); end
+
+  def to_s(); end
+end
+
+module RSpec::Mocks::TestDouble
+end
+
+module RSpec::Mocks::TestDoubleFormatter
+end
+
+module RSpec::Mocks::TestDoubleFormatter
+  def self.format(dbl, unwrap=T.unsafe(nil)); end
+end
+
+class RSpec::Mocks::TestDoubleProxy
+end
+
+class RSpec::Mocks::TestDoubleProxy
+end
+
+class RSpec::Mocks::UnsupportedMatcherError
+end
+
+class RSpec::Mocks::UnsupportedMatcherError
+end
+
+module RSpec::Mocks::VerifyingDouble
+  def __send__(name, *args, &block); end
+
+  def initialize(doubled_module, *args); end
+
+  def method_missing(message, *args, &block); end
+
+  def respond_to?(message, include_private=T.unsafe(nil)); end
+
+  def send(name, *args, &block); end
+end
+
+module RSpec::Mocks::VerifyingDouble::SilentIO
+end
+
+module RSpec::Mocks::VerifyingDouble::SilentIO
+end
+
+module RSpec::Mocks::VerifyingDouble
+end
+
+class RSpec::Mocks::VerifyingDoubleNotDefinedError
+end
+
+class RSpec::Mocks::VerifyingDoubleNotDefinedError
+end
+
+class RSpec::Mocks::VerifyingExistingClassNewMethodDouble
+end
+
+class RSpec::Mocks::VerifyingExistingClassNewMethodDouble
+end
+
+class RSpec::Mocks::VerifyingExistingMethodDouble
+  def initialize(object, method_name, proxy); end
+
+  def unimplemented?(); end
+
+  def with_signature(); end
+end
+
+class RSpec::Mocks::VerifyingExistingMethodDouble
+  def self.for(object, method_name, proxy); end
+end
+
+class RSpec::Mocks::VerifyingMessageExpectation
+  def initialize(*args); end
+
+  def method_reference(); end
+
+  def method_reference=(method_reference); end
+end
+
+class RSpec::Mocks::VerifyingMessageExpectation
+end
+
+class RSpec::Mocks::VerifyingMethodDouble
+  def add_expectation(*args, &block); end
+
+  def add_stub(*args, &block); end
+
+  def initialize(object, method_name, proxy, method_reference); end
+
+  def proxy_method_invoked(obj, *args, &block); end
+
+  def validate_arguments!(actual_args); end
+end
+
+class RSpec::Mocks::VerifyingMethodDouble
+end
+
+class RSpec::Mocks::VerifyingPartialClassDoubleProxy
+  include ::RSpec::Mocks::PartialClassDoubleProxyMethods
+end
+
+class RSpec::Mocks::VerifyingPartialClassDoubleProxy
+end
+
+class RSpec::Mocks::VerifyingPartialDoubleProxy
+  include ::RSpec::Mocks::VerifyingProxyMethods
+  def ensure_implemented(_method_name); end
+
+  def initialize(object, expectation_ordering, optional_callback_invocation_strategy=T.unsafe(nil)); end
+
+  def method_reference(); end
+end
+
+class RSpec::Mocks::VerifyingPartialDoubleProxy
+end
+
+class RSpec::Mocks::VerifyingProxy
+  include ::RSpec::Mocks::VerifyingProxyMethods
+  def initialize(object, order_group, doubled_module, method_reference_class); end
+
+  def method_reference(); end
+
+  def validate_arguments!(method_name, args); end
+
+  def visibility_for(method_name); end
+end
+
+class RSpec::Mocks::VerifyingProxy
+end
+
+module RSpec::Mocks::VerifyingProxyMethods
+  def add_message_expectation(method_name, opts=T.unsafe(nil), &block); end
+
+  def add_simple_stub(method_name, *args); end
+
+  def add_stub(method_name, opts=T.unsafe(nil), &implementation); end
+
+  def ensure_implemented(method_name); end
+
+  def ensure_publicly_implemented(method_name, _object); end
+end
+
+module RSpec::Mocks::VerifyingProxyMethods
+end
+
+module RSpec::Mocks::Version
+  STRING = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Mocks::Version
+end
+
+module RSpec::Mocks
+  def self.allow_message(subject, message, opts=T.unsafe(nil), &block); end
+
+  def self.configuration(); end
+
+  def self.error_generator(); end
+
+  def self.expect_message(subject, message, opts=T.unsafe(nil), &block); end
+
+  def self.setup(); end
+
+  def self.space(); end
+
+  def self.teardown(); end
+
+  def self.verify(); end
+
+  def self.with_temporary_scope(); end
+end
+
 RSpec::SharedContext = RSpec::Core::SharedContext
 
 module RSpec::Support
@@ -2646,6 +12402,12 @@ end
 
 module RSpec::Support::AllExceptionsExceptOnesWeMustNotRescue
   AVOID_RESCUING = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Support::BlockSignature
+end
+
+class RSpec::Support::BlockSignature
 end
 
 class RSpec::Support::Differ
@@ -2671,7 +12433,248 @@ class RSpec::Support::EncodedString
   UTF_8 = ::T.let(nil, ::T.untyped)
 end
 
+module RSpec::Support::FuzzyMatcher
+end
+
+module RSpec::Support::FuzzyMatcher
+  def self.values_match?(expected, actual); end
+end
+
+class RSpec::Support::LooseSignatureVerifier
+end
+
+class RSpec::Support::LooseSignatureVerifier::SignatureWithKeywordArgumentsMatcher
+  def has_kw_args_in?(args); end
+
+  def initialize(signature); end
+
+  def invalid_kw_args_from(_kw_args); end
+
+  def missing_kw_args_from(_kw_args); end
+
+  def non_kw_args_arity_description(); end
+
+  def valid_non_kw_args?(*args); end
+end
+
+class RSpec::Support::LooseSignatureVerifier::SignatureWithKeywordArgumentsMatcher
+end
+
+class RSpec::Support::LooseSignatureVerifier
+end
+
+class RSpec::Support::MethodSignature
+  def arbitrary_kw_args?(); end
+
+  def classify_arity(arity=T.unsafe(nil)); end
+
+  def classify_parameters(); end
+
+  def could_contain_kw_args?(args); end
+
+  def description(); end
+
+  def has_kw_args_in?(args); end
+
+  def initialize(method); end
+
+  def invalid_kw_args_from(given_kw_args); end
+
+  def max_non_kw_args(); end
+
+  def min_non_kw_args(); end
+
+  def missing_kw_args_from(given_kw_args); end
+
+  def non_kw_args_arity_description(); end
+
+  def optional_kw_args(); end
+
+  def required_kw_args(); end
+
+  def unlimited_args?(); end
+
+  def valid_non_kw_args?(positional_arg_count, optional_max_arg_count=T.unsafe(nil)); end
+  INFINITY = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Support::MethodSignature
+end
+
+class RSpec::Support::MethodSignatureExpectation
+  def empty?(); end
+
+  def expect_arbitrary_keywords(); end
+
+  def expect_arbitrary_keywords=(expect_arbitrary_keywords); end
+
+  def expect_unlimited_arguments(); end
+
+  def expect_unlimited_arguments=(expect_unlimited_arguments); end
+
+  def keywords(); end
+
+  def keywords=(values); end
+
+  def max_count(); end
+
+  def max_count=(number); end
+
+  def min_count(); end
+
+  def min_count=(number); end
+end
+
+class RSpec::Support::MethodSignatureExpectation
+end
+
+class RSpec::Support::MethodSignatureVerifier
+  def error_message(); end
+
+  def initialize(signature, args=T.unsafe(nil)); end
+
+  def kw_args(); end
+
+  def max_non_kw_args(); end
+
+  def min_non_kw_args(); end
+
+  def non_kw_args(); end
+
+  def valid?(); end
+
+  def with_expectation(expectation); end
+end
+
+class RSpec::Support::MethodSignatureVerifier
+end
+
 RSpec::Support::Mutex = Thread::Mutex
+
+class RSpec::Support::ObjectFormatter
+  def format(object); end
+
+  def initialize(max_formatted_output_length=T.unsafe(nil)); end
+
+  def max_formatted_output_length(); end
+
+  def max_formatted_output_length=(max_formatted_output_length); end
+
+  def prepare_array(array); end
+
+  def prepare_element(element); end
+
+  def prepare_for_inspection(object); end
+
+  def prepare_hash(input_hash); end
+
+  def recursive_structure?(object); end
+
+  def sort_hash_keys(input_hash); end
+
+  def with_entering_structure(structure); end
+  ELLIPSIS = ::T.let(nil, ::T.untyped)
+  INSPECTOR_CLASSES = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Support::ObjectFormatter::BaseInspector
+  def formatter(); end
+
+  def formatter=(_); end
+
+  def object(); end
+
+  def object=(_); end
+
+  def pretty_print(pp); end
+end
+
+class RSpec::Support::ObjectFormatter::BaseInspector
+  def self.[](*_); end
+
+  def self.can_inspect?(_object); end
+
+  def self.members(); end
+end
+
+class RSpec::Support::ObjectFormatter::BigDecimalInspector
+end
+
+class RSpec::Support::ObjectFormatter::BigDecimalInspector
+  def self.can_inspect?(object); end
+end
+
+class RSpec::Support::ObjectFormatter::DateTimeInspector
+  FORMAT = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Support::ObjectFormatter::DateTimeInspector
+  def self.can_inspect?(object); end
+end
+
+class RSpec::Support::ObjectFormatter::DelegatorInspector
+end
+
+class RSpec::Support::ObjectFormatter::DelegatorInspector
+  def self.can_inspect?(object); end
+end
+
+class RSpec::Support::ObjectFormatter::DescribableMatcherInspector
+end
+
+class RSpec::Support::ObjectFormatter::DescribableMatcherInspector
+  def self.can_inspect?(object); end
+end
+
+class RSpec::Support::ObjectFormatter::InspectableItem
+  def pretty_print(pp); end
+
+  def text(); end
+
+  def text=(_); end
+end
+
+class RSpec::Support::ObjectFormatter::InspectableItem
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class RSpec::Support::ObjectFormatter::InspectableObjectInspector
+end
+
+class RSpec::Support::ObjectFormatter::InspectableObjectInspector
+  def self.can_inspect?(object); end
+end
+
+class RSpec::Support::ObjectFormatter::TimeInspector
+  FORMAT = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Support::ObjectFormatter::TimeInspector
+  def self.can_inspect?(object); end
+end
+
+class RSpec::Support::ObjectFormatter::UninspectableObjectInspector
+  def klass(); end
+
+  def native_object_id(); end
+  OBJECT_ID_FORMAT = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Support::ObjectFormatter::UninspectableObjectInspector
+  def self.can_inspect?(object); end
+end
+
+class RSpec::Support::ObjectFormatter
+  def self.default_instance(); end
+
+  def self.format(object); end
+
+  def self.prepare_for_inspection(object); end
+end
+
+RSpec::Support::StrictSignatureVerifier = RSpec::Support::MethodSignatureVerifier
 
 module RSpec::Support::Version
   STRING = ::T.let(nil, ::T.untyped)
@@ -2686,11 +12689,37 @@ module RSpec::Support
 
   def self.register_matcher_definition(&block); end
 
+  def self.require_rspec_expectations(f); end
+
+  def self.require_rspec_matchers(f); end
+
+  def self.require_rspec_mocks(f); end
+
   def self.rspec_description_for_object(object); end
 end
 
 module RSpec::Version
   STRING = ::T.let(nil, ::T.untyped)
+end
+
+class Rainbow::Color::RGB
+  def self.to_ansi_domain(value); end
+end
+
+class Rainbow::NullPresenter
+  def method_missing(method_name, *args); end
+end
+
+class Rainbow::Presenter
+  def method_missing(method_name, *args); end
+end
+
+class Rainbow::StringUtils
+  def self.uncolor(string); end
+end
+
+module Rainbow
+  def self.new(); end
 end
 
 module Rake
@@ -2772,29 +12801,15 @@ RakeFileUtils = Rake::FileUtilsExt
 
 module Random::Formatter
   def alphanumeric(n=T.unsafe(nil)); end
-
   ALPHANUMERIC = ::T.let(nil, ::T.untyped)
 end
 
 class Random
-  extend ::Random::Formatter
-  def self.bytes(_); end
-
   def self.urandom(_); end
-end
-
-class Range
-  def %(_); end
-
-  def entries(); end
-
-  def to_a(); end
 end
 
 module RbConfig
   def self.expand(val, config=T.unsafe(nil)); end
-
-  def self.fire_update!(key, val, mkconf=T.unsafe(nil), conf=T.unsafe(nil)); end
 
   def self.ruby(); end
 end
@@ -2805,36 +12820,6 @@ end
 
 class Regexp
   def self.union(*_); end
-end
-
-module RubyVM::AbstractSyntaxTree
-end
-
-class RubyVM::AbstractSyntaxTree::Node
-  def children(); end
-
-  def first_column(); end
-
-  def first_lineno(); end
-
-  def last_column(); end
-
-  def last_lineno(); end
-
-  def pretty_print_children(q, names=T.unsafe(nil)); end
-
-  def type(); end
-end
-
-class RubyVM::AbstractSyntaxTree::Node
-end
-
-module RubyVM::AbstractSyntaxTree
-  def self.of(_); end
-
-  def self.parse(_); end
-
-  def self.parse_file(_); end
 end
 
 class RubyVM::InstructionSequence
@@ -2883,20 +12868,7 @@ class RubyVM::InstructionSequence
   def self.of(_); end
 end
 
-module RubyVM::MJIT
-end
-
-module RubyVM::MJIT
-  def self.enabled?(); end
-
-  def self.pause(*_); end
-
-  def self.resume(); end
-end
-
 class RubyVM
-  def self.resolve_feature_path(_); end
-
   def self.stat(*_); end
 end
 
@@ -2914,8 +12886,6 @@ class Set
   def divide(&func); end
 
   def eql?(o); end
-
-  def filter!(&block); end
 
   def flatten_merge(set, seen=T.unsafe(nil)); end
 
@@ -2975,6 +12945,10 @@ class SimpleCov::LinesClassifier
   WHITESPACE_OR_COMMENT_LINE = ::T.let(nil, ::T.untyped)
 end
 
+class SimpleDelegator
+  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
+end
+
 module SingleForwardable
   def def_delegator(accessor, method, ali=T.unsafe(nil)); end
 
@@ -3006,8 +12980,6 @@ end
 module Singleton
   def self.__init__(klass); end
 end
-
-SizedQueue = Thread::SizedQueue
 
 class Sorbet::Private::ConstantLookupCache
   def all_module_aliases(); end
@@ -3163,13 +13135,13 @@ class Sorbet::Private::GemGeneratorTracepoint::Tracer
 
   def self.install_tracepoints(); end
 
-  def self.method_added(mod, method, singleton); end
+  def self.on_method_added(mod, method, singleton); end
 
-  def self.module_created(mod); end
+  def self.on_module_created(mod); end
 
-  def self.module_extended(extended, extender); end
+  def self.on_module_extended(extended, extender); end
 
-  def self.module_included(included, includer); end
+  def self.on_module_included(included, includer); end
 
   def self.pre_cache_module_methods(); end
 
@@ -3326,6 +13298,10 @@ class Sorbet::Private::RequireEverything
 
   def self.rails?(); end
 
+  def self.rails_load_paths(); end
+
+  def self.rb_file_paths(); end
+
   def self.require_all_files(); end
 
   def self.require_everything(); end
@@ -3422,25 +13398,11 @@ end
 
 class String
   include ::JSON::Ext::Generator::GeneratorMethods::String
-  def +@(); end
-
-  def -@(); end
-
   def []=(*_); end
 
   def casecmp?(_); end
 
-  def delete_prefix(_); end
-
-  def delete_prefix!(_); end
-
-  def delete_suffix(_); end
-
-  def delete_suffix!(_); end
-
   def each_grapheme_cluster(); end
-
-  def encode(*_); end
 
   def encode!(*_); end
 
@@ -3463,7 +13425,6 @@ class String
   def unicode_normalized?(*_); end
 
   def unpack1(_); end
-
 end
 
 class String
@@ -3474,7 +13435,6 @@ class StringIO
   def length(); end
 
   def truncate(_); end
-
 end
 
 class StringScanner
@@ -3580,8 +13540,6 @@ class Struct
 
   def each_pair(); end
 
-  def filter(*_); end
-
   def length(); end
 
   def members(); end
@@ -3605,15 +13563,6 @@ Struct::Passwd = Etc::Passwd
 
 Struct::Tms = Process::Tms
 
-class Symbol
-  def casecmp?(_); end
-
-  def match?(*_); end
-
-  def next(); end
-
-end
-
 class SystemCallError
   def errno(); end
 end
@@ -3624,187 +13573,8 @@ class SystemExit
   def success?(); end
 end
 
-class Thread
-  def abort_on_exception(); end
-
-  def abort_on_exception=(abort_on_exception); end
-
-  def add_trace_func(_); end
-
-  def backtrace(*_); end
-
-  def backtrace_locations(*_); end
-
-  def exit(); end
-
-  def fetch(*_); end
-
-  def group(); end
-
-  def initialize(*_); end
-
-  def join(*_); end
-
-  def key?(_); end
-
-  def keys(); end
-
-  def name(); end
-
-  def name=(name); end
-
-  def pending_interrupt?(*_); end
-
-  def priority(); end
-
-  def priority=(priority); end
-
-  def report_on_exception(); end
-
-  def report_on_exception=(report_on_exception); end
-
-  def run(); end
-
-  def safe_level(); end
-
-  def status(); end
-
-  def stop?(); end
-
-  def terminate(); end
-
-  def thread_variable?(_); end
-
-  def thread_variable_get(_); end
-
-  def thread_variable_set(_, _1); end
-
-  def thread_variables(); end
-
-  def value(); end
-
-  def wakeup(); end
-end
-
-class Thread::ConditionVariable
-  def broadcast(); end
-
-  def marshal_dump(); end
-
-  def signal(); end
-
-  def wait(*_); end
-end
-
-class Thread::Mutex
-  def lock(); end
-
-  def locked?(); end
-
-  def owned?(); end
-
-  def synchronize(); end
-
-  def try_lock(); end
-
-  def unlock(); end
-end
-
-class Thread::Queue
-  def <<(_); end
-
-  def clear(); end
-
-  def close(); end
-
-  def closed?(); end
-
-  def deq(*_); end
-
-  def empty?(); end
-
-  def enq(_); end
-
-  def length(); end
-
-  def marshal_dump(); end
-
-  def num_waiting(); end
-
-  def pop(*_); end
-
-  def push(_); end
-
-  def shift(*_); end
-
-  def size(); end
-end
-
-class Thread::SizedQueue
-  def <<(*_); end
-
-  def enq(*_); end
-
-  def initialize(_); end
-
-  def max(); end
-
-  def max=(max); end
-
-  def push(*_); end
-end
-
-class Thread
-  def self.abort_on_exception(); end
-
-  def self.abort_on_exception=(abort_on_exception); end
-
-  def self.exclusive(&block); end
-
-  def self.exit(); end
-
-  def self.fork(*_); end
-
-  def self.handle_interrupt(_); end
-
-  def self.kill(_); end
-
-  def self.list(); end
-
-  def self.pass(); end
-
-  def self.pending_interrupt?(*_); end
-
-  def self.report_on_exception(); end
-
-  def self.report_on_exception=(report_on_exception); end
-
-  def self.start(*_); end
-
-  def self.stop(); end
-end
-
-class ThreadGroup
-  def add(_); end
-
-  def enclose(); end
-
-  def enclosed?(); end
-
-  def list(); end
-  Default = ::T.let(nil, ::T.untyped)
-end
-
 class TracePoint
-  def __enable(_, _1); end
-
-  def eval_script(); end
-
   def event(); end
-
-  def instruction_sequence(); end
-
-  def parameters(); end
 end
 
 class TrueClass
@@ -3835,147 +13605,6 @@ end
 
 class URI::FTP
   def self.new2(user, password, host, port, path, typecode=T.unsafe(nil), arg_check=T.unsafe(nil)); end
-end
-
-class URI::File
-  def check_password(user); end
-
-  def check_user(user); end
-
-  def check_userinfo(user); end
-
-  def set_userinfo(v); end
-  COMPONENT = ::T.let(nil, ::T.untyped)
-  DEFAULT_PORT = ::T.let(nil, ::T.untyped)
-end
-
-class URI::File
-end
-
-class URI::Generic
-  def +(oth); end
-
-  def -(oth); end
-
-  def ==(oth); end
-
-  def absolute(); end
-
-  def absolute?(); end
-
-  def coerce(oth); end
-
-  def component(); end
-
-  def component_ary(); end
-
-  def default_port(); end
-
-  def eql?(oth); end
-
-  def find_proxy(env=T.unsafe(nil)); end
-
-  def fragment(); end
-
-  def fragment=(v); end
-
-  def hierarchical?(); end
-
-  def host(); end
-
-  def host=(v); end
-
-  def hostname(); end
-
-  def hostname=(v); end
-
-  def initialize(scheme, userinfo, host, port, registry, path, opaque, query, fragment, parser=T.unsafe(nil), arg_check=T.unsafe(nil)); end
-
-  def merge(oth); end
-
-  def merge!(oth); end
-
-  def normalize(); end
-
-  def normalize!(); end
-
-  def opaque(); end
-
-  def opaque=(v); end
-
-  def parser(); end
-
-  def password(); end
-
-  def password=(password); end
-
-  def path(); end
-
-  def path=(v); end
-
-  def port(); end
-
-  def port=(v); end
-
-  def query(); end
-
-  def query=(v); end
-
-  def registry(); end
-
-  def registry=(v); end
-
-  def relative?(); end
-
-  def route_from(oth); end
-
-  def route_to(oth); end
-
-  def scheme(); end
-
-  def scheme=(v); end
-
-  def select(*components); end
-
-  def set_host(v); end
-
-  def set_opaque(v); end
-
-  def set_password(v); end
-
-  def set_path(v); end
-
-  def set_port(v); end
-
-  def set_registry(v); end
-
-  def set_scheme(v); end
-
-  def set_user(v); end
-
-  def set_userinfo(user, password=T.unsafe(nil)); end
-
-  def user(); end
-
-  def user=(user); end
-
-  def userinfo(); end
-
-  def userinfo=(userinfo); end
-end
-
-class URI::Generic
-  def self.build(args); end
-
-  def self.build2(args); end
-
-  def self.component(); end
-
-  def self.default_port(); end
-
-  def self.use_proxy?(hostname, addr, port, no_proxy); end
-
-  def self.use_registry(); end
 end
 
 class URI::HTTP


### PR DESCRIPTION
The plugin I'm working on needs all the models included for reflection, this PR allows for the use of [glob patters](https://ruby-doc.org/core-2.6.5/Dir.html#method-c-glob) in relative requires

I found no specs for the CLI, so this PR lacks and specs for this functionality.