### PR TITLE
Handle undeclared block args

### DIFF
--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -247,13 +247,13 @@ module Parlour
       #
       # @param name [String] The name of this method. You should not specify +self.+ in
       #   this - use the +class_method+ parameter instead.
-      # @param parameters [Array<Parameter>] An array of {Parameter} instances representing this 
+      # @param parameters [Array<Parameter>] An array of {Parameter} instances representing this
       #   method's parameters.
       # @param return_type [String, nil] A Sorbet string of what this method returns, such as
       #   +"String"+ or +"T.untyped"+. Passing nil denotes a void return.
       # @param returns [String, nil] Same as return_type.
       # @param abstract [Boolean] Whether this method is abstract.
-      # @param implementation [Boolean] DEPRECATED: Whether this method is an 
+      # @param implementation [Boolean] DEPRECATED: Whether this method is an
       #   implementation of a parent abstract method.
       # @param override [Boolean] Whether this method is overriding a parent overridable
       #   method, or implementing a parent abstract method.
@@ -544,25 +544,25 @@ module Parlour
       # can be merged into each other, as they lack definitions for themselves,
       # so there is nothing to conflict. (This isn't the case for subclasses
       # such as {ClassNamespace}.)
-      # 
+      #
       # @param others [Array<RbiGenerator::RbiObject>] An array of other {Namespace} instances.
       # @return [true] Always true.
       def mergeable?(others)
         true
       end
 
-      sig do 
+      sig do
         override.overridable.params(
           others: T::Array[RbiGenerator::RbiObject]
         ).void
       end
       # Given an array of {Namespace} instances, merges them into this one.
-      # All children, constants, extends and includes are copied into this 
+      # All children, constants, extends and includes are copied into this
       # instance.
       #
       # There may also be {RbiGenerator::Method} instances in the stream, which
       # are ignored.
-      # 
+      #
       # @param others [Array<RbiGenerator::RbiObject>] An array of other {Namespace} instances.
       # @return [void]
       def merge_into_self(others)
@@ -616,10 +616,19 @@ module Parlour
         end
 
         # Process singleton class attributes
-        class_attributes, remaining_children = \
-          (options.sort_namespaces ? children.sort_by(&:name) : children)
-          .partition { |child| child.is_a?(Attribute) && child.class_attribute }
-        
+        sorted_children = (
+          if options.sort_namespaces
+            # sort_by can be unstable (and is in current MRI).
+            # Use the this work around to preserve order for ties
+            children.sort_by.with_index { |child, i| [child.name, i] }
+          else
+            children
+          end
+        )
+        class_attributes, remaining_children = sorted_children.partition do |child|
+          child.is_a?(Attribute) && child.class_attribute
+        end
+
         if class_attributes.any?
           result << options.indented(indent_level, 'class << self')
 

--- a/spec/type_loader_spec.rb
+++ b/spec/type_loader_spec.rb
@@ -68,12 +68,29 @@ RSpec.describe Parlour::TypeLoader do
     project_root = described_class.load_project('.')
     parlour_module = project_root.children.find { |x| x.name == 'Parlour' }
     expect(parlour_module).to be_a Parlour::RbiGenerator::ModuleNamespace
-    
+
     rbi_generator = parlour_module.children.find { |x| x.name == 'RbiGenerator' }
     expect(rbi_generator).to be_a Parlour::RbiGenerator::ClassNamespace
 
     rbi_generator_init = rbi_generator.children.find { |x| x.name == 'initialize' }
     expect(rbi_generator_init).to have_attributes(class_method: false,
       return_type: nil)
+  end
+
+  context 'with undeclared block arg' do
+    let(:source) {
+      (<<-RUBY)
+        class A
+          sig { params(a: String).void }
+          def bar(a, &blk); end
+        end
+      RUBY
+    }
+
+    it 'can parse the source' do
+      # We just care that this doesn't error
+      namespace = described_class.load_source(source)
+      expect(namespace.children.map(&:name)).to match_array(['A'])
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/AaronC81/parlour/issues/65

I also fixed a failing test by forcing the children sorting to be stable (preserve order for equivalent sort items). It's less efficient, but that shouldn't matter since nodes don't tend to have a lot of children.

Also sorry about the whitespace noise. My editor was removing trailing whitespace, but I can get rid of those changes if it's annoying.