### PR TITLE
Fix parsing struct with a single node

### DIFF
--- a/lib/parlour/type_parser.rb
+++ b/lib/parlour/type_parser.rb
@@ -174,8 +174,11 @@ module Parlour
         # Instantiate the correct kind of class
         if ['T::Struct', '::T::Struct'].include?(node_to_s(superclass))
           # Find all of this struct's props and consts
+          # The body is typically a `begin` element but when there's only
+          # one node there's no wrapping block and instead it would directly
+          # be the node.
           prop_nodes = body.nil? ? [] :
-            body.to_a.select { |x| x.type == :send && [:prop, :const].include?(x.to_a[1]) }
+            (body.type == :begin ? body.to_a : [body]).select { |x| x.type == :send && [:prop, :const].include?(x.to_a[1]) }
 
           props = prop_nodes.map do |prop_node|
             _, prop_type, name_node, type_node, extras_hash_node = *prop_node

--- a/spec/type_parser_spec.rb
+++ b/spec/type_parser_spec.rb
@@ -740,6 +740,37 @@ RSpec.describe Parlour::TypeParser do
 
       expect(person.props).to be_empty
     end
+
+    it 'can have a single prop with no other nodes' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        class Person < T::Struct
+          prop :name, String
+        end
+      RUBY
+
+      root = instance.parse_all
+      expect(root.children.length).to eq 1
+
+      person = root.children.first
+      expect(person).to be_a Parlour::RbiGenerator::StructClassNamespace
+
+      expect(person.props[0]).to have_attributes(name: 'name', type: 'String')
+    end
+
+    it 'can have a class with no other nodes' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        class Person < T::Struct
+          class Foo
+          end
+        end
+      RUBY
+
+      root = instance.parse_all
+      expect(root.children.length).to eq 1
+
+      person = root.children.first
+      expect(person).to be_a Parlour::RbiGenerator::StructClassNamespace
+    end
   end
   
   it 'handles empty and comment-only files' do


### PR DESCRIPTION
Fixes an issue I bumped into loading some structs in our codebase that only had a single prop.