### PR TITLE
Allow untyped method signatures to be merged with typed ones

### DIFF
--- a/lib/parlour/rbi_generator/method.rb
+++ b/lib/parlour/rbi_generator/method.rb
@@ -204,6 +204,9 @@ module Parlour
       # @return [void]
       def merge_into_self(others)
         # We don't need to change anything! We only merge identical methods
+        # (That's not strictly true, we also sometimes merge typed methods and
+        # untyped methods. This is handled by a special case within the conflict
+        # resolver itself.)
       end
 
       sig { override.returns(String) }

--- a/lib/parlour/rbi_generator/method.rb
+++ b/lib/parlour/rbi_generator/method.rb
@@ -223,6 +223,16 @@ module Parlour
         parameters.each(&:generalize_from_rbi!)
       end
 
+      sig { returns(T::Boolean) }
+      # Returns true if this method is completely untyped; that is, all
+      # parameters are untyped and the return type is untyped.
+      #
+      # @return [bool]
+      def untyped?
+        is_untyped = ->x{ x.is_a?(Types::Untyped) || x == 'T.untyped' }
+        parameters.map(&:type).all?(&is_untyped) && is_untyped.(return_type)
+      end
+
       private
 
       sig do

--- a/lib/parlour/rbs_generator/method.rb
+++ b/lib/parlour/rbs_generator/method.rb
@@ -141,6 +141,18 @@ module Parlour
         # TODO: more info
         "Method #{name} - #{signatures.length} signatures"
       end
+
+      sig { returns(T::Boolean) }
+      # Returns true if this method is completely untyped; that is, all
+      # parameters are untyped and the return type is untyped.
+      #
+      # @return [bool]
+      def untyped?
+        is_untyped = ->x{ x.is_a?(Types::Untyped) || x == 'untyped' }
+        signatures.all? do |sig|
+          sig.parameters.map(&:type).all?(&is_untyped) && is_untyped.(sig.return_type)
+        end
+      end
     end
   end
 end

--- a/rbi/parlour.rbi
+++ b/rbi/parlour.rbi
@@ -966,6 +966,9 @@ module Parlour
       sig { override.void }
       def generalize_from_rbi!; end
 
+      sig { returns(T::Boolean) }
+      def untyped?; end
+
       sig { overridable.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
       def generate_definition(indent_level, options); end
 
@@ -1638,6 +1641,9 @@ module Parlour
 
       sig { override.returns(String) }
       def describe; end
+
+      sig { returns(T::Boolean) }
+      def untyped?; end
     end
 
     class MethodSignature

--- a/spec/conflict_resolver_spec.rb
+++ b/spec/conflict_resolver_spec.rb
@@ -710,7 +710,6 @@ RSpec.describe Parlour::ConflictResolver do
   it 'resolves conflicts where all but one copy of the method is untyped' do
     x = Parlour::TypeLoader.load_source(<<-RUBY).children.first
       class A
-        sig { params(i: T.untyped).returns(T.untyped) }
         def int_to_str(i); end
 
         sig { params(i: Integer).returns(String) }

--- a/spec/conflict_resolver_spec.rb
+++ b/spec/conflict_resolver_spec.rb
@@ -706,4 +706,70 @@ RSpec.describe Parlour::ConflictResolver do
 
     expect(x.children.length).to be 2
   end
+
+  it 'resolves conflicts where all but one copy of the method is untyped' do
+    x = Parlour::TypeLoader.load_source(<<-RUBY).children.first
+      class A
+        sig { params(i: T.untyped).returns(T.untyped) }
+        def int_to_str(i); end
+
+        sig { params(i: Integer).returns(String) }
+        def int_to_str(i); end
+
+        sig { params(i: Integer).returns(String) }
+        def int_to_str(i); end
+
+        sig { params(i: T.untyped).returns(T.untyped) }
+        def int_to_str(i); end
+      end
+    RUBY
+
+    expect(x.children.length).to be 4
+
+    subject.resolve_conflicts(x) { |*| raise 'unable to resolve automatically' }
+
+    expect(x.children.length).to be 1
+    expect(x.children.first.return_type).to eq "String"
+  end
+
+  it 'keeps an untyped copy of a method if there is no typed copy' do
+    x = Parlour::TypeLoader.load_source(<<-RUBY).children.first
+      class A
+        sig { params(i: T.untyped).returns(T.untyped) }
+        def int_to_str(i); end
+
+        sig { params(i: T.untyped).returns(T.untyped) }
+        def int_to_str(i); end
+      end
+    RUBY
+
+    expect(x.children.length).to be 2
+
+    subject.resolve_conflicts(x) { |*| raise 'unable to resolve automatically' }
+
+    expect(x.children.length).to be 1
+  end
+
+  it 'does not resolve untyped copies with different parameters' do
+    x = Parlour::TypeLoader.load_source(<<-RUBY).children.first
+      class A
+        sig { params(i: Integer).returns(String) }
+        def int_to_str(i); end
+
+        sig { params(i: Integer).returns(String) }
+        def int_to_str(i); end
+
+        sig { params(x: T.untyped).returns(T.untyped) }
+        def int_to_str(x); end
+      end
+    RUBY
+
+    expect(x.children.length).to be 3
+
+    invocations = 0
+    subject.resolve_conflicts(x) { |*| invocations += 1; nil }
+
+    expect(invocations).to be 1
+    expect(x.children.length).to be 0
+  end
 end

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -341,6 +341,22 @@ RSpec.describe Parlour::RbiGenerator do
         def box(a); end
       RUBY
     end
+
+    it 'return the correct value for #untyped?' do
+      meth_a = subject.root.create_method('a', parameters: [
+        pa('a', type: 'Integer')
+      ], return_type: 'T.untyped')
+      meth_b = subject.root.create_method('b', parameters: [
+        pa('a', type: 'T.untyped')
+      ], return_type: 'Integer')
+      meth_c = subject.root.create_method('c', parameters: [
+        pa('a', type: 'T.untyped')
+      ], return_type: Parlour::Types::Untyped.new)
+
+      expect(meth_a.untyped?).to eq false
+      expect(meth_b.untyped?).to eq false
+      expect(meth_c.untyped?).to eq true
+    end
   end
 
   context 'attributes' do

--- a/spec/rbs_generator_spec.rb
+++ b/spec/rbs_generator_spec.rb
@@ -248,6 +248,22 @@ RSpec.describe Parlour::RbsGenerator do
                | () -> void
       RUBY
     end
+
+    it 'return the correct value for #untyped?' do
+      meth_a = subject.root.create_method('a', [Parlour::RbsGenerator::MethodSignature.new([
+        pa('a', type: 'Integer')
+      ], 'untyped')])
+      meth_b = subject.root.create_method('b', [Parlour::RbsGenerator::MethodSignature.new([
+        pa('a', type: 'untyped')
+      ], 'Integer')])
+      meth_c = subject.root.create_method('c', [Parlour::RbsGenerator::MethodSignature.new([
+        pa('a', type: 'untyped')
+      ], Parlour::Types::Untyped.new)])
+
+      expect(meth_a.untyped?).to eq false
+      expect(meth_b.untyped?).to eq false
+      expect(meth_c.untyped?).to eq true
+    end
   end
 
   context 'attributes' do


### PR DESCRIPTION
This PR adds a special case to the conflict resolver so that "untyped" methods (ones where every parameter and the return type is `T.untyped`, such as those defined in Ruby source without a signature) can be automatically merged with their type signatures definitions. 

Previously, merging these two definitions would've caused a conflict resolver error:

```ruby
def int_to_str(i)
  i.to_s
end
```

```ruby
sig { params(i: Integer).returns(String) }
def int_to_str(i); end
```

But this now works as expected, keeping only the one with the `sig`.

Closes #115.

@Bo98 @vaporyhumo If you get a chance to test it out, I'd be curious to know if this fixes the conflict issue you were having! It seems to fix it for the minimal example in the issue.