### PR TITLE
Flatten namespaces when outputting RBI files

### DIFF
--- a/lib/parlour/conflict_resolver.rb
+++ b/lib/parlour/conflict_resolver.rb
@@ -124,7 +124,7 @@ module Parlour
             # The types aren't the same, so ask the resolver what to do, and
             # insert that (if not nil)
             choice = resolver.call("Different kinds of definition for the same name", children)
-            namespace.children << choice if choice
+            namespace.add_child(choice) if choice
             next
           end
 
@@ -149,7 +149,7 @@ module Parlour
             end
 
             non_namespaces.each do |x|
-              namespace.children << x
+              namespace.add_child(x)
             end
 
             # For certain namespace types the order matters. For example, if there's
@@ -173,14 +173,14 @@ module Parlour
           if T.must(first).mergeable?(T.must(rest))
             Debugging.debug_puts(self, @debugging_tree.end("Children are all mergeable; resolving automatically"))
             first.merge_into_self(rest)
-            namespace.children << first
+            namespace.add_child(first)
             next
           end
 
           # I give up! Let it be resolved manually somehow
           Debugging.debug_puts(self, @debugging_tree.end("Unable to resolve automatically; requesting manual resolution"))
           choice = resolver.call("Can't automatically resolve", children)
-          namespace.children << choice if choice
+          namespace.add_child(choice) if choice
         else
           Debugging.debug_puts(self, @debugging_tree.end("No conflicts"))
         end

--- a/lib/parlour/rbi_generator/enum_class_namespace.rb
+++ b/lib/parlour/rbi_generator/enum_class_namespace.rb
@@ -15,6 +15,7 @@ module Parlour
           sealed: T::Boolean,
           enums: T::Array[T.any([String, String], String)],
           abstract: T::Boolean,
+          path: String,
           block: T.nilable(T.proc.params(x: EnumClassNamespace).void)
         ).void
       end
@@ -27,10 +28,11 @@ module Parlour
       # @param sealed [Boolean] Whether this namespace is sealed.
       # @param enums [Array<(String, String), String>] The values of the enumeration.
       # @param abstract [Boolean] A boolean indicating whether this class is abstract.
+      # @param path [String] the fully resolved path to this constant.
       # @param block A block which the new instance yields itself to.
       # @return [void]
-      def initialize(generator, name, final, sealed, enums, abstract, &block)
-        super(generator, name, final, sealed, 'T::Enum', abstract, &block)
+      def initialize(generator, name, final, sealed, enums, abstract, path: '', &block)
+        super(generator, name, final, sealed, 'T::Enum', abstract, path: path, &block)
         @enums = enums
       end
 

--- a/lib/parlour/rbi_generator/struct_class_namespace.rb
+++ b/lib/parlour/rbi_generator/struct_class_namespace.rb
@@ -16,6 +16,7 @@ module Parlour
           sealed: T::Boolean,
           props: T::Array[StructProp],
           abstract: T::Boolean,
+          path: String,
           block: T.nilable(T.proc.params(x: StructClassNamespace).void)
         ).void
       end
@@ -28,10 +29,11 @@ module Parlour
       # @param sealed [Boolean] Whether this namespace is sealed.
       # @param props [Array<StructProp>] The props of the struct.
       # @param abstract [Boolean] A boolean indicating whether this class is abstract.
+      # @param path [String] the fully resolved path to this constant.
       # @param block A block which the new instance yields itself to.
       # @return [void]
-      def initialize(generator, name, final, sealed, props, abstract, &block)
-        super(generator, name, final, sealed, 'T::Struct', abstract, &block)
+      def initialize(generator, name, final, sealed, props, abstract, path: '', &block)
+        super(generator, name, final, sealed, 'T::Struct', abstract, path: path, &block)
         @props = props
       end
 

--- a/spec/cli/can_be_used_without_the_parser/expect.yaml
+++ b/spec/cli/can_be_used_without_the_parser/expect.yaml
@@ -3,7 +3,7 @@ files:
   rbi/can_be_used_without_the_parser.rbi: |
     # typed: strong
     module C
-      class D
-      end
     end
-
+    
+    class C::D
+    end

--- a/spec/cli/runs_specified_plugins/expect.yaml
+++ b/spec/cli/runs_specified_plugins/expect.yaml
@@ -17,7 +17,7 @@ files:
     end
 
     module C
-      class D
-      end
     end
-
+    
+    class C::D
+    end

--- a/spec/conflict_resolver_spec.rb
+++ b/spec/conflict_resolver_spec.rb
@@ -517,23 +517,25 @@ RSpec.describe Parlour::ConflictResolver do
 
       expected_rbi = <<~RUBY.strip
         module Outer
-          class A < T::Struct
+        end
+        
+        class Outer::A < T::Struct
 
+        end
+
+        module Outer::B
+        end
+        
+        class Outer::B::D
+        end
+        
+        class Outer::B::C
+        end
+
+        class Outer::Z < T::Enum
+          enums do
           end
 
-          module B
-            class C
-            end
-
-            class D
-            end
-          end
-
-          class Z < T::Enum
-            enums do
-            end
-
-          end
         end
       RUBY
 

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -100,29 +100,31 @@ RSpec.describe Parlour::RbiGenerator do
 
       expect(klass.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
         class Foo
-          class Bar
-            class A
-            end
-
-            class B
-            end
-
-            class C
-            end
-          end
-
-          class Baz
-            final!
-
-            class A
-            end
-
-            class B
-            end
-
-            class C
-            end
-          end
+        end
+        
+        class Foo::Bar
+        end
+        
+        class Foo::Bar::A
+        end
+        
+        class Foo::Bar::B
+        end
+        
+        class Foo::Bar::C
+        end
+        
+        class Foo::Baz
+          final!
+        end
+        
+        class Foo::Baz::A
+        end
+        
+        class Foo::Baz::B
+        end
+        
+        class Foo::Baz::C
         end
       RUBY
     end
@@ -138,18 +140,20 @@ RSpec.describe Parlour::RbiGenerator do
 
       expect(klass.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
         class Foo
-          class Bar
-            abstract!
-
-            class A
-            end
-
-            class B
-            end
-
-            class C
-            end
-          end
+        end
+        
+        class Foo::Bar
+          abstract!
+        
+        end
+        
+        class Foo::Bar::A
+        end
+        
+        class Foo::Bar::B
+        end
+        
+        class Foo::Bar::C
         end
       RUBY
     end
@@ -170,24 +174,25 @@ RSpec.describe Parlour::RbiGenerator do
 
       expect(klass.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
         class Foo
-          class Bar
-            abstract!
-
-            include Z
-            extend X
-            extend Y
-            Text = T.type_alias { T.any(String, Symbol) }
-            PI = 3.14
-
-            class A
-            end
-
-            class B
-            end
-
-            class C
-            end
-          end
+        end
+        
+        class Foo::Bar
+          abstract!
+        
+          include Z
+          extend X
+          extend Y
+          Text = T.type_alias { T.any(String, Symbol) }
+          PI = 3.14
+        end
+        
+        class Foo::Bar::A
+        end
+        
+        class Foo::Bar::B
+        end
+        
+        class Foo::Bar::C
         end
       RUBY
     end
@@ -420,17 +425,18 @@ RSpec.describe Parlour::RbiGenerator do
 
       expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
         module M
-          class Directions < T::Enum
-            enums do
-              North = new
-              South = new
-              West = new
-              East = new("Some custom serialization")
-            end
-
-            sig { returns(String) }
-            def self.mnemonic; end
+        end
+        
+        class M::Directions < T::Enum
+          enums do
+            North = new
+            South = new
+            West = new
+            East = new("Some custom serialization")
           end
+        
+          sig { returns(String) }
+          def self.mnemonic; end
         end
       RUBY
     end
@@ -486,12 +492,13 @@ RSpec.describe Parlour::RbiGenerator do
     expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
       # This is a module
       module M
-        # This is a class
-        class A
-          # This is a method
-          sig { void }
-          def foo; end
-        end
+      end
+      
+      # This is a class
+      class M::A
+        # This is a method
+        sig { void }
+        def foo; end
       end
     RUBY
   end
@@ -525,12 +532,13 @@ RSpec.describe Parlour::RbiGenerator do
       # This is a module
       # This was added internally
       module M
-        # This is a class
-        class A
-          # This is a method
-          sig { void }
-          def foo; end
-        end
+      end
+      
+      # This is a class
+      class M::A
+        # This is a method
+        sig { void }
+        def foo; end
       end
     RUBY
   end
@@ -561,16 +569,20 @@ RSpec.describe Parlour::RbiGenerator do
         c.create_method('foo')
       end
 
+      puts subject.root.generate_rbi(0, opts).join("\n")
+
       expect(subject.root.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
         module PathA
-          module B
-            class C
-              sig { void }
-              def foo; end
-            end
-          end
         end
-      RUBY
+        
+        module PathA::B
+        end
+        
+        class PathA::B::C
+          sig { void }
+          def foo; end
+        end
+RUBY
     end
 
     it 'throws on a non-root namespace' do
@@ -640,31 +652,31 @@ RSpec.describe Parlour::RbiGenerator do
     expect(custom_rbi_gen.root.generate_rbi(0, custom_opts).join("\n")).to eq fix_heredoc(<<-RUBY)
       module M
         interface!
-
+      
         include X
         include Y
         extend Z
-
+      
         "some arbitrary code"
-
+      
         "some more"
-
-        class A
-          module A
-          end
-
-          class B
-          end
-
-          sig { void }
-          def c; end
-        end
-
-        module B
-        end
-
+      
         sig { void }
         def c; end
+      end
+      
+      module M::B
+      end
+      
+      class M::A
+        sig { void }
+        def c; end
+      end
+      
+      module M::A::A
+      end
+      
+      class M::A::B
       end
     RUBY
   end
@@ -682,14 +694,15 @@ RSpec.describe Parlour::RbiGenerator do
 
     expect(mod.generate_rbi(0, opts).join("\n")).to eq fix_heredoc(<<-RUBY)
       module M
-        class Person < T::Struct
-          prop :name, String
-          prop :age, Integer, optional: true
-          prop :prefers_light_theme, T::Boolean, default: false
-
-          sig { returns(String) }
-          def theme; end
-        end
+      end
+      
+      class M::Person < T::Struct
+        prop :name, String
+        prop :age, Integer, optional: true
+        prop :prefers_light_theme, T::Boolean, default: false
+      
+        sig { returns(String) }
+        def theme; end
       end
     RUBY
   end


### PR DESCRIPTION
Addresses #11.

Rather than making this an option, I opted to change the behavior entirely. This is definitely a breaking change in terms of the output, but it should still be technically backwards compatible in that all output should result in the same objects. The main issue is that Tapioca (which is now the recommended way of handling RBI files) will rewrite any ingested RBI files into this format, and it can complain about things which this format doesn't (since constants can be referenced within the namespace). 

Flattening the output basically removes context and ambiguity and ensures the output is consistent.

Eager to hear feedback!

Here's a Slack thread from the Sorbet Slack for context:

> **Daniel Orner**  [3 days ago](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1689873513619089)
> 
> Another question - not sure if this is expected behavior or not.  
> In my generated RBI, I have the following (eliding unnecessary lines):
> 
> ```
> module Deimos::ActiveRecordConsume::BatchConsumption
>   sig { params(records: T::Array[Message]).returns(ActiveRecord::Relation) }
>   def deleted_query(records); end
> end
> ```
> 
> Then later on:
> 
> ```
> class Deimos::Message
> ...
> end
> ```
> 
> When I run `srb tc`, I get the following error:
> 
>  `Unable to resolve constant Message`
> 
> It seems like Sorbet is not able to figure out to go up the namespace tree until it finds the actual namespace of the `Message` class the way Ruby itself does?
> 
> **Daniel Orner**  [3 days ago](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1689873576035429?thread_ts=1689873513.619089&cid=CHN2L03NH)  
> Moving `Deimos::Message` up above the other doesn’t seem to make a difference btw
> 
> **jez**  [3 days ago](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1689873889745649?thread_ts=1689873513.619089&cid=CHN2L03NH)
> 
> sorbet is accurately modeling ruby here
> 
> ```
> ❯ cat foo.rb
> 
> module Deimos
>   class Message
>   end
> 
>   module ActiveRecordConsume
>     module BatchConsumption
>     end
>   end
> end
> 
> module Deimos::ActiveRecordConsume::BatchConsumption
>   p(Message)
> end
> 
> ❯ ruby foo.rb
> Traceback (most recent call last):
>         1: from foo.rb:12:in `<main>'
> foo.rb:13:in `<module:BatchConsumption>': uninitialized constant Deimos::ActiveRecordConsume::BatchConsumption::Message (NameError)
> Did you mean?  Deimos::Message
> ```
> 
> **Daniel Orner**  [3 days ago](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1689873935375399?thread_ts=1689873513.619089&cid=CHN2L03NH)  
> Huh! I could have sworn I tested this out and it worked 
> 
> **Daniel Orner**  [3 days ago](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1689873959611619?thread_ts=1689873513.619089&cid=CHN2L03NH)  
> Thank you for the prompt assistance yet again 
> 
> **jez**  [3 days ago](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1689873989511139?thread_ts=1689873513.619089&cid=CHN2L03NH)
> 
> it will only work in ruby and sorbet if you define your module like
> 
> ```
> module Deimos
>   module ActiveRecordConsume
>     module BatchConsumption
>       # ...
> ```
> 
> np
> 
> **Daniel Orner**  [3 days ago](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1689874001892159?thread_ts=1689873513.619089&cid=CHN2L03NH)  
> ohhhhhh that’s what I was missing
> 
> **Daniel Orner**  [3 days ago](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1689874005265159?thread_ts=1689873513.619089&cid=CHN2L03NH)  
> poifect, thanks
> 
> **Daniel Orner**  [3 days ago](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1689875754742379?thread_ts=1689873513.619089&cid=CHN2L03NH)
> 
> FYI - looks like the generated rbi that I packaged with the gem did it the “right” way (nesting the module) but the one generated by Tapioca seems to remove nesting and flatten everything. This means that I can run `srb tc` on the generated RBI and it looks fine, but when I include the gem in another project it fails. 
> 
> **Daniel Orner**  [3 days ago](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1689876585285699?thread_ts=1689873513.619089&cid=CHN2L03NH)
> 
> Yeah. Had to spend a bunch of time with `sord` making sure that every reference was fully namespaced. Even within the same module, e.g.
> 
> ```
> module Deimos
>   class BatchRecordList
>       sig { params(records: T::Array[BatchRecord]).void }
>   def initialize(records); end
>   end
> end
> 
> module Deimos
>   class BatchRecord
>   end
> end
> ```
> 
> still couldn’t find it since everything is splatted out by Tapioca.
> 
> **Ufuk Kayserilioglu**  [3 days ago](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1689893454702079?thread_ts=1689873513.619089&cid=CHN2L03NH)
> 
> as I mentioned in the other thread, the right thing to do is to fully qualify all constant references, like how Tapioca does. Sord should be able to do that based on the runtime information. Relying on relative constant resolution is brittle since the introduction of a completely unrelated constant can end up messing the whole resolution.
> 
> **Daniel Orner**  [2 days ago](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1689944421370699?thread_ts=1689873513.619089&cid=CHN2L03NH)
> 
> That’s a good point! Might see if I can take some time to update the Sord output to do this (actually I think it’s Parlour that does).