### PR TITLE
Make it easier to generate gem RBI

### DIFF
--- a/.parlour
+++ b/.parlour
@@ -1,0 +1,2 @@
+exclusions:
+  - lib/parlour/kernel_hack.rb

--- a/.parlour
+++ b/.parlour
@@ -1,2 +1,5 @@
-exclusions:
+excluded_paths:
   - lib/parlour/kernel_hack.rb
+
+excluded_modules:
+  - Parlour::DetachedRbiGenerator

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ key parts:
     no need to write your own parser!
 
   - You can **generate RBI to ship with your gem** for consuming projects to use
-    ([see "RBIs within gems" in sorbet the docs](https://sorbet.org/docs/rbi#rbis-within-gems)).
+    ([see "RBIs within gems" in Sorbet's docs](https://sorbet.org/docs/rbi#rbis-within-gems)).
 
 Please [**read the wiki**](https://github.com/AaronC81/parlour/wiki) to get
 started!

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Parlour::TypeLoader.load_project('root/of/the/project')
 The structure of the returned object trees is identical to those you would
 create when generating an RBI, built of instances of `RbiObject` subclasses.
 
-## Generating RBI for a gem
+## Generating RBI for a Gem
 
 Include `parlour` as a development_dependency in your `.gemspec`:
 
@@ -192,10 +192,13 @@ bundle exec parlour
 ```
 
 Parlour is configured to use sane defaults assuming a standard gem structure
-to allow sorbet to automatically find your RBI when your gem is included as
-a dependency. If you require more advanced configuration you can add a
+to generate an RBI that Sorbet will automatically find when your gem is included
+as a dependency. If you require more advanced configuration you can add a
 `.parlour` YAML file in the root of your project (see this project's `.parlour`
 file as an example).
+
+To disable the parsing step entire and just run plugins you can set `parser: false`
+in your `.parlour` file.
 
 ## Parlour Plugins
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ key parts:
     RBIs for the same codebase. These are combined automatically as much as
     possible, but any other conflicts can be resolved manually through prompts.
 
-  - The parser, which can read an RBI and convert it back into a tree of 
+  - The parser, which can read an RBI and convert it back into a tree of
     generator objects.
 
 ## Why should I use this?
@@ -26,7 +26,10 @@ key parts:
     RBI output file.
 
   - You can **effortlessly build tools which need to access types within an RBI**;
-    no need to write your own parser! 
+    no need to write your own parser!
+
+  - You can **generate RBI to ship with your gem** for consuming projects to use
+    ([see "RBIs within gems" in sorbet the docs](https://sorbet.org/docs/rbi#rbis-within-gems)).
 
 Please [**read the wiki**](https://github.com/AaronC81/parlour/wiki) to get
 started!
@@ -173,6 +176,26 @@ Parlour::TypeLoader.load_project('root/of/the/project')
 
 The structure of the returned object trees is identical to those you would
 create when generating an RBI, built of instances of `RbiObject` subclasses.
+
+## Generating RBI for a gem
+
+Include `parlour` as a development_dependency in your `.gemspec`:
+
+```ruby
+spec.add_development_dependency 'parlour'
+```
+
+Run Parlour from the command line:
+
+```ruby
+bundle exec parlour
+```
+
+Parlour is configured to use sane defaults assuming a standard gem structure
+to allow sorbet to automatically find your RBI when your gem is included as
+a dependency. If you require more advanced configuration you can add a
+`.parlour` YAML file in the root of your project (see this project's `.parlour`
+file as an example).
 
 ## Parlour Plugins
 

--- a/exe/parlour
+++ b/exe/parlour
@@ -25,25 +25,32 @@ command :run do |c|
       configuration = {}
     end
 
-    # Input/Output defaults
-    configuration[:root] ||= '.'
+    # Output default
     configuration[:output_file] ||= "rbi/#{File.basename(working_dir)}.rbi"
-
-    # Included/Excluded path defaults
-    configuration[:included_paths] ||= ['lib']
-    configuration[:excluded_paths] ||= ['sorbet', 'spec']
-
-    # Defaults can be overridden but we always want to exclude the output file
-    configuration[:excluded_paths] << configuration[:output_file]
-
-    # Included/Excluded module defaults
-    configuration[:included_modules] ||= []
-    configuration[:excluded_modules] ||= []
 
     # Style defaults
     configuration[:style] ||= {}
     configuration[:style][:tab_size] ||= 2
     configuration[:style][:break_params] ||= 4
+
+    # Parser defaults, set explicitly to false to not run parser
+    if configuration[:parser] != false
+      configuration[:parser] ||= {}
+
+      # Input/Output defaults
+      configuration[:parser][:root] ||= '.'
+
+      # Included/Excluded path defaults
+      configuration[:parser][:included_paths] ||= ['lib']
+      configuration[:parser][:excluded_paths] ||= ['sorbet', 'spec']
+
+      # Defaults can be overridden but we always want to exclude the output file
+      configuration[:parser][:excluded_paths] << configuration[:output_file]
+    end
+
+    # Included/Excluded module defaults
+    configuration[:included_modules] ||= []
+    configuration[:excluded_modules] ||= []
 
     # Require defaults
     configuration[:requires] ||= []
@@ -74,12 +81,14 @@ command :run do |c|
       tab_size: configuration[:style][:tab_size]
     )
 
-    Parlour::TypeLoader.load_project(
-      configuration[:root],
-      inclusions: configuration[:included_paths],
-      exclusions: configuration[:excluded_paths],
-      generator: gen,
-    )
+    if configuration[:parser]
+      Parlour::TypeLoader.load_project(
+        configuration[:parser][:root],
+        inclusions: configuration[:parser][:included_paths],
+        exclusions: configuration[:parser][:excluded_paths],
+        generator: gen,
+      )
+    end
     Parlour::Plugin.run_plugins(plugin_instances, gen)
 
     # Run a pass of the conflict resolver

--- a/exe/parlour
+++ b/exe/parlour
@@ -16,9 +16,23 @@ command :run do |c|
   c.description = 'Generates an RBI file from your .parlour file'
 
   c.action do |args, options|
-    configuration = keys_to_symbols(YAML.load_file(File.join(Dir.pwd, '.parlour')))
+    working_dir = Dir.pwd
+    config_filename = File.join(working_dir, '.parlour')
 
-    raise 'you must specify output_file in your .parlour file' unless configuration[:output_file]
+    if File.exists?(config_filename)
+      configuration = keys_to_symbols(YAML.load_file(config_filename))
+    else
+      configuration = {}
+    end
+
+    # Input/Output defaults
+    configuration[:root] ||= '.'
+    configuration[:output_file] ||= "rbi/#{File.basename(working_dir)}.rbi"
+    configuration[:inclusions] ||= ['lib']
+    configuration[:exclusions] ||= ['sorbet', 'spec']
+
+    # Defaults can be overridden but we always want to exclude the output file
+    configuration[:exclusions] << configuration[:output_file]
 
     # Style defaults
     configuration[:style] ||= {}
@@ -52,6 +66,13 @@ command :run do |c|
     gen = Parlour::RbiGenerator.new(
       break_params: configuration[:style][:break_params],
       tab_size: configuration[:style][:tab_size]
+    )
+
+    Parlour::TypeLoader.load_project(
+      configuration[:root],
+      inclusions: configuration[:inclusions],
+      exclusions: configuration[:exclusions],
+      generator: gen,
     )
     Parlour::Plugin.run_plugins(plugin_instances, gen)
 
@@ -98,6 +119,7 @@ command :run do |c|
     end
 
     # Write the final RBI
+    FileUtils.mkdir_p(File.dirname(configuration[:output_file]))
     File.write(configuration[:output_file], gen.rbi(strictness))
   end
 end

--- a/exe/parlour
+++ b/exe/parlour
@@ -28,11 +28,17 @@ command :run do |c|
     # Input/Output defaults
     configuration[:root] ||= '.'
     configuration[:output_file] ||= "rbi/#{File.basename(working_dir)}.rbi"
-    configuration[:inclusions] ||= ['lib']
-    configuration[:exclusions] ||= ['sorbet', 'spec']
+
+    # Included/Excluded path defaults
+    configuration[:included_paths] ||= ['lib']
+    configuration[:excluded_paths] ||= ['sorbet', 'spec']
 
     # Defaults can be overridden but we always want to exclude the output file
-    configuration[:exclusions] << configuration[:output_file]
+    configuration[:excluded_paths] << configuration[:output_file]
+
+    # Included/Excluded module defaults
+    configuration[:included_modules] ||= []
+    configuration[:excluded_modules] ||= []
 
     # Style defaults
     configuration[:style] ||= {}
@@ -70,8 +76,8 @@ command :run do |c|
 
     Parlour::TypeLoader.load_project(
       configuration[:root],
-      inclusions: configuration[:inclusions],
-      exclusions: configuration[:exclusions],
+      inclusions: configuration[:included_paths],
+      exclusions: configuration[:excluded_paths],
       generator: gen,
     )
     Parlour::Plugin.run_plugins(plugin_instances, gen)
@@ -93,6 +99,14 @@ command :run do |c|
       puts
       choice = ask("?  ", Integer) { |q| q.in = 0..candidates.length }
       choice == 0 ? nil : candidates[choice - 1]
+    end
+
+    if !configuration[:included_modules].empty? || !configuration[:excluded_modules].empty?
+      remove_unwanted_modules(
+        gen.root,
+        included_modules: configuration[:included_modules],
+        excluded_modules: configuration[:excluded_modules],
+      )
     end
 
     # Figure out strictness levels
@@ -143,4 +157,25 @@ def keys_to_symbols(hash)
       end
     ]
   end.to_h
+end
+
+def remove_unwanted_modules(root, included_modules:, excluded_modules:, prefix: nil)
+  root.children.select! do |child|
+    module_name = "#{prefix}#{child.name}"
+
+    if child.respond_to?(:children)
+      remove_unwanted_modules(
+        child,
+        included_modules: included_modules,
+        excluded_modules: excluded_modules,
+        prefix: "#{module_name}::",
+      )
+      has_included_children = !child.children.empty?
+    end
+
+    included = included_modules.empty? ? true : included_modules.any? { |m| module_name.start_with?(m) }
+    excluded = excluded_modules.empty? ? false : excluded_modules.any? { |m| module_name.start_with?(m) }
+
+    (included || has_included_children) && !excluded
+  end
 end

--- a/lib/parlour/detached_rbi_generator.rb
+++ b/lib/parlour/detached_rbi_generator.rb
@@ -6,14 +6,9 @@ module Parlour
     def detached!
       raise "cannot call methods on a detached RBI generator"
     end
-  
+
     sig { override.returns(Options) }
     def options
-      detached!
-    end
-
-    sig { override.returns(Namespace) }
-    def root
       detached!
     end
 

--- a/lib/parlour/plugin.rb
+++ b/lib/parlour/plugin.rb
@@ -50,7 +50,7 @@ module Parlour
       end
     end
 
-    sig { params(options: Hash).void }
+    sig { params(options: T::Hash[T.untyped, T.untyped]).void }
     def initialize(options); end
 
     sig { abstract.params(root: RbiGenerator::Namespace).void }

--- a/lib/parlour/rbi_generator/parameter.rb
+++ b/lib/parlour/rbi_generator/parameter.rb
@@ -42,7 +42,7 @@ module Parlour
 
         @kind = :keyword if kind == :normal && name.end_with?(':')
 
-        @type = type
+        @type = type || 'T.untyped'
         @default = default
       end
 
@@ -80,10 +80,10 @@ module Parlour
         T.must(name[prefix.length..-1])
       end
 
-      sig { returns(T.nilable(String)) }
+      sig { returns(String) }
       # A Sorbet string of this parameter's type, such as +"String"+ or
       # +"T.untyped"+.
-      # @return [String, nil]
+      # @return [String]
       attr_reader :type
 
       sig { returns(T.nilable(String)) }
@@ -118,7 +118,7 @@ module Parlour
       #
       # @return [String]
       def to_sig_param
-        "#{name_without_kind}: #{type || 'T.untyped'}"
+        "#{name_without_kind}: #{type}"
       end#
 
       # A mapping of {kind} values to the characteristic prefixes each kind has.

--- a/lib/parlour/type_loader.rb
+++ b/lib/parlour/type_loader.rb
@@ -46,7 +46,7 @@ module Parlour
     #
     # @param [String] root The root of the project; where the "sorbet" directory
     #   and "Gemfile" are located.
-    # @param [Array<String>] exclusions A list of files to include when loading
+    # @param [Array<String>] inclusions A list of files to include when loading
     #   the project, relative to the given root.
     # @param [Array<String>] exclusions A list of files to exclude when loading
     #   the project, relative to the given root.

--- a/lib/parlour/type_loader.rb
+++ b/lib/parlour/type_loader.rb
@@ -10,27 +10,34 @@ module Parlour
     # TODO: make this into a class which stores configuration and passes it to
     # all typeparsers
 
-    sig { params(source: String, filename: T.nilable(String)).returns(RbiGenerator::Namespace) }
+    sig { params(source: String, filename: T.nilable(String), generator: T.nilable(RbiGenerator)).returns(RbiGenerator::Namespace) }
     # Converts Ruby source code into a tree of objects.
     #
     # @param [String] source The Ruby source code.
     # @param [String, nil] filename The filename to use when parsing this code.
     #   This may be used in error messages, but is optional.
     # @return [RbiGenerator::Namespace] The root of the object tree.
-    def self.load_source(source, filename = nil)
-      TypeParser.from_source(filename || '(source)', source).parse_all
+    def self.load_source(source, filename = nil, generator: nil)
+      TypeParser.from_source(filename || '(source)', source, generator: generator).parse_all
     end
 
-    sig { params(filename: String).returns(RbiGenerator::Namespace) }
+    sig { params(filename: String, generator: T.nilable(RbiGenerator)).returns(RbiGenerator::Namespace) }
     # Converts Ruby source code into a tree of objects from a file.
     #
     # @param [String] filename The name of the file to load code from.
     # @return [RbiGenerator::Namespace] The root of the object tree.
-    def self.load_file(filename)
-      load_source(File.read(filename), filename)
+    def self.load_file(filename, generator: nil)
+      load_source(File.read(filename), filename, generator: generator)
     end
-  
-    sig { params(root: String, exclusions: T::Array[String]).returns(RbiGenerator::Namespace) }
+
+    sig do
+      params(
+        root: String,
+        inclusions: T::Array[String],
+        exclusions: T::Array[String],
+        generator: T.nilable(RbiGenerator),
+      ).returns(RbiGenerator::Namespace)
+    end
     # Loads an entire Sorbet project using Sorbet's file table, obeying any
     # "typed: ignore" sigils, into a tree of objects.
     #
@@ -39,12 +46,15 @@ module Parlour
     #
     # @param [String] root The root of the project; where the "sorbet" directory
     #   and "Gemfile" are located.
+    # @param [Array<String>] exclusions A list of files to include when loading
+    #   the project, relative to the given root.
     # @param [Array<String>] exclusions A list of files to exclude when loading
     #   the project, relative to the given root.
     # @return [RbiGenerator::Namespace] The root of the object tree.
-    def self.load_project(root, exclusions: [])
+    def self.load_project(root, inclusions: ['.'], exclusions: [], generator: nil)
+      expanded_inclusions = inclusions.map { |i| File.expand_path(i, root) }
       expanded_exclusions = exclusions.map { |e| File.expand_path(e, root) }
-      
+
       stdin, stdout, stderr, wait_thr = T.unsafe(Open3).popen3(
         'bundle exec srb tc -p file-table-json',
         chdir: root
@@ -63,13 +73,16 @@ module Parlour
         path = File.expand_path(rel_path, root)
 
         # Skip this file if it was excluded
-        next if expanded_exclusions.include?(path)
+        next if !expanded_inclusions.any? { |i| path.start_with?(i) } \
+          || expanded_exclusions.any? { |e| path.start_with?(e) }
 
         # There are some entries which are URLs to stdlib
         next unless File.exist?(path)
 
-        namespaces << load_file(path)
+        namespaces << load_file(path, generator: generator)
       end
+
+      namespaces.uniq!
 
       raise 'project is empty' if namespaces.empty?
 

--- a/lib/parlour/type_parser.rb
+++ b/lib/parlour/type_parser.rb
@@ -132,7 +132,7 @@ module Parlour
     # @return [RbiGenerator::Namespace] The root namespace of the parsed source.
     sig { returns(RbiGenerator::Namespace) }
     def parse_all
-      root = RbiGenerator::Namespace.new(DetachedRbiGenerator.new)
+      root = generator.root
       root.children.concat(parse_path_to_object(NodePath.new([])))
       root
     end

--- a/rbi/parlour.rbi
+++ b/rbi/parlour.rbi
@@ -725,7 +725,7 @@ module Parlour
       sig { returns(String) }
       def name_without_kind; end
 
-      sig { returns(T.nilable(String)) }
+      sig { returns(String) }
       attr_reader :type
 
       sig { returns(T.nilable(String)) }

--- a/rbi/parlour.rbi
+++ b/rbi/parlour.rbi
@@ -1,0 +1,893 @@
+# typed: strong
+module Parlour
+  VERSION = '2.1.0'
+
+  class ConflictResolver
+    extend T::Sig
+
+    sig { params(namespace: RbiGenerator::Namespace, resolver: T.proc.params(
+          desc: String,
+          choices: T::Array[RbiGenerator::RbiObject]
+        ).returns(RbiGenerator::RbiObject)).void }
+    def resolve_conflicts(namespace, &resolver); end
+
+    sig { params(arr: T::Array[T.untyped]).returns(T.nilable(Symbol)) }
+    def merge_strategy(arr); end
+
+    sig { params(arr: T::Array[T.untyped]).returns(T::Boolean) }
+    def all_eql?(arr); end
+  end
+
+  module Debugging
+    extend T::Sig
+
+    sig { params(value: T::Boolean).returns(T::Boolean) }
+    def self.debug_mode=(value); end
+
+    sig { returns(T::Boolean) }
+    def self.debug_mode?; end
+
+    sig { params(object: T.untyped, message: String).void }
+    def self.debug_puts(object, message); end
+
+    sig { params(object: T.untyped).returns(String) }
+    def self.name_for_debug_caller(object); end
+
+    module Tree
+      extend T::Sig
+      INDENT_SPACES = 2
+
+      sig { params(message: String).returns(String) }
+      def self.begin(message); end
+
+      sig { params(message: String).returns(String) }
+      def self.here(message); end
+
+      sig { params(message: String).returns(String) }
+      def self.end(message); end
+
+      sig { returns(T.untyped) }
+      def self.line_prefix; end
+
+      sig { returns(T.untyped) }
+      def self.text_prefix; end
+    end
+  end
+
+  class DetachedRbiGenerator < RbiGenerator
+    sig { returns(T.untyped) }
+    def detached!; end
+
+    sig { override.returns(Options) }
+    def options; end
+
+    sig { override.returns(T.nilable(Plugin)) }
+    def current_plugin; end
+
+    sig { override.params(strictness: String).returns(String) }
+    def rbi(strictness = 'strong'); end
+  end
+
+  class ParseError < StandardError
+    extend T::Sig
+
+    sig { returns(Parser::Source::Buffer) }
+    attr_reader :buffer
+
+    sig { returns(Parser::Source::Range) }
+    attr_reader :range
+
+    sig { params(buffer: T.untyped, range: T.untyped).returns(T.untyped) }
+    def initialize(buffer, range); end
+  end
+
+  class Plugin
+    abstract!
+
+    extend T::Sig
+    extend T::Helpers
+
+    sig { returns(T::Hash[String, T.class_of(Plugin)]) }
+    def self.registered_plugins; end
+
+    sig { params(new_plugin: T.class_of(Plugin)).void }
+    def self.inherited(new_plugin); end
+
+    sig { params(plugins: T::Array[Plugin], generator: RbiGenerator, allow_failure: T::Boolean).void }
+    def self.run_plugins(plugins, generator, allow_failure: true); end
+
+    sig { params(options: Hash).void }
+    def initialize(options); end
+
+    sig { abstract.params(root: RbiGenerator::Namespace).void }
+    def generate(root); end
+
+    sig { returns(T.nilable(String)) }
+    attr_accessor :strictness
+  end
+
+  module TypeLoader
+    extend T::Sig
+
+    sig { params(source: String, filename: T.nilable(String), generator: T.nilable(RbiGenerator)).returns(RbiGenerator::Namespace) }
+    def self.load_source(source, filename = nil, generator: nil); end
+
+    sig { params(filename: String, generator: T.nilable(RbiGenerator)).returns(RbiGenerator::Namespace) }
+    def self.load_file(filename, generator: nil); end
+
+    sig do
+      params(
+        root: String,
+        inclusions: T::Array[String],
+        exclusions: T::Array[String],
+        generator: T.nilable(RbiGenerator)
+      ).returns(RbiGenerator::Namespace)
+    end
+    def self.load_project(root, inclusions: ['.'], exclusions: [], generator: nil); end
+  end
+
+  class TypeParser
+    extend T::Sig
+
+    class NodePath
+      extend T::Sig
+
+      sig { returns(T::Array[Integer]) }
+      attr_reader :indices
+
+      sig { params(indices: T::Array[Integer]).void }
+      def initialize(indices); end
+
+      sig { returns(NodePath) }
+      def parent; end
+
+      sig { params(index: Integer).returns(NodePath) }
+      def child(index); end
+
+      sig { params(offset: Integer).returns(NodePath) }
+      def sibling(offset); end
+
+      sig { params(start: Parser::AST::Node).returns(Parser::AST::Node) }
+      def traverse(start); end
+    end
+
+    sig { params(ast: Parser::AST::Node, unknown_node_errors: T::Boolean, generator: T.nilable(RbiGenerator)).void }
+    def initialize(ast, unknown_node_errors: false, generator: nil); end
+
+    sig { params(filename: String, source: String, generator: T.nilable(RbiGenerator)).returns(TypeParser) }
+    def self.from_source(filename, source, generator: nil); end
+
+    sig { returns(Parser::AST::Node) }
+    attr_accessor :ast
+
+    sig { returns(T::Boolean) }
+    attr_reader :unknown_node_errors
+
+    sig { returns(RbiGenerator) }
+    attr_accessor :generator
+
+    sig { returns(RbiGenerator::Namespace) }
+    def parse_all; end
+
+    sig { params(path: NodePath, is_within_eigenclass: T::Boolean).returns(T::Array[RbiGenerator::RbiObject]) }
+    def parse_path_to_object(path, is_within_eigenclass: false); end
+
+    class IntermediateSig < T::Struct
+      prop :type_parameters, T.nilable(T::Array[Symbol])
+      prop :overridable, T::Boolean
+      prop :override, T::Boolean
+      prop :abstract, T::Boolean
+      prop :final, T::Boolean
+      prop :return_type, T.nilable(String)
+      prop :params, T.nilable(T::Array[Parser::AST::Node])
+
+    end
+
+    sig { params(path: NodePath).returns(IntermediateSig) }
+    def parse_sig_into_sig(path); end
+
+    sig { params(path: NodePath, is_within_eigenclass: T::Boolean).returns(T::Array[RbiGenerator::Method]) }
+    def parse_sig_into_methods(path, is_within_eigenclass: false); end
+
+    sig { params(path: NodePath, is_within_eigenclass: T::Boolean).returns(T::Array[RbiGenerator::Method]) }
+    def parse_method_into_methods(path, is_within_eigenclass: false); end
+
+    sig { params(node: T.nilable(Parser::AST::Node)).returns(T::Array[Symbol]) }
+    def constant_names(node); end
+
+    sig { params(node: Parser::AST::Node).returns(T::Boolean) }
+    def sig_node?(node); end
+
+    sig { params(path: NodePath).returns(T::Boolean) }
+    def previous_sibling_sig_node?(path); end
+
+    sig { params(node: T.nilable(Parser::AST::Node)).returns(T.nilable(String)) }
+    def node_to_s(node); end
+
+    sig { params(node: T.nilable(Parser::AST::Node), modifier: Symbol).returns(T::Boolean) }
+    def body_has_modifier?(node, modifier); end
+
+    sig { params(node: Parser::AST::Node).returns([T::Array[String], T::Array[String]]) }
+    def body_includes_and_extends(node); end
+
+    sig { params(desc: String, node: T.any(Parser::AST::Node, NodePath)).returns(T.noreturn) }
+    def parse_err(desc, node); end
+
+    sig do
+      type_parameters(:A, :B).params(
+        a: T::Array[T.type_parameter(:A)],
+        fa: T.proc.params(item: T.type_parameter(:A)).returns(T.untyped),
+        b: T::Array[T.type_parameter(:B)],
+        fb: T.proc.params(item: T.type_parameter(:B)).returns(T.untyped)
+      ).returns(T::Array[[T.type_parameter(:A), T.type_parameter(:B)]])
+    end
+    def zip_by(a, fa, b, fb); end
+  end
+
+  class RbiGenerator
+    extend T::Sig
+
+    sig { params(break_params: Integer, tab_size: Integer, sort_namespaces: T::Boolean).void }
+    def initialize(break_params: 4, tab_size: 2, sort_namespaces: false); end
+
+    sig { returns(Options) }
+    attr_reader :options
+
+    sig { returns(Namespace) }
+    attr_reader :root
+
+    sig { returns(T.nilable(Plugin)) }
+    attr_accessor :current_plugin
+
+    sig { overridable.params(strictness: String).returns(String) }
+    def rbi(strictness = 'strong'); end
+
+    class Arbitrary < RbiObject
+      sig { params(generator: RbiGenerator, code: String, block: T.nilable(T.proc.params(x: Arbitrary).void)).void }
+      def initialize(generator, code: '', &block); end
+
+      sig { returns(String) }
+      attr_accessor :code
+
+      sig { params(other: Object).returns(T::Boolean) }
+      def ==(other); end
+
+      sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_rbi(indent_level, options); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).returns(T::Boolean) }
+      def mergeable?(others); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).void }
+      def merge_into_self(others); end
+
+      sig { override.returns(String) }
+      def describe; end
+    end
+
+    class Attribute < Method
+      sig do
+        params(
+          generator: RbiGenerator,
+          name: String,
+          kind: Symbol,
+          type: String,
+          class_attribute: T::Boolean,
+          block: T.nilable(T.proc.params(x: Attribute).void)
+        ).void
+      end
+      def initialize(generator, name, kind, type, class_attribute: false, &block); end
+
+      sig { returns(Symbol) }
+      attr_reader :kind
+
+      sig { returns(T::Boolean) }
+      attr_reader :class_attribute
+
+      sig { override.params(other: Object).returns(T::Boolean) }
+      def ==(other); end
+
+      sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_definition(indent_level, options); end
+    end
+
+    class ClassNamespace < Namespace
+      extend T::Sig
+
+      sig do
+        params(
+          generator: RbiGenerator,
+          name: String,
+          final: T::Boolean,
+          superclass: T.nilable(String),
+          abstract: T::Boolean,
+          block: T.nilable(T.proc.params(x: ClassNamespace).void)
+        ).void
+      end
+      def initialize(generator, name, final, superclass, abstract, &block); end
+
+      sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_rbi(indent_level, options); end
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :superclass
+
+      sig { returns(T::Boolean) }
+      attr_reader :abstract
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).returns(T::Boolean) }
+      def mergeable?(others); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).void }
+      def merge_into_self(others); end
+
+      sig { override.returns(String) }
+      def describe; end
+    end
+
+    class Constant < RbiObject
+      sig do
+        params(
+          generator: RbiGenerator,
+          name: String,
+          value: String,
+          block: T.nilable(T.proc.params(x: Constant).void)
+        ).void
+      end
+      def initialize(generator, name: '', value: '', &block); end
+
+      sig { returns(String) }
+      attr_reader :value
+
+      sig { params(other: Object).returns(T::Boolean) }
+      def ==(other); end
+
+      sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_rbi(indent_level, options); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).returns(T::Boolean) }
+      def mergeable?(others); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).void }
+      def merge_into_self(others); end
+
+      sig { override.returns(String) }
+      def describe; end
+    end
+
+    class EnumClassNamespace < ClassNamespace
+      extend T::Sig
+
+      sig do
+        params(
+          generator: RbiGenerator,
+          name: String,
+          final: T::Boolean,
+          enums: T::Array[T.any([String, String], String)],
+          abstract: T::Boolean,
+          block: T.nilable(T.proc.params(x: EnumClassNamespace).void)
+        ).void
+      end
+      def initialize(generator, name, final, enums, abstract, &block); end
+
+      sig { returns(T::Array[T.any([String, String], String)]) }
+      attr_reader :enums
+
+      sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_body(indent_level, options); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).returns(T::Boolean) }
+      def mergeable?(others); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).void }
+      def merge_into_self(others); end
+    end
+
+    class Extend < RbiObject
+      sig { params(generator: RbiGenerator, name: String, block: T.nilable(T.proc.params(x: Extend).void)).void }
+      def initialize(generator, name: '', &block); end
+
+      sig { params(other: Object).returns(T::Boolean) }
+      def ==(other); end
+
+      sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_rbi(indent_level, options); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).returns(T::Boolean) }
+      def mergeable?(others); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).void }
+      def merge_into_self(others); end
+
+      sig { override.returns(String) }
+      def describe; end
+    end
+
+    class Include < RbiObject
+      sig { params(generator: RbiGenerator, name: String, block: T.nilable(T.proc.params(x: Include).void)).void }
+      def initialize(generator, name: '', &block); end
+
+      sig { params(other: Object).returns(T::Boolean) }
+      def ==(other); end
+
+      sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_rbi(indent_level, options); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).returns(T::Boolean) }
+      def mergeable?(others); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).void }
+      def merge_into_self(others); end
+
+      sig { override.returns(String) }
+      def describe; end
+    end
+
+    class Method < RbiObject
+      extend T::Sig
+
+      sig do
+        params(
+          generator: RbiGenerator,
+          name: String,
+          parameters: T::Array[Parameter],
+          return_type: T.nilable(String),
+          abstract: T::Boolean,
+          implementation: T::Boolean,
+          override: T::Boolean,
+          overridable: T::Boolean,
+          class_method: T::Boolean,
+          final: T::Boolean,
+          type_parameters: T.nilable(T::Array[Symbol]),
+          block: T.nilable(T.proc.params(x: Method).void)
+        ).void
+      end
+      def initialize(generator, name, parameters, return_type = nil, abstract: false, implementation: false, override: false, overridable: false, class_method: false, final: false, type_parameters: nil, &block); end
+
+      sig { overridable.params(other: Object).returns(T::Boolean) }
+      def ==(other); end
+
+      sig { returns(T::Array[Parameter]) }
+      attr_reader :parameters
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :return_type
+
+      sig { returns(T::Boolean) }
+      attr_reader :abstract
+
+      sig { returns(T::Boolean) }
+      attr_reader :implementation
+
+      sig { returns(T::Boolean) }
+      attr_reader :override
+
+      sig { returns(T::Boolean) }
+      attr_reader :overridable
+
+      sig { returns(T::Boolean) }
+      attr_reader :class_method
+
+      sig { returns(T::Boolean) }
+      attr_reader :final
+
+      sig { returns(T::Array[Symbol]) }
+      attr_reader :type_parameters
+
+      sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_rbi(indent_level, options); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).returns(T::Boolean) }
+      def mergeable?(others); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).void }
+      def merge_into_self(others); end
+
+      sig { override.returns(String) }
+      def describe; end
+
+      sig { overridable.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_definition(indent_level, options); end
+
+      sig { returns(String) }
+      def qualifiers; end
+    end
+
+    class ModuleNamespace < Namespace
+      extend T::Sig
+
+      sig do
+        params(
+          generator: RbiGenerator,
+          name: String,
+          final: T::Boolean,
+          interface: T::Boolean,
+          block: T.nilable(T.proc.params(x: ClassNamespace).void)
+        ).void
+      end
+      def initialize(generator, name, final, interface, &block); end
+
+      sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_rbi(indent_level, options); end
+
+      sig { returns(T::Boolean) }
+      attr_reader :interface
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).returns(T::Boolean) }
+      def mergeable?(others); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).void }
+      def merge_into_self(others); end
+
+      sig { override.returns(String) }
+      def describe; end
+    end
+
+    class Namespace < RbiObject
+      extend T::Sig
+
+      sig { override.overridable.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_rbi(indent_level, options); end
+
+      sig do
+        params(
+          generator: RbiGenerator,
+          name: T.nilable(String),
+          final: T::Boolean,
+          block: T.nilable(T.proc.params(x: Namespace).void)
+        ).void
+      end
+      def initialize(generator, name = nil, final = false, &block); end
+
+      sig { returns(T::Boolean) }
+      attr_reader :final
+
+      sig { returns(T::Array[RbiObject]) }
+      attr_reader :children
+
+      sig { returns(T::Array[RbiGenerator::Extend]) }
+      def extends; end
+
+      sig { returns(T::Array[RbiGenerator::Include]) }
+      def includes; end
+
+      sig { returns(T::Array[RbiGenerator::Constant]) }
+      def constants; end
+
+      sig { params(object: T.untyped, block: T.proc.params(x: Namespace).void).void }
+      def path(object, &block); end
+
+      sig { params(comment: T.any(String, T::Array[String])).void }
+      def add_comment_to_next_child(comment); end
+
+      sig do
+        params(
+          name: String,
+          final: T::Boolean,
+          superclass: T.nilable(String),
+          abstract: T::Boolean,
+          block: T.nilable(T.proc.params(x: ClassNamespace).void)
+        ).returns(ClassNamespace)
+      end
+      def create_class(name, final: false, superclass: nil, abstract: false, &block); end
+
+      sig do
+        params(
+          name: String,
+          final: T::Boolean,
+          enums: T.nilable(T::Array[T.any([String, String], String)]),
+          abstract: T::Boolean,
+          block: T.nilable(T.proc.params(x: EnumClassNamespace).void)
+        ).returns(EnumClassNamespace)
+      end
+      def create_enum_class(name, final: false, enums: nil, abstract: false, &block); end
+
+      sig do
+        params(
+          name: String,
+          final: T::Boolean,
+          props: T.nilable(T::Array[StructProp]),
+          abstract: T::Boolean,
+          block: T.nilable(T.proc.params(x: StructClassNamespace).void)
+        ).returns(StructClassNamespace)
+      end
+      def create_struct_class(name, final: false, props: nil, abstract: false, &block); end
+
+      sig do
+        params(
+          name: String,
+          final: T::Boolean,
+          interface: T::Boolean,
+          block: T.nilable(T.proc.params(x: ClassNamespace).void)
+        ).returns(ModuleNamespace)
+      end
+      def create_module(name, final: false, interface: false, &block); end
+
+      sig do
+        params(
+          name: String,
+          parameters: T.nilable(T::Array[Parameter]),
+          return_type: T.nilable(String),
+          returns: T.nilable(String),
+          abstract: T::Boolean,
+          implementation: T::Boolean,
+          override: T::Boolean,
+          overridable: T::Boolean,
+          class_method: T::Boolean,
+          final: T::Boolean,
+          type_parameters: T.nilable(T::Array[Symbol]),
+          block: T.nilable(T.proc.params(x: Method).void)
+        ).returns(Method)
+      end
+      def create_method(name, parameters: nil, return_type: nil, returns: nil, abstract: false, implementation: false, override: false, overridable: false, class_method: false, final: false, type_parameters: nil, &block); end
+
+      sig do
+        params(
+          name: String,
+          kind: Symbol,
+          type: String,
+          class_attribute: T::Boolean,
+          block: T.nilable(T.proc.params(x: Attribute).void)
+        ).returns(Attribute)
+      end
+      def create_attribute(name, kind:, type:, class_attribute: false, &block); end
+
+      sig do
+        params(
+          name: String,
+          type: String,
+          class_attribute: T::Boolean,
+          block: T.nilable(T.proc.params(x: Attribute).void)
+        ).returns(Attribute)
+      end
+      def create_attr_reader(name, type:, class_attribute: false, &block); end
+
+      sig do
+        params(
+          name: String,
+          type: String,
+          class_attribute: T::Boolean,
+          block: T.nilable(T.proc.params(x: Attribute).void)
+        ).returns(Attribute)
+      end
+      def create_attr_writer(name, type:, class_attribute: false, &block); end
+
+      sig do
+        params(
+          name: String,
+          type: String,
+          class_attribute: T::Boolean,
+          block: T.nilable(T.proc.params(x: Attribute).void)
+        ).returns(Attribute)
+      end
+      def create_attr_accessor(name, type:, class_attribute: false, &block); end
+
+      sig { params(code: T.untyped, block: T.untyped).returns(T.untyped) }
+      def create_arbitrary(code:, &block); end
+
+      sig { params(name: String, block: T.nilable(T.proc.params(x: Extend).void)).returns(RbiGenerator::Extend) }
+      def create_extend(name, &block); end
+
+      sig { params(extendables: T::Array[String]).returns(T::Array[Extend]) }
+      def create_extends(extendables); end
+
+      sig { params(name: String, block: T.nilable(T.proc.params(x: Include).void)).returns(Include) }
+      def create_include(name, &block); end
+
+      sig { params(includables: T::Array[String]).returns(T::Array[Include]) }
+      def create_includes(includables); end
+
+      sig { params(name: String, value: String, block: T.nilable(T.proc.params(x: Constant).void)).returns(Constant) }
+      def create_constant(name, value:, &block); end
+
+      sig { params(name: String, type: String, block: T.nilable(T.proc.params(x: Constant).void)).returns(Constant) }
+      def create_type_alias(name, type:, &block); end
+
+      sig { override.overridable.params(others: T::Array[RbiGenerator::RbiObject]).returns(T::Boolean) }
+      def mergeable?(others); end
+
+      sig { override.overridable.params(others: T::Array[RbiGenerator::RbiObject]).void }
+      def merge_into_self(others); end
+
+      sig { override.overridable.returns(String) }
+      def describe; end
+
+      sig { overridable.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_body(indent_level, options); end
+
+      sig { params(object: RbiObject).void }
+      def move_next_comments(object); end
+    end
+
+    class Options
+      extend T::Sig
+
+      sig { params(break_params: Integer, tab_size: Integer, sort_namespaces: T::Boolean).void }
+      def initialize(break_params:, tab_size:, sort_namespaces:); end
+
+      sig { returns(Integer) }
+      attr_reader :break_params
+
+      sig { returns(Integer) }
+      attr_reader :tab_size
+
+      sig { returns(T::Boolean) }
+      attr_reader :sort_namespaces
+
+      sig { params(level: Integer, str: String).returns(String) }
+      def indented(level, str); end
+    end
+
+    class Parameter
+      extend T::Sig
+      PREFIXES = {
+        normal: '',
+        splat: '*',
+        double_splat: '**',
+        block: '&'
+      }.freeze
+
+      sig { params(name: String, type: T.nilable(String), default: T.nilable(String)).void }
+      def initialize(name, type: nil, default: nil); end
+
+      sig { params(other: Object).returns(T::Boolean) }
+      def ==(other); end
+
+      sig { returns(String) }
+      attr_reader :name
+
+      sig { returns(String) }
+      def name_without_kind; end
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :type
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :default
+
+      sig { returns(Symbol) }
+      attr_reader :kind
+
+      sig { returns(String) }
+      def to_def_param; end
+
+      sig { returns(String) }
+      def to_sig_param; end
+    end
+
+    class RbiObject
+      abstract!
+
+      extend T::Helpers
+      extend T::Sig
+
+      sig { params(generator: RbiGenerator, name: String).void }
+      def initialize(generator, name); end
+
+      sig { returns(RbiGenerator) }
+      attr_reader :generator
+
+      sig { returns(T.nilable(Plugin)) }
+      attr_reader :generated_by
+
+      sig { returns(String) }
+      attr_reader :name
+
+      sig { returns(T::Array[String]) }
+      attr_reader :comments
+
+      sig { params(comment: T.any(String, T::Array[String])).void }
+      def add_comment(comment); end
+
+      sig { abstract.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_rbi(indent_level, options); end
+
+      sig { abstract.params(others: T::Array[RbiGenerator::RbiObject]).returns(T::Boolean) }
+      def mergeable?(others); end
+
+      sig { abstract.params(others: T::Array[RbiGenerator::RbiObject]).void }
+      def merge_into_self(others); end
+
+      sig { abstract.returns(String) }
+      def describe; end
+
+      sig { params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_comments(indent_level, options); end
+    end
+
+    class StructClassNamespace < ClassNamespace
+      extend T::Sig
+
+      sig do
+        params(
+          generator: RbiGenerator,
+          name: String,
+          final: T::Boolean,
+          props: T::Array[StructProp],
+          abstract: T::Boolean,
+          block: T.nilable(T.proc.params(x: StructClassNamespace).void)
+        ).void
+      end
+      def initialize(generator, name, final, props, abstract, &block); end
+
+      sig { returns(T::Array[StructProp]) }
+      attr_reader :props
+
+      sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
+      def generate_body(indent_level, options); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).returns(T::Boolean) }
+      def mergeable?(others); end
+
+      sig { override.params(others: T::Array[RbiGenerator::RbiObject]).void }
+      def merge_into_self(others); end
+    end
+
+    class StructProp
+      extend T::Sig
+      EXTRA_PROPERTIES = %i{
+        optional enum dont_store foreign default factory immutable array override redaction
+      }
+
+      sig do
+        params(
+          name: String,
+          type: String,
+          optional: T.nilable(T.any(T::Boolean, Symbol)),
+          enum: T.nilable(String),
+          dont_store: T.nilable(T::Boolean),
+          foreign: T.nilable(String),
+          default: T.nilable(String),
+          factory: T.nilable(String),
+          immutable: T.nilable(T::Boolean),
+          array: T.nilable(String),
+          override: T.nilable(T::Boolean),
+          redaction: T.nilable(String)
+        ).void
+      end
+      def initialize(name, type, optional: nil, enum: nil, dont_store: nil, foreign: nil, default: nil, factory: nil, immutable: nil, array: nil, override: nil, redaction: nil); end
+
+      sig { params(other: Object).returns(T::Boolean) }
+      def ==(other); end
+
+      sig { returns(String) }
+      attr_reader :name
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :type
+
+      sig { returns(T.nilable(T.any(T::Boolean, Symbol))) }
+      attr_reader :optional
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :enum
+
+      sig { returns(T.nilable(T::Boolean)) }
+      attr_reader :dont_store
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :foreign
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :default
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :factory
+
+      sig { returns(T.nilable(T::Boolean)) }
+      attr_reader :immutable
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :array
+
+      sig { returns(T.nilable(T::Boolean)) }
+      attr_reader :override
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :redaction
+
+      sig { returns(String) }
+      def to_prop_call; end
+    end
+  end
+end

--- a/rbi/parlour.rbi
+++ b/rbi/parlour.rbi
@@ -82,7 +82,7 @@ module Parlour
     sig { params(plugins: T::Array[Plugin], generator: RbiGenerator, allow_failure: T::Boolean).void }
     def self.run_plugins(plugins, generator, allow_failure: true); end
 
-    sig { params(options: Hash).void }
+    sig { params(options: T::Hash[T.untyped, T.untyped]).void }
     def initialize(options); end
 
     sig { abstract.params(root: RbiGenerator::Namespace).void }

--- a/rbi/parlour.rbi
+++ b/rbi/parlour.rbi
@@ -54,20 +54,6 @@ module Parlour
     end
   end
 
-  class DetachedRbiGenerator < RbiGenerator
-    sig { returns(T.untyped) }
-    def detached!; end
-
-    sig { override.returns(Options) }
-    def options; end
-
-    sig { override.returns(T.nilable(Plugin)) }
-    def current_plugin; end
-
-    sig { override.params(strictness: String).returns(String) }
-    def rbi(strictness = 'strong'); end
-  end
-
   class ParseError < StandardError
     extend T::Sig
 

--- a/spec/type_loader_spec.rb
+++ b/spec/type_loader_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Parlour::TypeLoader do
 
     it 'with exclusions' do
       project_root = described_class.load_project('.',
-        exclusions: ['lib/parlour/rbi_generator/arbitrary.rb'])
+        exclusions: ['rbi', 'lib/parlour/rbi_generator/arbitrary.rb'])
       parlour_module = project_root.children.find { |x| x.name == 'Parlour' }
       expect(parlour_module).to be_a Parlour::RbiGenerator::ModuleNamespace
 

--- a/spec/type_loader_spec.rb
+++ b/spec/type_loader_spec.rb
@@ -66,7 +66,8 @@ RSpec.describe Parlour::TypeLoader do
   context 'can load this project' do
     it 'fully' do
       # Is this like a quine, in test form? :)
-      project_root = described_class.load_project('.')
+      project_root = described_class.load_project('.',
+        exclusions: ['rbi'])
       parlour_module = project_root.children.find { |x| x.name == 'Parlour' }
       expect(parlour_module).to be_a Parlour::RbiGenerator::ModuleNamespace
 

--- a/spec/type_parser_spec.rb
+++ b/spec/type_parser_spec.rb
@@ -281,9 +281,9 @@ RSpec.describe Parlour::TypeParser do
 
       expect(meth.parameters.length).to eq 2
       expect(meth.parameters[0]).to have_attributes(name: 'x', kind: :normal,
-        type: nil, default: nil)
+        type: "T.untyped", default: nil)
       expect(meth.parameters[1]).to have_attributes(name: 'y', kind: :normal,
-        type: nil, default: 'true')
+        type: "T.untyped", default: 'true')
     end
 
     it 'works for methods with complex parameters' do
@@ -299,13 +299,13 @@ RSpec.describe Parlour::TypeParser do
 
       expect(meth.parameters.length).to eq 4
       expect(meth.parameters[0]).to have_attributes(name: 'x', kind: :normal,
-        type: nil, default: nil)
+        type: "T.untyped", default: nil)
       expect(meth.parameters[1]).to have_attributes(name: 'y:', kind: :keyword,
-        type: nil, default: nil)
+        type: "T.untyped", default: nil)
       expect(meth.parameters[2]).to have_attributes(name: 'z:', kind: :keyword,
-        type: nil, default: '3')
+        type: "T.untyped", default: '3')
       expect(meth.parameters[3]).to have_attributes(name: '&blk', kind: :block,
-        type: nil, default: nil)
+        type: "T.untyped", default: nil)
     end
 
     it 'works with splat-arguments' do
@@ -320,9 +320,9 @@ RSpec.describe Parlour::TypeParser do
         return_type: "T.untyped", override: false)
 
       expect(meth.parameters[0]).to have_attributes(name: '*args', type: :splat,
-        type: nil)
+        type: "T.untyped")
       expect(meth.parameters[1]).to have_attributes(name: '**kwargs',
-        type: :double_splat, type: nil)
+        type: :double_splat, type: "T.untyped")
     end
 
     it 'supports class methods using self.x' do
@@ -337,7 +337,7 @@ RSpec.describe Parlour::TypeParser do
         override: false, final: false, class_method: true)
       expect(meth.parameters.length).to eq 1
       expect(meth.parameters.first).to have_attributes(name: 'x',
-        type: nil)
+        type: "T.untyped")
     end
 
     it 'supports class methods within an eigenclass' do
@@ -352,7 +352,7 @@ RSpec.describe Parlour::TypeParser do
         override: false, final: false, class_method: true)
       expect(meth.parameters.length).to eq 1
       expect(meth.parameters.first).to have_attributes(name: 'x',
-        type: nil)
+        type: "T.untyped")
     end
 
     it 'errors on a self.x method within an eigenclass' do


### PR DESCRIPTION
Sets up Parlour to easily generate gem RBI. This basically pulls in the functionality provided by `brain_freeze` so you can just do everything with `parlour` instead of needing an additional gem.

Some changes:
- Previously the parlour CLI was set up to only run plugins. Now it first run the `TypeLoader.load_project`, then the plugins, and run the conflict resolver on the result.
- The `TypeParser` would previously use the `DetachedRbiGenerator` throughout but now it will default to using that but also accept an `RbiGenerator` that you can pass in. This lets us reuse the same generator/root for both the `load_project` and the plugins.
- Add options:
  - `root`: defaults to `'.'`, should usually be your project root, should be where your `sorbet` folder lives.
  - `included_paths`: Lets you specify what paths you want the `load_project` to read. This defaults to `['lib']`
  - `excluded_paths`: Paths you want to exclude from `load_project`. This defaults to `['sorbet', `spec`]`.
  - `included_modules`: The modules you specifically want to include. Defaults to `[]` which means "include everything".
  - `excluded_modules`: The modules you specifically want to exclude. Defaults to `[]` which means "don't exclude anything".
- Update `TypeLoader.load_project` to accept the `inclusions` that's the opposite of `exclusions`. Also both of them now can be an entire filename but could also be a path prefix.

I ran this on a large monorepo of gems that I've been testing on this and got the same result as running `brain_freeze`.