### PR TITLE
Fix specialized classes conflict resolver

### DIFF
--- a/lib/parlour/conflict_resolver.rb
+++ b/lib/parlour/conflict_resolver.rb
@@ -1,4 +1,6 @@
 # typed: true
+require 'set'
+
 module Parlour
   # Responsible for resolving conflicts (that is, multiple definitions with the
   # same name) between objects defined in the same namespace.
@@ -203,21 +205,13 @@ module Parlour
 
       # Find all the namespaces and non-namespaces
       namespace_types, non_namespace_types = array_types.partition { |x| x <= RbiGenerator::Namespace }
+      exactly_namespace, namespace_subclasses = namespace_types.partition { |x| x == RbiGenerator::Namespace }
 
-      # If there are two namespace types, one should be Namespace and the other
-      # should be a subclass of it
-      if namespace_types.length == 2
-        exactly_namespace, exactly_one_subclass = namespace_types.partition { |x| x == RbiGenerator::Namespace }
+      return nil unless namespace_subclasses.empty? \
+        || (namespace_subclasses.length == 1 && namespace_subclasses.first < RbiGenerator::Namespace) \
+        || namespace_subclasses.to_set == Set[RbiGenerator::ClassNamespace, RbiGenerator::StructClassNamespace] \
+        || namespace_subclasses.to_set == Set[RbiGenerator::ClassNamespace, RbiGenerator::EnumClassNamespace]
 
-        return nil unless exactly_namespace.length == 1 \
-          && exactly_one_subclass.length == 1 \
-          && exactly_one_subclass.first < RbiGenerator::Namespace
-      elsif namespace_types.length != 1
-        # The only other valid number of namespaces is 1, where we don't need to
-        # check anything
-        return nil
-      end
-      
       # It's OK, albeit cursed, for there to be a method with the same name as
       # a namespace (Rainbow does this)
       return nil if non_namespace_types.length != 0 && non_namespace_types != [RbiGenerator::Method]

--- a/lib/parlour/rbi_generator/enum_class_namespace.rb
+++ b/lib/parlour/rbi_generator/enum_class_namespace.rb
@@ -86,6 +86,27 @@ module Parlour
 
         T.must(super && all_enums.map { |e| e.enums.sort }.reject(&:empty?).uniq.length <= 1)
       end
+
+      sig do
+        override.params(
+          others: T::Array[RbiGenerator::RbiObject]
+        ).void
+      end
+      # Given an array of {EnumClassNamespace} instances, merges them into this one.
+      # You MUST ensure that {mergeable?} is true for those instances.
+      #
+      # @param others [Array<RbiGenerator::RbiObject>] An array of other {EnumClassNamespace} instances.
+      # @return [void]
+      def merge_into_self(others)
+        super
+
+        others.each do |other|
+          next unless EnumClassNamespace === other
+          other = T.cast(other, EnumClassNamespace)
+
+          @enums = other.enums if enums.empty?
+        end
+      end
     end
   end
 end

--- a/lib/parlour/rbi_generator/enum_class_namespace.rb
+++ b/lib/parlour/rbi_generator/enum_class_namespace.rb
@@ -80,10 +80,11 @@ module Parlour
       # @param others [Array<RbiGenerator::RbiObject>] An array of other {EnumClassNamespace} instances.
       # @return [Boolean] Whether this instance may be merged with them.
       def mergeable?(others)
-        others = T.cast(others, T::Array[EnumClassNamespace]) rescue (return false)
+        others = T.cast(others, T::Array[Namespace]) rescue (return false)
         all = others + [self]
+        all_enums = T.cast(all.select { |x| EnumClassNamespace === x }, T::Array[EnumClassNamespace])
 
-        T.must(super && all.map(&:enums).uniq.length <= 1)
+        T.must(super && all_enums.map { |e| e.enums.sort }.reject(&:empty?).uniq.length <= 1)
       end
     end
   end

--- a/lib/parlour/rbi_generator/struct_class_namespace.rb
+++ b/lib/parlour/rbi_generator/struct_class_namespace.rb
@@ -77,6 +77,27 @@ module Parlour
 
         T.must(super && all_structs.map { |s| s.props.map(&:to_prop_call).sort }.reject(&:empty?).uniq.length <= 1)
       end
+
+      sig do
+        override.params(
+          others: T::Array[RbiGenerator::RbiObject]
+        ).void
+      end
+      # Given an array of {StructClassNamespace} instances, merges them into this one.
+      # You MUST ensure that {mergeable?} is true for those instances.
+      #
+      # @param others [Array<RbiGenerator::RbiObject>] An array of other {StructClassNamespace} instances.
+      # @return [void]
+      def merge_into_self(others)
+        super
+
+        others.each do |other|
+          next unless StructClassNamespace === other
+          other = T.cast(other, StructClassNamespace)
+
+          @props = other.props if props.empty?
+        end
+      end
     end
   end
 end

--- a/lib/parlour/rbi_generator/struct_class_namespace.rb
+++ b/lib/parlour/rbi_generator/struct_class_namespace.rb
@@ -71,10 +71,11 @@ module Parlour
       # @param others [Array<RbiGenerator::RbiObject>] An array of other {StructClassNamespace} instances.
       # @return [Boolean] Whether this instance may be merged with them.
       def mergeable?(others)
-        others = T.cast(others, T::Array[StructClassNamespace]) rescue (return false)
+        others = T.cast(others, T::Array[Namespace]) rescue (return false)
         all = others + [self]
+        all_structs = T.cast(all.select { |x| StructClassNamespace === x }, T::Array[StructClassNamespace])
 
-        T.must(super && all.map(&:props).uniq.length <= 1)
+        T.must(super && all_structs.map { |s| s.props.map(&:to_prop_call).sort }.reject(&:empty?).uniq.length <= 1)
       end
     end
   end

--- a/lib/parlour/type_parser.rb
+++ b/lib/parlour/type_parser.rb
@@ -234,7 +234,7 @@ module Parlour
         elsif ['T::Enum', '::T::Enum'].include?(node_to_s(superclass))
           # Look for (block (send nil :enums) ...) structure
           enums_node = body.nil? ? nil :
-            body.to_a.find { |x| x.type == :block && x.to_a[0].type == :send && x.to_a[0].to_a[1] == :enums }
+            (body.type == :begin ? body.to_a : [body]).find { |x| x.type == :block && x.to_a[0].type == :send && x.to_a[0].to_a[1] == :enums }
 
           # Find the constant assigments within this block
           constant_nodes = enums_node.to_a[2].to_a

--- a/spec/conflict_resolver_spec.rb
+++ b/spec/conflict_resolver_spec.rb
@@ -201,8 +201,8 @@ RSpec.describe Parlour::ConflictResolver do
 
     it 'merges enums with some value and no value' do
       m = gen.root.create_module('M') do |m|
-        m.create_enum_class('Direction', enums: ['North', 'South', 'East', 'West'])
         m.create_enum_class('Direction', enums: [])
+        m.create_enum_class('Direction', enums: ['North', 'South', 'East', 'West'])
       end
 
       expect(m.children.length).to be 2
@@ -212,6 +212,8 @@ RSpec.describe Parlour::ConflictResolver do
 
       expect(m.children.length).to be 1
       expect(invocations).to be 0
+
+      expect(m.children.first.enums).to eq(['North', 'South', 'East', 'West'])
     end
 
     it 'does not merge enums with different values' do
@@ -282,8 +284,8 @@ RSpec.describe Parlour::ConflictResolver do
 
     it 'merges structs with some value and no value' do
       m = gen.root.create_module('M') do |m|
-        m.create_struct_class('Person', props: [Parlour::RbiGenerator::StructProp.new('name', 'String')])
         m.create_struct_class('Person', props: [])
+        m.create_struct_class('Person', props: [Parlour::RbiGenerator::StructProp.new('name', 'String')])
       end
 
       expect(m.children.length).to be 2
@@ -293,6 +295,8 @@ RSpec.describe Parlour::ConflictResolver do
 
       expect(m.children.length).to be 1
       expect(invocations).to be 0
+
+      expect(m.children.first.props.map(&:name)).to eq(['name'])
     end
 
     it 'does not merge struct with different value' do


### PR DESCRIPTION
Fixes #78 

~Want to confirm this works on my codebase with no regressions.~ Confirmed 🙂 

Fixing conflict resolution in specialized namespaces (i.e. Enum and Struct). Some notable changes:
- Handle merging a plain `ClassNamespace` with one of the specialized ones
- Handle merging multiple of the same specialized namespaces if they have the either the same enums/props (or some are empty).
- When merging multiple specialized namespaces choose the non-empty enums/props.
- Fix issue where load order of plain `ClassNamespace` vs the specialized ones would affect mergeability (i.e. say things were mergeable when they shouldn't be).

Wanted to call out the last commit which specifically orders the namespaces when using the `differing_namespaces` strategy. I found cases where a module namespace was getting dropped when generating RBI and realized it was due to a `Namespace` occurring  before a `ModuleNamespace` with the same name. I fixed and added a test that exercised the bug.