### PR TITLE
Disable typechecking on the name attribute for TypedObject.

### DIFF
--- a/lib/parlour/typed_object.rb
+++ b/lib/parlour/typed_object.rb
@@ -20,7 +20,7 @@ module Parlour
     # @return [Plugin, nil]
     attr_reader :generated_by
 
-    sig { returns(String) }
+    sig { returns(String).checked(:never) }
     # The name of this object.
     # @return [String]
     attr_reader :name


### PR DESCRIPTION
I was having some problems with a SorbetRails plugin where the conflict resolution stage was taking an obscenely long time. This makes that problem significantly less severe.

For my open source Rails app vglist, it consistently decreases the time spent generating type signatures down from 14 seconds to 9 seconds. For a large Rails app, the difference is _much_ more significant. From 750 seconds down to 314 seconds.

I can't share more specific info from the larger app (proprietary and all that), but I can share the flamegraphs for my personal project [vglist](https://github.com/connorshea/vglist): https://gist.github.com/connorshea/a6e8c303b8464af90f33b98278fd3276

Unfortunately GitHub Gists don't allow JS inside an SVG to be run (even if you open them as Raw), so if you want to look at them in detail you'll need to save the files locally and view them in your browser from your filesystem (yes I realize that's very sketchy, unfortunately I don't know of a better solution other than hosting these on a website I own, which is too much work lol).

Essentially, the important part is in the `#resolve_conflicts` method.

Before this change:

<img width="812" alt="Screen Shot 2021-07-05 at 1 20 56 PM" src="https://user-images.githubusercontent.com/2977353/124511723-0a249500-dd94-11eb-96b0-8a220eb08f9c.png">

After:

<img width="550" alt="Screen Shot 2021-07-05 at 1 21 59 PM" src="https://user-images.githubusercontent.com/2977353/124511710-02fd8700-dd94-11eb-9370-5fade87a1876.png">

You'll note that the `TypedObject#name` method shows up as a large block of time before, and it's gone afterward.

In vglist, the `#resolve_conflicts` method goes from 8,491ms to 3,907ms. In the large Rails app I'm testing with, it cuts the `#resolve_conflicts` method down from 611,506ms to 172,784ms.

As far as I understand, I _think_ this performance improvement is due to the way that subclasses of TypedObject are compared with one another during conflict resolution to discover and eliminate duplicates. The first thing that always gets compared will be the `name` attribute, and therefore it's called _a lot_ of times (specifically, 4.4 million times in vglist and *258 million* times in the large Rails app).