### PR TITLE
Struct default values should always be Strings of ruby code

### DIFF
--- a/lib/parlour/type_parser.rb
+++ b/lib/parlour/type_parser.rb
@@ -189,16 +189,21 @@ module Parlour
               parse_err 'prop/const key must be a symbol', prop_node unless key_node.type == :sym
               key = key_node.to_a.first
 
-              value = case value_node.type
-              when :true
-                true
-              when :false
-                false
-              when :sym
-                value_node.to_a.first
-              else
-                T.must(node_to_s(value_node))
-              end
+              value =
+                if key == :default
+                  T.must(node_to_s(value_node))
+                else
+                  case value_node.type
+                  when :true
+                    true
+                  when :false
+                    false
+                  when :sym
+                    value_node.to_a.first
+                  else
+                    T.must(node_to_s(value_node))
+                  end
+                end
 
               [key, value]
             end.to_h
@@ -258,7 +263,7 @@ module Parlour
             abstract,
           )
         end
-        
+
         final_obj.children.concat(parse_path_to_object(path.child(2))) if body
         final_obj.create_includes(includes)
         final_obj.create_extends(extends)

--- a/spec/type_parser_spec.rb
+++ b/spec/type_parser_spec.rb
@@ -771,8 +771,28 @@ RSpec.describe Parlour::TypeParser do
       person = root.children.first
       expect(person).to be_a Parlour::RbiGenerator::StructClassNamespace
     end
+
+    it 'can have members with default and factory values of various types' do
+      # Ensures that default and factory parameters are passed into StructProp
+      # as strings of ruby code, not as actual values
+
+      instance = described_class.from_source('(test)', <<-RUBY)
+        class Auto < T::Struct
+          const :doors, Integer, default: (2 + 2)
+          const :wheels, Integer, default: 4
+          const :all_wheel_drive, T::Boolean, default: false
+          const :mpg, Float, factory: -> { 31.2 }
+        end
+      RUBY
+
+      root = instance.parse_all
+      expect(root.children.length).to eq 1
+
+      person = root.children.first
+      expect(person).to be_a Parlour::RbiGenerator::StructClassNamespace
+    end
   end
-  
+
   it 'handles empty and comment-only files' do
     instance = described_class.from_source('(test)', '')
 


### PR DESCRIPTION
Trying out the new struct parsing code in my project (thanks - very useful!) and hit a crash when parsing a struct property that was a `T::Boolean` with a default value of `false`. The code in TypeParser that constructed StructProp instances would always cast :true, :false, or :sym AST nodes to their actual value, instead of preserving them as Strings of ruby code, as expected by the `default` constructor arg to StructProp.

Included test repros the issue (as well as testing some other corner cases), and the patch makes the test pass, though I'm open for suggestions on improving the fix if you think there's a cleaner way to do the value node handling.