### PR TITLE
Add support for T::Struct

### DIFF
--- a/lib/parlour.rb
+++ b/lib/parlour.rb
@@ -22,6 +22,8 @@ require 'parlour/rbi_generator/namespace'
 require 'parlour/rbi_generator/module_namespace'
 require 'parlour/rbi_generator/class_namespace'
 require 'parlour/rbi_generator/enum_class_namespace'
+require 'parlour/rbi_generator/struct_prop'
+require 'parlour/rbi_generator/struct_class_namespace'
 require 'parlour/rbi_generator'
 require 'parlour/detached_rbi_generator'
 

--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -200,6 +200,35 @@ module Parlour
         params(
           name: String,
           final: T::Boolean,
+          props: T.nilable(T::Array[StructProp]),
+          abstract: T::Boolean,
+          block: T.nilable(T.proc.params(x: StructClassNamespace).void)
+        ).returns(StructClassNamespace)
+      end
+      # Creates a new struct class definition as a child of this namespace.
+      #
+      # @example Create a person struct.
+      #   namespace.create_class('Person', props: [
+      #     Parlour::RbiGenerator::StructProp.new('name', 'String')
+      #   ])
+      #
+      # @param name [String] The name of this class.
+      # @param final [Boolean] Whether this namespace is final.
+      # @param props [Array<StructProp>] The props of the struct.
+      # @param abstract [Boolean] A boolean indicating whether this class is abstract.
+      # @param block A block which the new instance yields itself to.
+      # @return [EnumClassNamespace]
+      def create_struct_class(name, final: false, props: nil, abstract: false, &block)
+        new_struct_class = StructClassNamespace.new(generator, name, final, props || [], abstract, &block)
+        move_next_comments(new_struct_class)
+        children << new_struct_class
+        new_struct_class
+      end
+
+      sig do
+        params(
+          name: String,
+          final: T::Boolean,
           interface: T::Boolean,
           block: T.nilable(T.proc.params(x: ClassNamespace).void)
         ).returns(ModuleNamespace)

--- a/lib/parlour/rbi_generator/struct_prop.rb
+++ b/lib/parlour/rbi_generator/struct_prop.rb
@@ -1,0 +1,136 @@
+# typed: true
+module Parlour
+  class RbiGenerator
+    # Represents a +T::Struct+ property.
+    class StructProp
+      extend T::Sig
+
+      sig do
+        params(
+          name: String,
+          type: String,
+          optional: T.nilable(T.any(T::Boolean, Symbol)),
+          enum: T.nilable(String),
+          dont_store: T.nilable(T::Boolean),
+          foreign: T.nilable(String),
+          default: T.nilable(String),
+          factory: T.nilable(String),
+          immutable: T.nilable(T::Boolean),
+          array: T.nilable(String),
+          override: T.nilable(T::Boolean),
+          redaction: T.nilable(String),
+        ).void
+      end
+      # Create a new struct property.
+      #
+      # For documentation on all optional properties, please refer to the
+      # documentation for T::Struct within the sorbet-runtime gem:
+      # https://github.com/sorbet/sorbet/blob/master/gems/sorbet-runtime/lib/types/props/_props.rb#L31-L106
+      #
+      # @param name [String] The name of this property.
+      # @param type [String] A Sorbet string of this property's type, such as
+      #   +"String"+.
+      # @return [void]
+      def initialize(name, type, optional: nil, enum: nil, dont_store: nil,
+        foreign: nil, default: nil, factory: nil, immutable: nil, array: nil,
+        override: nil, redaction: nil)
+        
+        @name = name
+        @type = type
+        @optional = optional
+        @enum = enum
+        @dont_store = dont_store
+        @foreign = foreign
+        @default = default
+        @factory = factory
+        @immutable = immutable
+        @array = array
+        @override = override
+        @redaction = redaction
+      end
+
+      sig { params(other: Object).returns(T::Boolean) }
+      # Returns true if this instance is equal to another instance.
+      #
+      # @param other [Object] The other instance. If this is not a {StructProp} (or a
+      #   subclass of it), this will always return false.
+      # @return [Boolean]
+      def ==(other)
+        StructProp === other &&
+          name       == other.name &&
+          type       == other.type &&
+          optional   == other.optional &&
+          enum       == other.enum &&
+          dont_store == other.dont_store &&
+          foreign    == other.foreign &&
+          default    == other.default &&
+          factory    == other.factory &&
+          immutable  == other.immutable &&
+          array      == other.array &&
+          override   == other.override &&
+          redaction  == other.redaction
+      end
+
+      sig { returns(String) }
+      # The name of this parameter, including any prefixes or suffixes such as
+      # +*+.
+      # @return [String]
+      attr_reader :name
+
+      sig { returns(T.nilable(String)) }
+      # A Sorbet string of this parameter's type, such as +"String"+ or
+      # +"T.untyped"+.
+      # @return [String, nil]
+      attr_reader :type
+
+      sig { returns(T.nilable(T.any(T::Boolean, Symbol))) }
+      attr_reader :optional
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :enum
+
+      sig { returns(T.nilable(T::Boolean)) }
+      attr_reader :dont_store
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :foreign
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :default
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :factory
+
+      sig { returns(T.nilable(T::Boolean)) }
+      attr_reader :immutable
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :array
+
+      sig { returns(T.nilable(T::Boolean)) }
+      attr_reader :override
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :redaction
+
+      # The optional properties available on instances of this class.
+      EXTRA_PROPERTIES = %i{
+        optional enum dont_store foreign default factory immutable array override redaction
+      }
+
+      sig { returns(String) }
+      # Returns the +prop+ call required to create this property.
+      # @return [String]
+      def to_prop_call
+        call = "prop :#{name}, #{type}"
+
+        EXTRA_PROPERTIES.each do |extra_property|
+          value = send extra_property
+          call += ", #{extra_property}: #{value}" unless value.nil?
+        end
+
+        call
+      end
+    end
+  end
+end

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -602,4 +602,29 @@ RSpec.describe Parlour::RbiGenerator do
       end
     RUBY
   end
+
+  it 'supports structs' do
+    mod = subject.root.create_module('M') do |m|
+      m.create_struct_class('Person', props: [
+        Parlour::RbiGenerator::StructProp.new('name', 'String'),
+        Parlour::RbiGenerator::StructProp.new('age', 'Integer', optional: true),
+        Parlour::RbiGenerator::StructProp.new('prefers_light_theme', 'T::Boolean', default: 'false'),
+      ]) do |person|
+        person.create_method('theme', returns: 'String')
+      end
+    end
+
+    expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
+      module M
+        class Person < T::Struct
+          prop :name, String
+          prop :age, Integer, optional: true
+          prop :prefers_light_theme, T::Boolean, default: false
+
+          sig { returns(String) }
+          def theme; end
+        end
+      end
+    RUBY
+  end
 end

--- a/spec/type_parser_spec.rb
+++ b/spec/type_parser_spec.rb
@@ -457,4 +457,58 @@ RSpec.describe Parlour::TypeParser do
       return_type: 'T.type_parameter(:A)',
       type_parameters: [:A, :B])
   end
+
+  context 'structs' do
+    it 'can have props' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        class Person < T::Struct
+          prop :name, String
+          prop 'age', Integer, optional: true
+        end
+      RUBY
+
+      root = instance.parse_all
+      expect(root.children.length).to eq 1
+
+      person = root.children.first
+      expect(person).to be_a Parlour::RbiGenerator::StructClassNamespace
+
+      expect(person.props[0]).to have_attributes(name: 'name', type: 'String')
+      expect(person.props[1]).to have_attributes(name: 'age', type: 'Integer',
+        optional: true)
+    end
+
+    it 'can have props and consts' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        class Person < T::Struct
+          prop :name, String
+          const :dob, DateTime
+        end
+      RUBY
+
+      root = instance.parse_all
+      expect(root.children.length).to eq 1
+
+      person = root.children.first
+      expect(person).to be_a Parlour::RbiGenerator::StructClassNamespace
+
+      expect(person.props[0]).to have_attributes(name: 'name', type: 'String')
+      expect(person.props[1]).to have_attributes(name: 'dob', type: 'DateTime',
+        immutable: true)
+    end
+
+    it 'can be empty' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        class Empty < T::Struct; end
+      RUBY
+
+      root = instance.parse_all
+      expect(root.children.length).to eq 1
+
+      person = root.children.first
+      expect(person).to be_a Parlour::RbiGenerator::StructClassNamespace
+
+      expect(person.props).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
This PR adds full RBI generation and parsing support for `T::Struct` classes with `prop` and `const` members.

Closes #64.