### PR TITLE
Use trace option to control plugin failures

### DIFF
--- a/exe/parlour
+++ b/exe/parlour
@@ -113,7 +113,7 @@ command :run do |c|
         generator: gen,
       )
     end
-    Parlour::Plugin.run_plugins(plugin_instances, gen)
+    Parlour::Plugin.run_plugins(plugin_instances, gen, allow_failure: !!options.trace)
 
     # Run a pass of the conflict resolver
     Parlour::ConflictResolver.new.resolve_conflicts(gen.root) do |msg, candidates|


### PR DESCRIPTION
This makes the `--trace` option control wether or not plugin errors are raised directly or not.
While this might be a bit sub-par, this makes plugins development a lot nicer.

Enhances #92