### PR TITLE
Add upper bound to Searchable::Child

### DIFF
--- a/lib/parlour/mixin/searchable.rb
+++ b/lib/parlour/mixin/searchable.rb
@@ -8,7 +8,7 @@ module Parlour
       extend T::Sig
       extend T::Generic
 
-      Child = type_member
+      Child = type_member {{ upper: TypedObject }}
 
       abstract!
 

--- a/rbi/parlour.rbi
+++ b/rbi/parlour.rbi
@@ -88,7 +88,7 @@ module Parlour
 
       extend T::Sig
       extend T::Generic
-      Child = type_member
+      Child = type_member {{ upper: TypedObject }}
 
       sig { abstract.returns(T::Array[Child]) }
       def children; end


### PR DESCRIPTION
Fixes type check failure which started recently; presumably due to a Sorbet change making this more strict:

```
./lib/parlour/mixin/searchable.rb:49: Call to method `name` on unbounded type member `Parlour::Mixin::Searchable::Child` https://srb.help/7039
    49 |        (name.nil? ? true : child.name == name) \
                                          ^^^^
  Got `Parlour::Mixin::Searchable::Child` originating from:
    ./lib/parlour/mixin/searchable.rb:48:
    48 |      def searchable_child_matches(child, name, type)
                                           ^^^^^
  Consider adding an `upper` bound to `Parlour::Mixin::Searchable::Child` here
    ./lib/parlour/mixin/searchable.rb:11:
    11 |      Child = type_member
              ^^^^^^^^^^^^^^^^^^^

./lib/parlour/mixin/searchable.rb:[5](https://github.com/AaronC81/parlour/runs/6342620404?check_suite_focus=true#step:5:5)0: Call to method `is_a?` on unbounded type member `Parlour::Mixin::Searchable::Child` https://srb.help/[7](https://github.com/AaronC81/parlour/runs/6342620404?check_suite_focus=true#step:5:7)039
    50 |        && (type.nil? ? true : child.is_a?(type))
                                             ^^^^^
  Got `Parlour::Mixin::Searchable::Child` originating from:
    ./lib/parlour/mixin/searchable.rb:4[8](https://github.com/AaronC81/parlour/runs/6342620404?check_suite_focus=true#step:5:8):
    48 |      def searchable_child_matches(child, name, type)
                                           ^^^^^
  Note:
    Use `case` instead of `is_a?` to check the type of an unconstrained generic type member
```