### PR TITLE
Add support for generating constants on eigenclasses

### DIFF
--- a/lib/parlour/rbi_generator/constant.rb
+++ b/lib/parlour/rbi_generator/constant.rb
@@ -8,6 +8,7 @@ module Parlour
           generator: RbiGenerator,
           name: String,
           value: String,
+          eigen_constant: T::Boolean,
           block: T.nilable(T.proc.params(x: Constant).void)
         ).void
       end
@@ -15,15 +16,22 @@ module Parlour
       #
       # @param name [String] The name of the constant.
       # @param value [String] The value of the constant, as a Ruby code string.
-      def initialize(generator, name: '', value: '', &block)
+      # @param eigen_constant [Boolean] Whether this constant is defined on the
+      #   eigenclass of the current namespace.
+      def initialize(generator, name: '', value: '', eigen_constant: false, &block)
         super(generator, name)
         @value = value
+        @eigen_constant = eigen_constant
         yield_self(&block) if block
       end
 
       # @return [String] The value of the constant, as a Ruby code string.
       sig { returns(String) }
       attr_reader :value
+
+      # @return [Boolean] Whether this constant is defined on the eigenclass
+      #   of the current namespace.
+      attr_reader :eigen_constant
 
       sig { params(other: Object).returns(T::Boolean) }
       # Returns true if this instance is equal to another extend.
@@ -32,7 +40,8 @@ module Parlour
       #   subclass of it), this will always return false.
       # @return [Boolean]
       def ==(other)
-        Constant === other && name == other.name && value == other.value
+        Constant === other && name == other.name && value == other.value \
+          && eigen_constant == other.eigen_constant
       end
 
       sig do

--- a/rbi/parlour.rbi
+++ b/rbi/parlour.rbi
@@ -1,6 +1,9 @@
 # typed: strong
+module Kernel
+end
+
 module Parlour
-  VERSION = '2.1.0'
+  VERSION = '3.0.0'
 
   class ConflictResolver
     extend T::Sig
@@ -317,13 +320,17 @@ module Parlour
           generator: RbiGenerator,
           name: String,
           value: String,
+          eigen_constant: T::Boolean,
           block: T.nilable(T.proc.params(x: Constant).void)
         ).void
       end
-      def initialize(generator, name: '', value: '', &block); end
+      def initialize(generator, name: '', value: '', eigen_constant: false, &block); end
 
       sig { returns(String) }
       attr_reader :value
+
+      sig { returns(T.untyped) }
+      attr_reader :eigen_constant
 
       sig { params(other: Object).returns(T::Boolean) }
       def ==(other); end
@@ -663,8 +670,15 @@ module Parlour
       sig { params(includables: T::Array[String]).returns(T::Array[Include]) }
       def create_includes(includables); end
 
-      sig { params(name: String, value: String, block: T.nilable(T.proc.params(x: Constant).void)).returns(Constant) }
-      def create_constant(name, value:, &block); end
+      sig do
+        params(
+          name: String,
+          value: String,
+          eigen_constant: T::Boolean,
+          block: T.nilable(T.proc.params(x: Constant).void)
+        ).returns(Constant)
+      end
+      def create_constant(name, value:, eigen_constant: false, &block); end
 
       sig { params(name: String, type: String, block: T.nilable(T.proc.params(x: Constant).void)).returns(Constant) }
       def create_type_alias(name, type:, &block); end

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -627,4 +627,36 @@ RSpec.describe Parlour::RbiGenerator do
       end
     RUBY
   end
+
+  it 'supports eigenclass constants' do
+    mod = subject.root.create_module('M') do |m|
+      m.create_constant("X", value: "3", eigen_constant: true)
+    end
+
+    expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
+      module M
+        class << self
+          X = 3
+        end
+      end
+    RUBY
+  end
+
+  it 'supports multiple "class << self" constructs' do
+    mod = subject.root.create_module('M') do |m|
+      m.create_attr_reader("foo", type: "String", class_attribute: true)
+      m.create_constant("X", value: "3", eigen_constant: true)
+    end
+
+    expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
+      module M
+        class << self
+          X = 3
+
+          sig { returns(String) }
+          attr_reader :foo
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Closes #90.

This adds the ability for constants to be defined on eigenclasses by creating them with the `eigen_constant` keyword argument set to `true.