### PR TITLE
Parse methods without sigs

### DIFF
--- a/lib/parlour/type_parser.rb
+++ b/lib/parlour/type_parser.rb
@@ -712,15 +712,14 @@ module Parlour
     # @return [Boolean] True if that node represents a "sig" call, false
     #   otherwise.
     def previous_sibling_sig_node?(path)
-      begin
-        previous_sibling = path.sibling(-1)
-        previous_node = previous_sibling.traverse(ast)
-        sig_node?(previous_node)
-      # `sibling` call could raise IndexError or ArgumentError
+      previous_sibling = path.sibling(-1)
+      previous_node = previous_sibling.traverse(ast)
+      sig_node?(previous_node)
+    rescue IndexError, ArgumentError, TypeError
+      # `sibling` call could raise IndexError or ArgumentError if reaching into negative indices
       # `traverse` call could raise TypeError if path doesn't return Parser::AST::Node
-      rescue IndexError, ArgumentError, TypeError
-        false
-      end
+
+      false
     end
 
     sig { params(node: T.nilable(Parser::AST::Node)).returns(T.nilable(String)) }

--- a/spec/type_parser_spec.rb
+++ b/spec/type_parser_spec.rb
@@ -606,6 +606,8 @@ RSpec.describe Parlour::TypeParser do
     it 'supports methods entirely without signatures' do
       instance = described_class.from_source('(test)', <<-RUBY)
         class A
+          attr_accessor :foo
+
           def self.bar
             "hello"
           end
@@ -623,9 +625,12 @@ RSpec.describe Parlour::TypeParser do
       expect(a).to be_a Parlour::RbiGenerator::ClassNamespace
       expect(a).to have_attributes(name: 'A', final: false)
 
-      bar, baz = *a.children
+      foo, bar, baz = *a.children
+      expect(foo).to be_a Parlour::RbiGenerator::Attribute
       expect(bar).to be_a Parlour::RbiGenerator::Method
       expect(baz).to be_a Parlour::RbiGenerator::Method
+      expect(foo).to have_attributes(name: 'foo', return_type: 'T.untyped',
+        kind: :accessor)
       expect(bar).to have_attributes(name: 'bar', return_type: nil,
         class_method: true)
       expect(baz).to have_attributes(name: 'baz', return_type: nil,

--- a/spec/type_parser_spec.rb
+++ b/spec/type_parser_spec.rb
@@ -253,6 +253,172 @@ RSpec.describe Parlour::TypeParser do
     end
   end
 
+  context '#parse_method_into_methods' do
+    it 'works with no params' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        def foo
+          3
+        end
+      RUBY
+
+      meth = instance.parse_method_into_methods(Parlour::TypeParser::NodePath.new([])).only
+      expect(meth).to have_attributes(name: 'foo', return_type: nil,
+        override: false, class_method: false)
+    end
+
+    it 'works for methods with simple parameters' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        def foo(x, y = true)
+          y ? x.length : 0
+        end
+      RUBY
+
+      meth = instance.parse_method_into_methods(Parlour::TypeParser::NodePath.new([])).only
+      expect(meth.return_type).to eq nil
+      expect(meth.name).to eq 'foo'
+      expect(meth.override).to eq false
+      expect(meth.final).to eq false
+
+      expect(meth.parameters.length).to eq 2
+      expect(meth.parameters[0]).to have_attributes(name: 'x', kind: :normal,
+        type: nil, default: nil)
+      expect(meth.parameters[1]).to have_attributes(name: 'y', kind: :normal,
+        type: nil, default: 'true')
+    end
+
+    it 'works for methods with complex parameters' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        def foo(x, y:, z: 3, &blk)
+          nil
+        end
+      RUBY
+
+      meth = instance.parse_method_into_methods(Parlour::TypeParser::NodePath.new([])).only
+      expect(meth).to have_attributes(name: 'foo',
+        return_type: nil, override: false, final: false)
+
+      expect(meth.parameters.length).to eq 4
+      expect(meth.parameters[0]).to have_attributes(name: 'x', kind: :normal,
+        type: nil, default: nil)
+      expect(meth.parameters[1]).to have_attributes(name: 'y:', kind: :keyword,
+        type: nil, default: nil)
+      expect(meth.parameters[2]).to have_attributes(name: 'z:', kind: :keyword,
+        type: nil, default: '3')
+      expect(meth.parameters[3]).to have_attributes(name: '&blk', kind: :block,
+        type: nil, default: nil)
+    end
+
+    it 'works with splat-arguments' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        def foo(*args, **kwargs)
+          nil
+        end
+      RUBY
+
+      meth = instance.parse_method_into_methods(Parlour::TypeParser::NodePath.new([])).only
+      expect(meth).to have_attributes(name: 'foo',
+        return_type: nil, override: false)
+
+      expect(meth.parameters[0]).to have_attributes(name: '*args', type: :splat,
+        type: nil)
+      expect(meth.parameters[1]).to have_attributes(name: '**kwargs',
+        type: :double_splat, type: nil)
+    end
+
+    it 'supports class methods using self.x' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        def self.foo(x)
+          3
+        end
+      RUBY
+
+      meth = instance.parse_method_into_methods(Parlour::TypeParser::NodePath.new([])).only
+      expect(meth).to have_attributes(name: 'foo', return_type: nil,
+        override: false, final: false, class_method: true)
+      expect(meth.parameters.length).to eq 1
+      expect(meth.parameters.first).to have_attributes(name: 'x',
+        type: nil)
+    end
+
+    it 'supports class methods within an eigenclass' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        def foo(x)
+          3
+        end
+      RUBY
+
+      meth = instance.parse_method_into_methods(Parlour::TypeParser::NodePath.new([]), is_within_eigenclass: true).only
+      expect(meth).to have_attributes(name: 'foo', return_type: nil,
+        override: false, final: false, class_method: true)
+      expect(meth.parameters.length).to eq 1
+      expect(meth.parameters.first).to have_attributes(name: 'x',
+        type: nil)
+    end
+
+    it 'errors on a self.x method within an eigenclass' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        def self.foo(x)
+          3
+        end
+      RUBY
+
+      expect do
+        instance.parse_method_into_methods(Parlour::TypeParser::NodePath.new([]), is_within_eigenclass: true).only
+      end.to raise_error Parlour::ParseError
+    end
+
+    context 'attributes' do
+      it 'supports attr_accessor' do
+        instance = described_class.from_source('(test)', <<-RUBY)
+          attr_accessor :foo
+        RUBY
+
+        meth = instance.parse_method_into_methods(Parlour::TypeParser::NodePath.new([])).only
+        expect(meth).to have_attributes(name: 'foo', return_type: 'T.untyped',
+          kind: :accessor)
+      end
+
+      it 'supports attr_reader' do
+        instance = described_class.from_source('(test)', <<-RUBY)
+          attr_reader :foo
+        RUBY
+
+        meth = instance.parse_method_into_methods(Parlour::TypeParser::NodePath.new([])).only
+        expect(meth).to have_attributes(name: 'foo', return_type: 'T.untyped',
+          kind: :reader)
+      end
+
+      it 'supports attr_writer' do
+        instance = described_class.from_source('(test)', <<-RUBY)
+          attr_writer :foo
+        RUBY
+
+        meth = instance.parse_method_into_methods(Parlour::TypeParser::NodePath.new([])).only
+        expect(meth).to have_attributes(name: 'foo', return_type: 'T.untyped',
+          kind: :writer)
+        expect(meth.parameters.length).to eq 1
+        expect(meth.parameters[0]).to have_attributes(name: 'foo',
+          type: 'T.untyped')
+      end
+
+      it 'supports attribute with multiple names' do
+        instance = described_class.from_source('(test)', <<-RUBY)
+          attr_accessor :foo, :bar, :baz
+        RUBY
+
+        meths = instance.parse_method_into_methods(Parlour::TypeParser::NodePath.new([]))
+        foo, bar, baz = meths
+
+        expect(foo).to have_attributes(name: 'foo', return_type: 'T.untyped',
+          kind: :accessor)
+        expect(bar).to have_attributes(name: 'bar', return_type: 'T.untyped',
+          kind: :accessor)
+        expect(baz).to have_attributes(name: 'baz', return_type: 'T.untyped',
+          kind: :accessor)
+      end
+    end
+  end
+
   context '#parse_all' do
     it 'parses class structures' do
       instance = described_class.from_source('(test)', <<-RUBY)


### PR DESCRIPTION
Fixes #69 

I created a new method based on `parse_sig_into_methods` called `parse_method_into_methods`. This new method will generate `RbiGenerator::Method`s and `RbiGenerator::Attribute`s from unsigged methods, setting any parameter types and return types to `T.untyped`. 

I had started by trying to adapt the `parse_sig_into_methods` to handle the `sig` not being present but there were a lot of validations sprinkled throughout the method and adding a bunch of conditionals made it much harder to read. One idea on how to remove some of the duplication:
- Leave the `parse_method_into_methods` as-is, basically take a method call or `attr_*` and return a method/attribute that is totally untyped.
- Have the `parse_sig_into_methods`
  - Parse the sig
  - Call the `parse_method_into_methods` to generate untyped methods/attributes
  - Loop over the returned methods/attributes and apply the relevant validations and add types where possible.

I'd lean toward leaving this PR as-is (i.e. with the duplication) and applying this or some other type of refactor as a follow up if you wanted to. There would probably be some personal preference involved in how you actually DRYed up the code so might make more sense as something you'd do vs a contributor.