### PR TITLE
Add #find and #find_all for RBI/RBS Namespace

### DIFF
--- a/lib/parlour.rb
+++ b/lib/parlour.rb
@@ -14,6 +14,8 @@ require 'parlour/types'
 require 'parlour/options'
 require 'parlour/typed_object'
 require 'parlour/generator'
+require 'parlour/mixin/searchable'
+
 require 'parlour/rbi_generator/parameter'
 require 'parlour/rbi_generator/rbi_object'
 require 'parlour/rbi_generator/type_alias'

--- a/lib/parlour/mixin/searchable.rb
+++ b/lib/parlour/mixin/searchable.rb
@@ -1,0 +1,54 @@
+# typed: true
+
+module Parlour
+  module Mixin
+    # Extends a particular type system's Namespace class to provide searchable
+    # children.
+    module Searchable
+      extend T::Sig
+      extend T::Generic
+
+      Child = type_member
+
+      abstract!
+
+      sig { abstract.returns(T::Array[Child]) }
+      def children; end
+
+      sig { params(name: T.nilable(String), type: T.nilable(Class)).returns(Child) }
+      # Finds the first child matching the given predicates.
+      #
+      # @param [String, nil] name The name of the child to filter on, or nil.
+      # @param [Class, nil] type The type of the child to filter on, or nil. The
+      #   type is compared using #is_a?.
+      def find(name: nil, type: nil)
+        T.unsafe(children).find { |c| searchable_child_matches(c, name, type) }
+      end
+
+      sig { params(name: T.nilable(String), type: T.nilable(Class)).returns(T::Array[Child]) }
+      # Finds the first child matching the given predicates.
+      #
+      # @param [String, nil] name The name of the child to filter on, or nil.
+      # @param [Class, nil] type The type of the child to filter on, or nil. The
+      #   type is compared using #is_a?.
+      def find_all(name: nil, type: nil)
+        T.unsafe(children).select { |c| searchable_child_matches(c, name, type) }
+      end
+
+      private
+
+      sig do
+        params(
+          child: Child,
+          name: T.nilable(String),
+          type: T.nilable(Class)
+        )
+        .returns(T::Boolean)
+      end
+      def searchable_child_matches(child, name, type)
+        (name.nil? ? true : child.name == name) \
+        && (type.nil? ? true : child.is_a?(type))
+      end
+    end
+  end
+end

--- a/lib/parlour/rbi_generator/class_namespace.rb
+++ b/lib/parlour/rbi_generator/class_namespace.rb
@@ -5,6 +5,8 @@ module Parlour
     class ClassNamespace < Namespace
       extend T::Sig
 
+      Child = type_member(fixed: RbiObject)
+
       sig do
         params(
           generator: Generator,

--- a/lib/parlour/rbi_generator/enum_class_namespace.rb
+++ b/lib/parlour/rbi_generator/enum_class_namespace.rb
@@ -5,6 +5,8 @@ module Parlour
     class EnumClassNamespace < ClassNamespace
       extend T::Sig
 
+      Child = type_member(fixed: RbiObject)
+
       sig do
         params(
           generator: Generator,

--- a/lib/parlour/rbi_generator/module_namespace.rb
+++ b/lib/parlour/rbi_generator/module_namespace.rb
@@ -5,6 +5,8 @@ module Parlour
     class ModuleNamespace < Namespace
       extend T::Sig
 
+      Child = type_member(fixed: RbiObject)
+
       sig do
         params(
           generator: Generator,

--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -5,6 +5,7 @@ module Parlour
     # {RbiGenerator#root}.
     class Namespace < RbiObject
       extend T::Sig
+      extend T::Generic
 
       sig do
         override.overridable.params(
@@ -60,10 +61,13 @@ module Parlour
       # @return [Boolean]
       attr_reader :sealed
 
-      sig { returns(T::Array[RbiObject]) }
+      sig { override.returns(T::Array[RbiObject]).checked(:never) }
       # The child {RbiObject} instances inside this namespace.
       # @return [Array<RbiObject>]
       attr_reader :children
+
+      include Mixin::Searchable
+      Child = type_member(fixed: RbiObject)
 
       sig { returns(T::Array[RbiGenerator::Extend]) }
       # The {RbiGenerator::Extend} objects from {children}.

--- a/lib/parlour/rbi_generator/struct_class_namespace.rb
+++ b/lib/parlour/rbi_generator/struct_class_namespace.rb
@@ -6,6 +6,8 @@ module Parlour
     class StructClassNamespace < ClassNamespace
       extend T::Sig
 
+      Child = type_member(fixed: RbiObject)
+
       sig do
         params(
           generator: Generator,

--- a/lib/parlour/rbs_generator/class_namespace.rb
+++ b/lib/parlour/rbs_generator/class_namespace.rb
@@ -5,6 +5,8 @@ module Parlour
     class ClassNamespace < Namespace
       extend T::Sig
 
+      Child = type_member(fixed: RbsObject)
+
       sig do
         params(
           generator: Generator,

--- a/lib/parlour/rbs_generator/interface_namespace.rb
+++ b/lib/parlour/rbs_generator/interface_namespace.rb
@@ -5,6 +5,8 @@ module Parlour
     class InterfaceNamespace < Namespace
       extend T::Sig
 
+      Child = type_member(fixed: RbsObject)
+
       sig do
         override.params(
           indent_level: Integer,

--- a/lib/parlour/rbs_generator/module_namespace.rb
+++ b/lib/parlour/rbs_generator/module_namespace.rb
@@ -5,6 +5,8 @@ module Parlour
     class ModuleNamespace < Namespace
       extend T::Sig
 
+      Child = type_member(fixed: RbsObject)
+
       sig do
         override.params(
           indent_level: Integer,

--- a/lib/parlour/rbs_generator/namespace.rb
+++ b/lib/parlour/rbs_generator/namespace.rb
@@ -5,6 +5,7 @@ module Parlour
     # {RbsGenerator#root}.
     class Namespace < RbsObject
       extend T::Sig
+      extend T::Generic
 
       sig do
         override.overridable.params(
@@ -45,10 +46,13 @@ module Parlour
         yield_self(&block) if block
       end
 
-      sig { returns(T::Array[RbsObject]) }
+      sig { override.returns(T::Array[RbsObject]).checked(:never) }
       # The child {RbsObject} instances inside this namespace.
       # @return [Array<RbsObject>]
       attr_reader :children
+
+      include Mixin::Searchable
+      Child = type_member(fixed: RbsObject)
 
       sig { returns(T::Array[RbsGenerator::Extend]) }
       # The {RbsGenerator::Extend} objects from {children}.

--- a/rbi/parlour.rbi
+++ b/rbi/parlour.rbi
@@ -70,6 +70,28 @@ module Parlour
     attr_accessor :current_plugin
   end
 
+  module Mixin
+    module Searchable
+      abstract!
+
+      extend T::Sig
+      extend T::Generic
+      Child = type_member
+
+      sig { abstract.returns(T::Array[Child]) }
+      def children; end
+
+      sig { params(name: T.nilable(String), type: T.nilable(Class)).returns(Child) }
+      def find(name: nil, type: nil); end
+
+      sig { params(name: T.nilable(String), type: T.nilable(Class)).returns(T::Array[Child]) }
+      def find_all(name: nil, type: nil); end
+
+      sig { params(child: Child, name: T.nilable(String), type: T.nilable(Class)).returns(T::Boolean) }
+      def searchable_child_matches(child, name, type); end
+    end
+  end
+
   class Options
     extend T::Sig
 
@@ -749,6 +771,7 @@ module Parlour
 
     class ClassNamespace < Namespace
       extend T::Sig
+      Child = type_member(fixed: RbiObject)
 
       sig do
         params(
@@ -824,6 +847,7 @@ module Parlour
 
     class EnumClassNamespace < ClassNamespace
       extend T::Sig
+      Child = type_member(fixed: RbiObject)
 
       sig do
         params(
@@ -975,6 +999,7 @@ module Parlour
 
     class ModuleNamespace < Namespace
       extend T::Sig
+      Child = type_member(fixed: RbiObject)
 
       sig do
         params(
@@ -1012,7 +1037,10 @@ module Parlour
     end
 
     class Namespace < RbiObject
+      include Mixin::Searchable
       extend T::Sig
+      extend T::Generic
+      Child = type_member(fixed: RbiObject)
 
       sig { override.overridable.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
       def generate_rbi(indent_level, options); end
@@ -1276,6 +1304,7 @@ module Parlour
 
     class StructClassNamespace < ClassNamespace
       extend T::Sig
+      Child = type_member(fixed: RbiObject)
 
       sig do
         params(
@@ -1491,6 +1520,7 @@ module Parlour
 
     class ClassNamespace < Namespace
       extend T::Sig
+      Child = type_member(fixed: RbsObject)
 
       sig do
         params(
@@ -1596,6 +1626,7 @@ module Parlour
 
     class InterfaceNamespace < Namespace
       extend T::Sig
+      Child = type_member(fixed: RbsObject)
 
       sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
       def generate_rbs(indent_level, options); end
@@ -1674,6 +1705,7 @@ module Parlour
 
     class ModuleNamespace < Namespace
       extend T::Sig
+      Child = type_member(fixed: RbsObject)
 
       sig { override.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
       def generate_rbs(indent_level, options); end
@@ -1683,7 +1715,10 @@ module Parlour
     end
 
     class Namespace < RbsObject
+      include Mixin::Searchable
       extend T::Sig
+      extend T::Generic
+      Child = type_member(fixed: RbsObject)
 
       sig { override.overridable.params(indent_level: Integer, options: Options).returns(T::Array[String]) }
       def generate_rbs(indent_level, options); end

--- a/sorbet/config
+++ b/sorbet/config
@@ -2,3 +2,4 @@
 .
 --typed-override
 sorbet/override.yaml
+--ignore=parlour.rbi

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -725,4 +725,22 @@ RSpec.describe Parlour::RbiGenerator do
       end
     RUBY
   end
+
+  it 'implements the Searchable mixin' do
+    mod = subject.root.create_module('M') do |m|
+      m.create_class('A') do |a|
+        a.create_class('B')
+      end
+      m.create_module('C')
+      m.create_class('D')
+    end
+
+    expect(mod.find(name: 'A').name).to eq 'A'
+    expect(mod.find(name: 'A').find(name: 'B').name).to eq 'B'
+    expect(mod.find(name: 'C').name).to eq 'C'
+    expect(mod.find(type: Parlour::RbiGenerator::ModuleNamespace).name).to eq 'C'
+
+    expect(mod.find_all(name: 'A').map(&:name)).to eq ['A']
+    expect(mod.find_all(type: Parlour::RbiGenerator::ClassNamespace).map(&:name)).to eq ['A', 'D']
+  end
 end

--- a/spec/rbs_generator_spec.rb
+++ b/spec/rbs_generator_spec.rb
@@ -460,4 +460,22 @@ RSpec.describe Parlour::RbsGenerator do
       end
     RUBY
   end
+
+  it 'implements the Searchable mixin' do
+    mod = subject.root.create_module('M') do |m|
+      m.create_class('A') do |a|
+        a.create_class('B')
+      end
+      m.create_module('C')
+      m.create_class('D')
+    end
+
+    expect(mod.find(name: 'A').name).to eq 'A'
+    expect(mod.find(name: 'A').find(name: 'B').name).to eq 'B'
+    expect(mod.find(name: 'C').name).to eq 'C'
+    expect(mod.find(type: Parlour::RbsGenerator::ModuleNamespace).name).to eq 'C'
+
+    expect(mod.find_all(name: 'A').map(&:name)).to eq ['A']
+    expect(mod.find_all(type: Parlour::RbsGenerator::ClassNamespace).map(&:name)).to eq ['A', 'D']
+  end
 end


### PR DESCRIPTION
This adds two new methods to `Namespace` for RBI and RBS, using a new `Searchable` mixin - `#find` and `#find_all`, for returning the first child or all children of a namespace respectively, based on a set of criteria.

The `name:` keyword argument can be used to filter by the name of the child, and `type:` can be used to filter by its class.

I did consider just implementing `Enumerable`, but decided against it since a `Namespace` does a bit more than just hold its children - it may contain modifiers such as `final!` or `interface!`, and also has quite a few methods for code generation. If you do want to use it like an `Enumerable`, it's already easy enough to do so using `#children` to grab the underlying array.

Closes #73.