### PR TITLE
Add "sealed!" generation and parsing support

### DIFF
--- a/lib/parlour/rbi_generator/class_namespace.rb
+++ b/lib/parlour/rbi_generator/class_namespace.rb
@@ -10,6 +10,7 @@ module Parlour
           generator: Generator,
           name: String,
           final: T::Boolean,
+          sealed: T::Boolean,
           superclass: T.nilable(String),
           abstract: T::Boolean,
           block: T.nilable(T.proc.params(x: ClassNamespace).void)
@@ -21,13 +22,14 @@ module Parlour
       # @param generator [RbiGenerator] The current RbiGenerator.
       # @param name [String] The name of this class.
       # @param final [Boolean] Whether this namespace is final.
+      # @param sealed [Boolean] Whether this namespace is sealed.
       # @param superclass [String, nil] The superclass of this class, or nil if it doesn't
       #   have one.
       # @param abstract [Boolean] A boolean indicating whether this class is abstract.
       # @param block A block which the new instance yields itself to.
       # @return [void]
-      def initialize(generator, name, final, superclass, abstract, &block)
-        super(generator, name, final, &block)
+      def initialize(generator, name, final, sealed, superclass, abstract, &block)
+        super(generator, name, final, sealed, &block)
         @superclass = superclass
         @abstract = abstract
       end

--- a/lib/parlour/rbi_generator/enum_class_namespace.rb
+++ b/lib/parlour/rbi_generator/enum_class_namespace.rb
@@ -10,6 +10,7 @@ module Parlour
           generator: Generator,
           name: String,
           final: T::Boolean,
+          sealed: T::Boolean,
           enums: T::Array[T.any([String, String], String)],
           abstract: T::Boolean,
           block: T.nilable(T.proc.params(x: EnumClassNamespace).void)
@@ -21,12 +22,13 @@ module Parlour
       # @param generator [RbiGenerator] The current RbiGenerator.
       # @param name [String] The name of this class.
       # @param final [Boolean] Whether this namespace is final.
+      # @param sealed [Boolean] Whether this namespace is sealed.
       # @param enums [Array<(String, String), String>] The values of the enumeration.
       # @param abstract [Boolean] A boolean indicating whether this class is abstract.
       # @param block A block which the new instance yields itself to.
       # @return [void]
-      def initialize(generator, name, final, enums, abstract, &block)
-        super(generator, name, final, 'T::Enum', abstract, &block)
+      def initialize(generator, name, final, sealed, enums, abstract, &block)
+        super(generator, name, final, sealed, 'T::Enum', abstract, &block)
         @enums = enums
       end
 

--- a/lib/parlour/rbi_generator/module_namespace.rb
+++ b/lib/parlour/rbi_generator/module_namespace.rb
@@ -10,6 +10,7 @@ module Parlour
           generator: Generator,
           name: String,
           final: T::Boolean,
+          sealed: T::Boolean,
           interface: T::Boolean,
           block: T.nilable(T.proc.params(x: ClassNamespace).void)
         ).void
@@ -20,12 +21,13 @@ module Parlour
       # @param generator [RbiGenerator] The current RbiGenerator.
       # @param name [String] The name of this module.
       # @param final [Boolean] Whether this namespace is final.
+      # @param sealed [Boolean] Whether this namespace is sealed.
       # @param interface [Boolean] A boolean indicating whether this module is an
       #   interface.
       # @param block A block which the new instance yields itself to.
       # @return [void]
-      def initialize(generator, name, final, interface, &block)
-        super(generator, name, final, &block)
+      def initialize(generator, name, final, sealed, interface, &block)
+        super(generator, name, final, sealed, &block)
         @name = name
         @interface = interface
       end

--- a/lib/parlour/rbi_generator/struct_class_namespace.rb
+++ b/lib/parlour/rbi_generator/struct_class_namespace.rb
@@ -11,6 +11,7 @@ module Parlour
           generator: Generator,
           name: String,
           final: T::Boolean,
+          sealed: T::Boolean,
           props: T::Array[StructProp],
           abstract: T::Boolean,
           block: T.nilable(T.proc.params(x: StructClassNamespace).void)
@@ -22,12 +23,13 @@ module Parlour
       # @param generator [RbiGenerator] The current RbiGenerator.
       # @param name [String] The name of this class.
       # @param final [Boolean] Whether this namespace is final.
+      # @param sealed [Boolean] Whether this namespace is sealed.
       # @param props [Array<StructProp>] The props of the struct.
       # @param abstract [Boolean] A boolean indicating whether this class is abstract.
       # @param block A block which the new instance yields itself to.
       # @return [void]
-      def initialize(generator, name, final, props, abstract, &block)
-        super(generator, name, final, 'T::Struct', abstract, &block)
+      def initialize(generator, name, final, sealed, props, abstract, &block)
+        super(generator, name, final, sealed, 'T::Struct', abstract, &block)
         @props = props
       end
 

--- a/lib/parlour/type_parser.rb
+++ b/lib/parlour/type_parser.rb
@@ -158,6 +158,7 @@ module Parlour
 
         name, superclass, body = *node
         final = body_has_modifier?(body, :final!)
+        sealed = body_has_modifier?(body, :sealed!)
         abstract = body_has_modifier?(body, :abstract!)
         includes, extends = body ? body_includes_and_extends(body) : [[], []]
 
@@ -169,6 +170,7 @@ module Parlour
           new_obj = RbiGenerator::Namespace.new(
             generator,
             n.to_s,
+            false,
             false,
           )
           target.children << new_obj if target
@@ -233,6 +235,7 @@ module Parlour
             generator,
             this_name.to_s,
             final,
+            sealed,
             props,
             abstract,
           )
@@ -256,6 +259,7 @@ module Parlour
             generator,
             this_name.to_s,
             final,
+            sealed,
             enums,
             abstract,
           )
@@ -264,6 +268,7 @@ module Parlour
             generator,
             this_name.to_s,
             final,
+            sealed,
             node_to_s(superclass),
             abstract,
           )
@@ -284,6 +289,7 @@ module Parlour
 
         name, body = *node
         final = body_has_modifier?(body, :final!)
+        sealed = body_has_modifier?(body, :sealed!)
         interface = body_has_modifier?(body, :interface!)
         includes, extends = body ? body_includes_and_extends(body) : [[], []]
 
@@ -296,6 +302,7 @@ module Parlour
             generator,
             n.to_s,
             false,
+            false,
           )
           target.children << new_obj if target
           target = new_obj
@@ -306,6 +313,7 @@ module Parlour
           generator,
           this_name.to_s,
           final,
+          sealed,
           interface,
         ) do |m|
           m.children.concat(parse_path_to_object(path.child(1))) if body

--- a/rbi/parlour.rbi
+++ b/rbi/parlour.rbi
@@ -772,12 +772,13 @@ module Parlour
           generator: Generator,
           name: String,
           final: T::Boolean,
+          sealed: T::Boolean,
           superclass: T.nilable(String),
           abstract: T::Boolean,
           block: T.nilable(T.proc.params(x: ClassNamespace).void)
         ).void
       end
-      def initialize(generator, name, final, superclass, abstract, &block); end
+      def initialize(generator, name, final, sealed, superclass, abstract, &block); end
 
       sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
       def generate_rbi(indent_level, options); end
@@ -846,12 +847,13 @@ module Parlour
           generator: Generator,
           name: String,
           final: T::Boolean,
+          sealed: T::Boolean,
           enums: T::Array[T.any([String, String], String)],
           abstract: T::Boolean,
           block: T.nilable(T.proc.params(x: EnumClassNamespace).void)
         ).void
       end
-      def initialize(generator, name, final, enums, abstract, &block); end
+      def initialize(generator, name, final, sealed, enums, abstract, &block); end
 
       sig { returns(T::Array[T.any([String, String], String)]) }
       attr_reader :enums
@@ -996,11 +998,12 @@ module Parlour
           generator: Generator,
           name: String,
           final: T::Boolean,
+          sealed: T::Boolean,
           interface: T::Boolean,
           block: T.nilable(T.proc.params(x: ClassNamespace).void)
         ).void
       end
-      def initialize(generator, name, final, interface, &block); end
+      def initialize(generator, name, final, sealed, interface, &block); end
 
       sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
       def generate_rbi(indent_level, options); end
@@ -1032,13 +1035,17 @@ module Parlour
           generator: Generator,
           name: T.nilable(String),
           final: T::Boolean,
+          sealed: T::Boolean,
           block: T.nilable(T.proc.params(x: Namespace).void)
         ).void
       end
-      def initialize(generator, name = nil, final = false, &block); end
+      def initialize(generator, name = nil, final = false, sealed = false, &block); end
 
       sig { returns(T::Boolean) }
       attr_reader :final
+
+      sig { returns(T::Boolean) }
+      attr_reader :sealed
 
       sig { returns(T::Array[RbiObject]) }
       attr_reader :children
@@ -1065,44 +1072,48 @@ module Parlour
         params(
           name: String,
           final: T::Boolean,
+          sealed: T::Boolean,
           superclass: T.nilable(String),
           abstract: T::Boolean,
           block: T.nilable(T.proc.params(x: ClassNamespace).void)
         ).returns(ClassNamespace)
       end
-      def create_class(name, final: false, superclass: nil, abstract: false, &block); end
+      def create_class(name, final: false, sealed: false, superclass: nil, abstract: false, &block); end
 
       sig do
         params(
           name: String,
           final: T::Boolean,
+          sealed: T::Boolean,
           enums: T.nilable(T::Array[T.any([String, String], String)]),
           abstract: T::Boolean,
           block: T.nilable(T.proc.params(x: EnumClassNamespace).void)
         ).returns(EnumClassNamespace)
       end
-      def create_enum_class(name, final: false, enums: nil, abstract: false, &block); end
+      def create_enum_class(name, final: false, sealed: false, enums: nil, abstract: false, &block); end
 
       sig do
         params(
           name: String,
           final: T::Boolean,
+          sealed: T::Boolean,
           props: T.nilable(T::Array[StructProp]),
           abstract: T::Boolean,
           block: T.nilable(T.proc.params(x: StructClassNamespace).void)
         ).returns(StructClassNamespace)
       end
-      def create_struct_class(name, final: false, props: nil, abstract: false, &block); end
+      def create_struct_class(name, final: false, sealed: false, props: nil, abstract: false, &block); end
 
       sig do
         params(
           name: String,
           final: T::Boolean,
+          sealed: T::Boolean,
           interface: T::Boolean,
           block: T.nilable(T.proc.params(x: ClassNamespace).void)
         ).returns(ModuleNamespace)
       end
-      def create_module(name, final: false, interface: false, &block); end
+      def create_module(name, final: false, sealed: false, interface: false, &block); end
 
       sig do
         params(
@@ -1283,12 +1294,13 @@ module Parlour
           generator: Generator,
           name: String,
           final: T::Boolean,
+          sealed: T::Boolean,
           props: T::Array[StructProp],
           abstract: T::Boolean,
           block: T.nilable(T.proc.params(x: StructClassNamespace).void)
         ).void
       end
-      def initialize(generator, name, final, props, abstract, &block); end
+      def initialize(generator, name, final, sealed, props, abstract, &block); end
 
       sig { returns(T::Array[StructProp]) }
       attr_reader :props

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe Parlour::RbiGenerator do
         end
       RUBY
     end
+
+    it 'can be sealed' do
+      mod = subject.root.create_module('Foo', sealed: true)
+
+      expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
+        module Foo
+          sealed!
+        end
+      RUBY
+    end
   end
 
   context 'class namespace' do
@@ -60,6 +70,16 @@ RSpec.describe Parlour::RbiGenerator do
       expect(klass.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
         class Foo
           final!
+        end
+      RUBY
+    end
+
+    it 'can be sealed' do
+      klass = subject.root.create_class('Foo', sealed: true)
+
+      expect(klass.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
+        class Foo
+          sealed!
         end
       RUBY
     end

--- a/spec/type_parser_spec.rb
+++ b/spec/type_parser_spec.rb
@@ -426,6 +426,7 @@ RSpec.describe Parlour::TypeParser do
           class B
             class C
               final!
+              sealed!
               abstract!
             end
 
@@ -444,19 +445,19 @@ RSpec.describe Parlour::TypeParser do
 
       a = root.children.first
       expect(a).to be_a Parlour::RbiGenerator::ClassNamespace
-      expect(a).to have_attributes(name: 'A', superclass: nil, final: false, abstract: false)
+      expect(a).to have_attributes(name: 'A', superclass: nil, final: false, abstract: false, sealed: false)
 
       b = a.children.first
       expect(b).to be_a Parlour::RbiGenerator::ClassNamespace
-      expect(b).to have_attributes(name: 'B', superclass: nil, final: false, abstract: false)
+      expect(b).to have_attributes(name: 'B', superclass: nil, final: false, abstract: false, sealed: false)
 
       c, d, e = *b.children
       expect(c).to be_a Parlour::RbiGenerator::ClassNamespace
       expect(d).to be_a Parlour::RbiGenerator::ClassNamespace
       expect(e).to be_a Parlour::RbiGenerator::ClassNamespace
-      expect(c).to have_attributes(name: 'C', superclass: nil, final: true, abstract: true)
-      expect(d).to have_attributes(name: 'D', superclass: nil, final: false, abstract: true)
-      expect(e).to have_attributes(name: 'E', superclass: 'B::D', final: false, abstract: false)
+      expect(c).to have_attributes(name: 'C', superclass: nil, final: true, abstract: true, sealed: true)
+      expect(d).to have_attributes(name: 'D', superclass: nil, final: false, abstract: true, sealed: false)
+      expect(e).to have_attributes(name: 'E', superclass: 'B::D', final: false, abstract: false, sealed: false)
     end
 
     it 'parses module structures containing methods' do
@@ -465,6 +466,7 @@ RSpec.describe Parlour::TypeParser do
           module B
             module C
               final!
+              sealed!
               interface!
             end
 
@@ -500,19 +502,19 @@ RSpec.describe Parlour::TypeParser do
 
       a = root.children.first
       expect(a).to be_a Parlour::RbiGenerator::ModuleNamespace
-      expect(a).to have_attributes(name: 'A', final: false, interface: false)
+      expect(a).to have_attributes(name: 'A', final: false, interface: false, sealed: false)
 
       b = a.children.first
       expect(b).to be_a Parlour::RbiGenerator::ModuleNamespace
-      expect(b).to have_attributes(name: 'B', final: false, interface: false)
+      expect(b).to have_attributes(name: 'B', final: false, interface: false, sealed: false)
 
       c, d, e = *b.children
       expect(c).to be_a Parlour::RbiGenerator::ModuleNamespace
       expect(d).to be_a Parlour::RbiGenerator::ModuleNamespace
       expect(e).to be_a Parlour::RbiGenerator::ModuleNamespace
-      expect(c).to have_attributes(name: 'C', final: true, interface: true)
-      expect(d).to have_attributes(name: 'D', final: false, interface: true)
-      expect(e).to have_attributes(name: 'E', final: false, interface: false)
+      expect(c).to have_attributes(name: 'C', final: true, interface: true, sealed: true)
+      expect(d).to have_attributes(name: 'D', final: false, interface: true, sealed: false)
+      expect(e).to have_attributes(name: 'E', final: false, interface: false, sealed: false)
       expect(e.includes.map(&:name)).to eq ['D']
 
       abs_foo, abs_bar = *d.children


### PR DESCRIPTION
Adds support for generating and parsing `sealed!` on classes and modules in RBI.

Closes #106.