### PR TITLE
#initialize methods should always return void

### DIFF
--- a/lib/parlour/type_parser.rb
+++ b/lib/parlour/type_parser.rb
@@ -706,7 +706,7 @@ module Parlour
       elsif kind == :attr
         case attr_direction
         when :reader, :accessor, :writer
-          attr_type = return_type
+          attr_type = return_type || "T.untyped"
         else
           raise "unknown attribute direction #{attr_direction}"
         end

--- a/lib/parlour/type_parser.rb
+++ b/lib/parlour/type_parser.rb
@@ -672,7 +672,9 @@ module Parlour
         class_method = true
       end
 
-      return_type = "T.untyped"
+      return_type = unless def_names == ["initialize"]
+        "T.untyped"
+      end
 
       if kind == :def
         parameters = def_params.map do |def_param|

--- a/spec/type_parser_spec.rb
+++ b/spec/type_parser_spec.rb
@@ -367,6 +367,19 @@ RSpec.describe Parlour::TypeParser do
       end.to raise_error Parlour::ParseError
     end
 
+    it 'marks initialize methods as returning void' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        def initialize(x, y)
+          @x = x
+          @y = y
+        end
+      RUBY
+
+      meth = instance.parse_method_into_methods(Parlour::TypeParser::NodePath.new([])).only
+      expect(meth.return_type).to eq nil
+      expect(meth.name).to eq 'initialize'
+    end
+
     context 'attributes' do
       it 'supports attr_accessor' do
         instance = described_class.from_source('(test)', <<-RUBY)


### PR DESCRIPTION
I ran into an interesting issue today when Sorbet tried to typecheck some Parlour-generated code from one of my gems:

```
sorbet/rbi/gems/kube-dsl@0.7.1.rbi:10950: The initialize method should always return void https://srb.help/3510
       10950 |  sig { returns(T.untyped) }
                      ^^^^^^^^^^^^^^^^^^
  Autocorrect: Use `-a` to autocorrect
    sorbet/rbi/gems/kube-dsl@0.7.1.rbi:10950: Replace with void
       10950 |  sig { returns(T.untyped) }
```

The `#initialize` method is somewhat special in that its return value is always discarded, and in a recent release it looks like the Sorbet folks have decided to enforce void return values for all `#initialize` instance methods.