### PR TITLE
Fix SingleElementCollection types.

### DIFF
--- a/lib/parlour/types.rb
+++ b/lib/parlour/types.rb
@@ -256,7 +256,7 @@ module Parlour
 
       sig { override.returns(String) }
       def generate_rbs
-        "#{collection_name}[#{element.generate_rbs}]"
+        "::#{collection_name}[#{element.generate_rbs}]"
       end
 
       sig { override.returns(String) }
@@ -269,7 +269,7 @@ module Parlour
     class Array < SingleElementCollection
       sig { override.returns(String) }
       def collection_name
-        '::Array'
+        'Array'
       end
 
       sig { params(other: Object).returns(T::Boolean) }
@@ -282,7 +282,7 @@ module Parlour
     class Set < SingleElementCollection
       sig { override.returns(String) }
       def collection_name
-        '::Set'
+        'Set'
       end
 
       sig { params(other: Object).returns(T::Boolean) }
@@ -295,7 +295,7 @@ module Parlour
     class Range < SingleElementCollection
       sig { override.returns(String) }
       def collection_name
-        '::Range'
+        'Range'
       end
 
       sig { params(other: Object).returns(T::Boolean) }
@@ -308,7 +308,7 @@ module Parlour
     class Enumerable < SingleElementCollection
       sig { override.returns(String) }
       def collection_name
-        '::Enumerable'
+        'Enumerable'
       end
 
       sig { params(other: Object).returns(T::Boolean) }
@@ -321,7 +321,7 @@ module Parlour
     class Enumerator < SingleElementCollection
       sig { override.returns(String) }
       def collection_name
-        '::Enumerator'
+        'Enumerator'
       end
 
       sig { params(other: Object).returns(T::Boolean) }

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -64,4 +64,64 @@ RSpec.describe Parlour::Types do
     it { expect(type.generate_rbs).to eq('::Hash[String, Integer]') }
     it { expect(type.describe).to eq('Hash<String, Integer>') }
   end
+
+  describe 'Array' do
+    subject(:type) {
+      Parlour::Types::Array.new('String')
+    }
+
+    it { expect(type.element).to eq(Parlour::Types::Raw.new('String')) }
+
+    it { expect(type.generate_rbi).to eq('T::Array[String]') }
+    it { expect(type.generate_rbs).to eq('::Array[String]') }
+    it { expect(type.describe).to eq('Array<String>') }
+  end
+
+  describe 'Set' do
+    subject(:type) {
+      Parlour::Types::Set.new('String')
+    }
+
+    it { expect(type.element).to eq(Parlour::Types::Raw.new('String')) }
+
+    it { expect(type.generate_rbi).to eq('T::Set[String]') }
+    it { expect(type.generate_rbs).to eq('::Set[String]') }
+    it { expect(type.describe).to eq('Set<String>') }
+  end
+
+  describe 'Range' do
+    subject(:type) {
+      Parlour::Types::Range.new('String')
+    }
+
+    it { expect(type.element).to eq(Parlour::Types::Raw.new('String')) }
+
+    it { expect(type.generate_rbi).to eq('T::Range[String]') }
+    it { expect(type.generate_rbs).to eq('::Range[String]') }
+    it { expect(type.describe).to eq('Range<String>') }
+  end
+
+  describe 'Enumerable' do
+    subject(:type) {
+      Parlour::Types::Enumerable.new('String')
+    }
+
+    it { expect(type.element).to eq(Parlour::Types::Raw.new('String')) }
+
+    it { expect(type.generate_rbi).to eq('T::Enumerable[String]') }
+    it { expect(type.generate_rbs).to eq('::Enumerable[String]') }
+    it { expect(type.describe).to eq('Enumerable<String>') }
+  end
+
+  describe 'Enumerator' do
+    subject(:type) {
+      Parlour::Types::Enumerator.new('String')
+    }
+
+    it { expect(type.element).to eq(Parlour::Types::Raw.new('String')) }
+
+    it { expect(type.generate_rbi).to eq('T::Enumerator[String]') }
+    it { expect(type.generate_rbs).to eq('::Enumerator[String]') }
+    it { expect(type.describe).to eq('Enumerator<String>') }
+  end
 end


### PR DESCRIPTION
`generate_rbi` was outputting `T::::Array`. Should `describe` also return root level types? I was following how Hash is implemented, which just has `Hash<Key, Value>`