### PR TITLE
Improve constant type matching

### DIFF
--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Parlour::RbiGenerator do
         subject.root.create_method('foo', returns: 'String', return_type: 'String')
       end.to raise_error(RuntimeError)
     end
- 
+
     it 'can be created with parameters' do
       meth = subject.root.create_method('foo', parameters: [
         pa('a', type: 'Integer', default: '4')
@@ -549,6 +549,11 @@ RSpec.describe Parlour::RbiGenerator do
           name
         end
       end
+      ::PathC = Class.new do
+        def self.class
+          Module
+        end
+      end
     end
 
     it 'generates correctly' do
@@ -589,6 +594,19 @@ RSpec.describe Parlour::RbiGenerator do
       constant = Module.new
 
       expect { subject.root.path(constant) { |*| } }.to raise_error(RuntimeError)
+    end
+
+    it 'works properly on constants that lie about their class' do
+      subject.root.path(::PathC) do |c|
+        c.create_method('foo')
+      end
+
+      expect(subject.root.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
+        class PathC
+          sig { void }
+          def foo; end
+        end
+      RUBY
     end
   end
 


### PR DESCRIPTION
As promised in #112, here is a small patch that streamlines and improves constant type matching in the `path` method.

Here are the highlights of the changes:

1. Instead of looping over the name parts twice, we are now iterating over the parts once and collecting them in a `namespace` array as we keep descending. That removes the need to pass temporary values around between the two loops as well.
2. In order to detect the type of the constant at each level, we are now essentially using `Class === instance` instead of looking up `instance.class`, which could be overridden. Encapsulating the check in a `case/when` construct makes that much more streamlined.
3. We do fallback to reading the `class` of the instance only if the type is not `Module` or `Class`, which we only use for error display purposes, so it doesn't really matter if it is not exact.

I've added a test case to show how this prevents the library from generating the wrong code if the type is somehow lying about its class.