### PR TITLE
Support user-defined generic classes.

### DIFF
--- a/rbi/parlour.rbi
+++ b/rbi/parlour.rbi
@@ -427,6 +427,29 @@ module Parlour
       def describe; end
     end
 
+    class Generic < Type
+      sig { params(type: TypeLike, type_params: T::Array[TypeLike]).void }
+      def initialize(type, type_params); end
+
+      sig { params(other: Object).returns(T::Boolean) }
+      def ==(other); end
+
+      sig { returns(Type) }
+      attr_reader :type
+
+      sig { returns(T::Array[Type]) }
+      attr_reader :type_params
+
+      sig { override.returns(String) }
+      def generate_rbi; end
+
+      sig { override.returns(String) }
+      def generate_rbs; end
+
+      sig { override.returns(String) }
+      def describe; end
+    end
+
     class SingleElementCollection < Type
       abstract!
 

--- a/spec/type_parser_spec.rb
+++ b/spec/type_parser_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Parlour::TypeParser do
       instance = described_class.from_source('(test)', <<-RUBY)
         sig do
           params(
-            x: String, 
+            x: String,
             y: T.nilable(T.any(Integer, T::Boolean)),
             z: Numeric,
             blk: T.proc.returns(T::Boolean)
@@ -151,7 +151,7 @@ RSpec.describe Parlour::TypeParser do
       expect(meth).to have_attributes(name: 'foo', return_type: 'Integer',
         override: false, final: true)
     end
-    
+
     it 'supports class methods using self.x' do
       instance = described_class.from_source('(test)', <<-RUBY)
         sig { params(x: String).returns(Integer) }
@@ -441,7 +441,7 @@ RSpec.describe Parlour::TypeParser do
 
       root = instance.parse_all
       expect(root.children.length).to eq 1
-      
+
       a = root.children.first
       expect(a).to be_a Parlour::RbiGenerator::ClassNamespace
       expect(a).to have_attributes(name: 'A', superclass: nil, final: false, abstract: false)
@@ -497,7 +497,7 @@ RSpec.describe Parlour::TypeParser do
 
       root = instance.parse_all
       expect(root.children.length).to eq 1
-      
+
       a = root.children.first
       expect(a).to be_a Parlour::RbiGenerator::ModuleNamespace
       expect(a).to have_attributes(name: 'A', final: false, interface: false)
@@ -522,7 +522,7 @@ RSpec.describe Parlour::TypeParser do
       expect(abs_bar).to have_attributes(name: 'bar', abstract: true, return_type: 'Integer')
       expect(abs_bar.parameters.length).to eq 1
       expect(abs_bar.parameters.first).to have_attributes(name: 'x', type: 'Integer')
-      
+
       impl_foo, impl_bar = *e.children
       expect(impl_foo).to be_a Parlour::RbiGenerator::Method
       expect(impl_bar).to be_a Parlour::RbiGenerator::Method
@@ -556,7 +556,7 @@ RSpec.describe Parlour::TypeParser do
 
       root = instance.parse_all
       expect(root.children.length).to eq 1
-      
+
       a = root.children.first
       expect(a).to be_a Parlour::RbiGenerator::ClassNamespace
       expect(a).to have_attributes(name: 'A', final: false)
@@ -662,7 +662,7 @@ RSpec.describe Parlour::TypeParser do
       d = c.children.first
       expect(d).to be_a Parlour::RbiGenerator::Namespace
       expect(d).to have_attributes(name: 'D', final: false)
-      
+
       e = d.children.first
       expect(e).to be_a Parlour::RbiGenerator::Namespace
       expect(e).to have_attributes(name: 'E', final: false)
@@ -917,6 +917,22 @@ RSpec.describe Parlour::TypeParser do
       )
     end
 
+    it 'parses hashes' do
+      expect(t('T::Hash[String, Integer]')).to eq \
+        Parlour::Types::Hash.new(
+          Parlour::Types::Raw.new('String'),
+          Parlour::Types::Raw.new('Integer'),
+        )
+    end
+
+    it 'parses generics' do
+      expect(t('Wrapper[String]')).to eq \
+        Parlour::Types::Generic.new(
+          Parlour::Types::Raw.new('Wrapper'),
+          [Parlour::Types::Raw.new('String')]
+        )
+    end
+
     it 'parses booleans' do
       expect(t('T::Boolean')).to eq Parlour::Types::Boolean.new
     end
@@ -940,7 +956,7 @@ RSpec.describe Parlour::TypeParser do
           Parlour::Types::Raw.new('String'),
         )
     end
-    
+
     it 'parses shapes' do
       expect(t('{ a: String, b: T.any(Integer, T::Boolean) }')).to eq \
         Parlour::Types::Record.new(
@@ -957,7 +973,7 @@ RSpec.describe Parlour::TypeParser do
     it 'can generalize this project' do
       project_root = Parlour::TypeLoader.load_project('.', exclusions: ['rbi'])
       project_root.generalize_from_rbi!
-      
+
       parlour_module = project_root.children.find { |x| x.name == 'Parlour' }
       expect(parlour_module).to be_a Parlour::RbiGenerator::ModuleNamespace
 
@@ -976,6 +992,6 @@ RSpec.describe Parlour::TypeParser do
       expect(meth.parameters[2]).to have_attributes(
         name: 'sort_namespaces:', type: Parlour::Types::Boolean.new,
       )
-    end 
+    end
   end
 end

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -1,0 +1,67 @@
+# typed: ignore
+
+require 'parser/current'
+
+# TODO: Add unit tests for more types
+RSpec.describe Parlour::Types do
+  describe 'Generic' do
+    subject(:type) {
+      Parlour::Types::Generic.new(
+        Parlour::Types::Raw.new('Mapper'),
+        [
+          Parlour::Types::Raw.new('String'),
+          Parlour::Types::Generic.new(
+            Parlour::Types::Raw.new('Mapper'),
+            [
+              Parlour::Types::Raw.new('String'),
+              Parlour::Types::Raw.new('Integer'),
+            ]
+          )
+        ]
+      )
+    }
+
+    it { expect(type.type).to eq(Parlour::Types::Raw.new('Mapper')) }
+    it do
+      expect(type.type_params).to eq([
+        Parlour::Types::Raw.new('String'),
+        Parlour::Types::Generic.new(
+          Parlour::Types::Raw.new('Mapper'),
+          [
+            Parlour::Types::Raw.new('String'),
+            Parlour::Types::Raw.new('Integer')
+          ]
+        )
+      ])
+    end
+
+    it {
+      expect(type.generate_rbi).to eq(
+        'Mapper[String, Mapper[String, Integer]]'
+      )
+    }
+    it {
+      expect(type.generate_rbs).to eq(
+        'Mapper[String, Mapper[String, Integer]]'
+      )
+    }
+    it {
+      expect(type.describe).to eq(
+        'Mapper<String, Mapper<String, Integer>>'
+      )
+    }
+  end
+
+  describe 'Hash' do
+    subject(:type) {
+      Parlour::Types::Hash.new('String', 'Integer')
+    }
+
+    it { expect(type.key).to eq(Parlour::Types::Raw.new('String')) }
+    it { expect(type.value).to eq(Parlour::Types::Raw.new('Integer')) }
+
+    it { expect(type.generate_rbi).to eq('T::Hash[String, Integer]') }
+    it { expect(type.generate_rbs).to eq('::Hash[String, Integer]') }
+    it { expect(type.describe).to eq('Hash<String, Integer>') }
+  end
+end


### PR DESCRIPTION
Related sord issue: https://github.com/AaronC81/sord/issues/121

This commit adds
- Parlour::Types::Generic, which represents a generic class with an
arbitrary number of type parameters
- support for Parlour::Types::Generic to Parlour::TypeParser

I considered was using `Generic` to implement some of the built in generics like `Hash`, `Array` etc. It feels a natural thing to do, but we'd need to add some sort of `Raw`-like type that handles the `T::Hash` vs `::Hash` vs `Hash` stuff.