### PR TITLE
Fix crash when parsing activesupport's rbi

### DIFF
--- a/lib/parlour/type_parser.rb
+++ b/lib/parlour/type_parser.rb
@@ -529,6 +529,12 @@ module Parlour
         attr_direction = method_name.to_s.gsub('attr_', '').to_sym
         def_names = T.must(parameters).map { |param| param.to_a[0].to_s }
         class_method = false
+      when :block
+        # handle multiple sigs for the same method
+        if def_node.to_a[0].type == :send &&
+          def_node.to_a[0].to_a[1] == :sig
+          return parse_sig_into_methods(path.sibling(1), is_within_eigenclass: is_within_eigenclass)
+        end
       else
         parse_err 'node after a sig must be a method definition', def_node
       end

--- a/spec/type_parser_spec.rb
+++ b/spec/type_parser_spec.rb
@@ -200,6 +200,23 @@ RSpec.describe Parlour::TypeParser do
         type: 'String')
     end
 
+    it 'works with multiple sigs' do
+      instance = described_class.from_source('(test)', <<-RUBY)
+        sig { params(x: Integer).returns(String) }
+        sig { params(x: String).returns(Integer) }
+        def self.foo(x)
+          3
+        end
+      RUBY
+
+      meth = instance.parse_sig_into_methods(Parlour::TypeParser::NodePath.new([0])).only
+      expect(meth).to have_attributes(name: 'foo', return_type: 'Integer',
+        override: false, final: false, class_method: true)
+      expect(meth.parameters.length).to eq 1
+      expect(meth.parameters.first).to have_attributes(name: 'x',
+        type: 'String')
+    end
+
     it 'errors on a self.x method within an eigenclass' do
       instance = described_class.from_source('(test)', <<-RUBY)
         sig { params(x: String).returns(Integer) }


### PR DESCRIPTION
Core RBI files are allowed to have multiple overloading `sig` definitions. For example, this is taken from activesupport's rbi in `sorbet-typed`:

```
  # these are the sigs for Date- in the stdlib
  # https://github.com/sorbet/sorbet/blob/3910f6cfd9935c9b42e2135e32e15ab8a6e5b9be/rbi/stdlib/date.rbi#L373
  # note that if more sigs are added to sorbet you should replicate them here
  # check sorbet master: https://github.com/sorbet/sorbet/blob/master/rbi/stdlib/date.rbi
  sig {params(arg0: Numeric).returns(T.self_type)}
  sig {params(arg0: Date).returns(Rational)}
  # these sigs are added for activesupport users
  sig {params(arg0: ActiveSupport::Duration).returns(T.self_type)}
  def -(arg0); end
```

Parlour currently can't handle this and straight out crashes with the error: `node after a sig must be a method definition`

This PR fixes it so at least it doesn't crash. It doesn't go further by amalgamating all the `sigs` together into one (e.g. trying to figure out all the possible permutations of parameters and return values). Might be worth documenting this as a known bug.