### PR TITLE
Add "sort namespaces" option

### DIFF
--- a/lib/parlour/rbi_generator.rb
+++ b/lib/parlour/rbi_generator.rb
@@ -4,7 +4,7 @@ module Parlour
   class RbiGenerator
     extend T::Sig
 
-    sig { params(break_params: Integer, tab_size: Integer).void }
+    sig { params(break_params: Integer, tab_size: Integer, sort_namespaces: T::Boolean).void }
     # Creates a new RBI generator.
     #
     # @example Create a default generator.
@@ -16,9 +16,15 @@ module Parlour
     # @param break_params [Integer] If there are at least this many parameters in a 
     #   Sorbet +sig+, then it is broken onto separate lines.
     # @param tab_size [Integer] The number of spaces to use per indent.
+    # @param sort_namespaces [Boolean] Whether to sort all items within a
+    #   namespace alphabetically.
     # @return [void]
-    def initialize(break_params: 4, tab_size: 2)
-      @options = Options.new(break_params: break_params, tab_size: tab_size)
+    def initialize(break_params: 4, tab_size: 2, sort_namespaces: false)
+      @options = Options.new(
+        break_params: break_params,
+        tab_size: tab_size,
+        sort_namespaces: sort_namespaces
+      )
       @root = Namespace.new(self)
     end
 

--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -115,6 +115,14 @@ module Parlour
         block.call(current_part)
       end
 
+      sig { void }
+      # Sorts the children of this namespace alphabetically.
+      # If {Options#sort_namespaces} is true on the RBI generator when 
+      # {#generate_body} is called, then this will be called automatically.
+      def sort_children
+        children.sort_by! { |x| x.name.downcase }
+      end
+
       sig { params(comment: T.any(String, T::Array[String])).void }
       # Adds one or more comments to the next child RBI object to be created.
       #
@@ -590,10 +598,15 @@ module Parlour
       # Generates the RBI lines for the body of this namespace. This consists of
       # {includes}, {extends} and {children}.
       #
+      # If {Options#sort_namespaces} is true, calling this method will sort
+      # this namespace's children.
+      #
       # @param indent_level [Integer] The indentation level to generate the lines at.
       # @param options [Options] The formatting options to use.
       # @return [Array<String>] The RBI lines for the body, formatted as specified.
       def generate_body(indent_level, options)
+        sort_children if options.sort_namespaces
+
         result = []
 
         result += [options.indented(indent_level, 'final!'), ''] if final

--- a/lib/parlour/rbi_generator/options.rb
+++ b/lib/parlour/rbi_generator/options.rb
@@ -6,7 +6,7 @@ module Parlour
     class Options
       extend T::Sig
 
-      sig { params(break_params: Integer, tab_size: Integer).void }
+      sig { params(break_params: Integer, tab_size: Integer, sort_namespaces: T::Boolean).void }
       # Creates a new set of formatting options.
       #
       # @example Create Options with +break_params+ of +4+ and +tab_size+ of +2+.
@@ -15,10 +15,13 @@ module Parlour
       # @param break_params [Integer] If there are at least this many parameters in a 
       #   Sorbet +sig+, then it is broken onto separate lines.
       # @param tab_size [Integer] The number of spaces to use per indent.
+      # @param sort_namespaces [Boolean] Whether to sort all items within a
+      #   namespace alphabetically.
       # @return [void]
-      def initialize(break_params:, tab_size:)
+      def initialize(break_params:, tab_size:, sort_namespaces:)
         @break_params = break_params
         @tab_size = tab_size
+        @sort_namespaces = sort_namespaces
       end
       
       sig { returns(Integer) }
@@ -45,6 +48,15 @@ module Parlour
       # The number of spaces to use per indent.
       # @return [Integer]
       attr_reader :tab_size
+
+      sig { returns(T::Boolean) }
+      # Whether to sort all items within a namespace alphabetically.
+      # TODO do like items stay together?
+      # If true, items are sorted by their name when the RBI is generated.
+      # If false, items are generated in the order they are added to the
+      # namespace.
+      # @return [Boolean]
+      attr_reader :sort_namespaces
 
       sig { params(level: Integer, str: String).returns(String) }
       # Returns a string indented to the given indent level, according to the

--- a/lib/parlour/rbi_generator/options.rb
+++ b/lib/parlour/rbi_generator/options.rb
@@ -51,7 +51,8 @@ module Parlour
 
       sig { returns(T::Boolean) }
       # Whether to sort all items within a namespace alphabetically.
-      # TODO do like items stay together?
+      # Items which are typically grouped together, such as "include" or
+      # "extend" calls, will remain grouped together when sorted.
       # If true, items are sorted by their name when the RBI is generated.
       # If false, items are generated in the order they are added to the
       # namespace.

--- a/lib/parlour/rbi_generator/parameter.rb
+++ b/lib/parlour/rbi_generator/parameter.rb
@@ -7,7 +7,7 @@ module Parlour
 
       sig do
         params(
-          name: T.nilable(String),
+          name: String,
           type: T.nilable(String),
           default: T.nilable(String)
         ).void

--- a/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -13,8 +13,6 @@ class Array
 
   def dig(*_); end
 
-  def filter!(); end
-
   def flatten!(*_); end
 
   def pack(*_); end
@@ -4175,8 +4173,6 @@ module Enumerable
 
   def each_entry(*_); end
 
-  def filter(); end
-
   def grep_v(_); end
 
   def slice_after(*_); end
@@ -4322,31 +4318,19 @@ class Etc::Group
 end
 
 class Etc::Passwd
-  def dir(); end
-
   def dir=(_); end
 
   def gecos(); end
 
   def gecos=(_); end
 
-  def gid(); end
-
   def gid=(_); end
-
-  def name(); end
 
   def name=(_); end
 
-  def passwd(); end
-
   def passwd=(_); end
 
-  def shell(); end
-
   def shell=(_); end
-
-  def uid(); end
 
   def uid=(_); end
 end
@@ -4484,12 +4468,6 @@ module Forwardable
   def self.debug(); end
 
   def self.debug=(debug); end
-end
-
-class FrozenError
-end
-
-class FrozenError
 end
 
 module GC
@@ -8494,13 +8472,9 @@ class Hash
 
   def fetch_values(*_); end
 
-  def filter!(); end
-
   def flatten(*_); end
 
   def index(_); end
-
-  def merge!(*_); end
 
   def replace(_); end
 
@@ -9520,10 +9494,6 @@ class Regexp
   def match?(*_); end
 end
 
-class Regexp
-  def self.union(*_); end
-end
-
 module RubyVM::AbstractSyntaxTree
 end
 
@@ -9631,8 +9601,6 @@ class Set
   def divide(&func); end
 
   def eql?(o); end
-
-  def filter!(&block); end
 
   def flatten_merge(set, seen=T.unsafe(nil)); end
 
@@ -10375,10 +10343,6 @@ end
 class URI::File
 end
 
-class URI::HTTP
-  def request_uri(); end
-end
-
 class URI::LDAP
   def attributes(); end
 
@@ -10476,12 +10440,6 @@ end
 
 module URI
   extend ::URI::Escape
-  def self.decode_www_form(str, enc=T.unsafe(nil), separator: T.unsafe(nil), use__charset_: T.unsafe(nil), isindex: T.unsafe(nil)); end
-
-  def self.encode_www_form(enum, enc=T.unsafe(nil)); end
-
-  def self.encode_www_form_component(str, enc=T.unsafe(nil)); end
-
   def self.get_encoding(label); end
 
 end

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -561,7 +561,11 @@ RSpec.describe Parlour::RbiGenerator do
     m.create_include('Y')
     m.create_module('B')
     m.create_method('c', parameters: [], return_type: nil)
-    m.create_class('A')
+    m.create_class('A') do |a|
+      a.create_method('c')
+      a.create_module('A')
+      a.create_class('B')
+    end
     m.create_arbitrary(code: '"some arbitrary code"')
     m.create_include('X')
     m.create_arbitrary(code: '"some more"')
@@ -580,6 +584,14 @@ RSpec.describe Parlour::RbiGenerator do
         "some more"
 
         class A
+          module A
+          end
+
+          class B
+          end
+
+          sig { void }
+          def c; end
         end
 
         module B

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Parlour::RbiGenerator do
   end
 
   def opts
-    Parlour::RbiGenerator::Options.new(break_params: 4, tab_size: 2)
+    Parlour::RbiGenerator::Options.new(break_params: 4, tab_size: 2, sort_namespaces: false)
   end
 
   it 'has a root namespace' do
@@ -547,5 +547,47 @@ RSpec.describe Parlour::RbiGenerator do
   it 'allows a strictness level to be specified' do
     expect(subject.rbi).to match /^\# typed: strong/
     expect(subject.rbi('true')).to match /^\# typed: true/
+  end
+
+  it 'supports sorting output' do
+    custom_rbi_gen = Parlour::RbiGenerator.new(sort_namespaces: true)
+    custom_opts = Parlour::RbiGenerator::Options.new(
+      break_params: 4,
+      tab_size: 2,
+      sort_namespaces: true
+    )
+
+    m = custom_rbi_gen.root.create_module('M', interface: true)
+    m.create_include('Y')
+    m.create_module('B')
+    m.create_method('c', parameters: [], return_type: nil)
+    m.create_class('A')
+    m.create_arbitrary(code: '"some arbitrary code"')
+    m.create_include('X')
+    m.create_arbitrary(code: '"some more"')
+    m.create_extend('Z')
+
+    expect(custom_rbi_gen.root.generate_rbi(0, custom_opts).join("\n")).to eq fix_heredoc(<<-RUBY)
+      module M
+        interface!
+
+        include X
+        include Y
+        extend Z
+
+        "some arbitrary code"
+
+        "some more"
+
+        class A
+        end
+
+        module B
+        end
+
+        sig { void }
+        def c; end
+      end
+    RUBY
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,6 @@ def suppress_stdout
   prev_stdout = $stdout
   $stdout = StringIO.new
   yield
-rescue StandardError
+ensure
   $stdout = prev_stdout
 end


### PR DESCRIPTION
This adds a `sort_namespaces` option to the `Options` class and `RbiGenerator` constructor.

When true, this sorts the children of all namespaces alphabetically, though it preserves the existing grouping of `include` and `extend` calls. Arbitrary objects are also kept above all other normal objects, as their name is blank.

When false, the ordering remains the same as it was before this PR.

Closes #59.