### PR TITLE
Fix Parlour CLI on Ruby 3.2.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby: [2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2]
     continue-on-error: false
       
     runs-on: ubuntu-latest    

--- a/exe/parlour
+++ b/exe/parlour
@@ -18,7 +18,7 @@ command :run do |c|
     working_dir = Dir.pwd
     config_filename = File.join(working_dir, '.parlour')
 
-    if File.exists?(config_filename)
+    if File.exist?(config_filename)
       configuration = keys_to_symbols(YAML.load_file(config_filename))
     else
       configuration = {}


### PR DESCRIPTION
`File#exists?` has now been removed, so use `exist?`