### PR TITLE
Fix incorrect sig

### DIFF
--- a/lib/parlour/conflict_resolver.rb
+++ b/lib/parlour/conflict_resolver.rb
@@ -13,7 +13,7 @@ module Parlour
         resolver: T.proc.params(
           desc: String,
           choices: T::Array[RbiGenerator::RbiObject]
-        ).returns(RbiGenerator::RbiObject)
+        ).returns(T.nilable(RbiGenerator::RbiObject))
       ).void
     end
     # Given a namespace, attempts to automatically resolve conflicts in the


### PR DESCRIPTION
The block passed to `resolve_conflicts` is allowed to return `nil`. Most of the caller code handles this correctly by doing stuff like

```ruby
            choice = resolver.call("Different kinds of definition for the same name", children)
            namespace.children << choice if choice
```

And the docs allow this:

![image](https://user-images.githubusercontent.com/509837/89428884-7e793300-d702-11ea-9e0a-08dc74c2b1c8.png)


It's just the sig that's wrong. Note that the bundled `parlour.rbi` will need to be regenerated too.

Came across this while working on https://github.com/chanzuckerberg/sorbet-rails/pull/367