### PR TITLE
Fix conflict between writers and methods of the same name

### DIFF
--- a/lib/parlour/conflict_resolver.rb
+++ b/lib/parlour/conflict_resolver.rb
@@ -42,8 +42,15 @@ module Parlour
       Debugging.debug_puts(self, Debugging::Tree.begin("Resolving conflicts for #{namespace.name}..."))
 
       # Check for multiple definitions with the same name
-      grouped_by_name_children = namespace.children.group_by(&:name)
-
+      # (Special case here: writer attributes get an "=" appended to their name)
+      grouped_by_name_children = namespace.children.group_by do |child|
+        if RbiGenerator::Attribute === child && child.kind == :writer
+          "#{child.name}=" unless child.name.end_with?('=')
+        else
+          child.name
+        end
+      end
+      
       grouped_by_name_children.each do |name, children|
         Debugging.debug_puts(self, Debugging::Tree.begin("Checking children named #{name}..."))
 

--- a/spec/conflict_resolver_spec.rb
+++ b/spec/conflict_resolver_spec.rb
@@ -312,4 +312,19 @@ RSpec.describe Parlour::ConflictResolver do
 
     expect(x.children.length).to be 2
   end
+  
+  it 'does not conflict writers with non-=-suffixed methods' do
+    x = Parlour::TypeLoader.load_source(<<-RUBY).children.first
+      class A
+        attr_writer :foo
+        def foo; end
+      end
+    RUBY
+
+    expect(x.children.length).to be 2
+
+    subject.resolve_conflicts(x) { |*| raise 'unable to resolve automatically' }
+
+    expect(x.children.length).to be 2
+  end
 end


### PR DESCRIPTION
This works by special-casing the conflict resolver's naming.

Closes #79.