### PR TITLE
Improve constant name lookup

### DIFF
--- a/rbi/parlour.rbi
+++ b/rbi/parlour.rbi
@@ -1066,8 +1066,8 @@ module Parlour
       sig { returns(T::Array[RbiGenerator::Constant]) }
       def constants; end
 
-      sig { params(object: T.untyped, block: T.proc.params(x: Namespace).void).void }
-      def path(object, &block); end
+      sig { params(constant: Module, block: T.proc.params(x: Namespace).void).void }
+      def path(constant, &block); end
 
       sig { params(comment: T.any(String, T::Array[String])).void }
       def add_comment_to_next_child(comment); end


### PR DESCRIPTION
There were a few things wrong with the way the current code was looking up constant names:

1. The parameter supplied to the `path` method can be typed as a `Module` since `Class` is a subclass of `Module`, thus, every constant would be a `Module`.
2. The parameter name as `object` was misleading, since we don't expect any random object, but a constant.
3. Looking up the name of a constant via the `to_s` method is a world of pain, since `to_s` does more magic like converting singleton names to `#<Class:Foo>` format or refinement names to `#<refinement:Bar xxx>` format. All of these are ultimately useless as a class/module identifier and cannot be processed properly by this method. We should be looking up the actual `name` of the constant.
4. Looking up the actual name of the constant is not straight-forward since a lot of code in the wild actually override the `name` class method and return non-sensical values. What gives the most accurate result is to call the `Module.name` method on the current constant instance, which can be achieved using the `bind.call` trick. This ensures that we get the identifier used to originally bind the constant with, not a value returned from a potentially overridden `name` method.

This PR adds tests and makes code changes to ensure that `Namespace#path` is safe against these pitfalls