### PR TITLE
Cast initialiser blocks to more abstract `T.proc` types

### DIFF
--- a/lib/parlour/rbi_generator/attribute.rb
+++ b/lib/parlour/rbi_generator/attribute.rb
@@ -36,11 +36,11 @@ module Parlour
         @class_attribute = class_attribute
         case kind
         when :accessor, :reader
-          super(generator, name, [], type, &block)
+          super(generator, name, [], type, &T.cast(block, T.nilable(T.proc.params(x: Method).void)))
         when :writer
           super(generator, name, [
             Parameter.new(name, type: type)
-          ], type, &block)
+          ], type, &T.cast(block, T.nilable(T.proc.params(x: Method).void)))
         else
           raise 'unknown kind'
         end

--- a/lib/parlour/rbi_generator/class_namespace.rb
+++ b/lib/parlour/rbi_generator/class_namespace.rb
@@ -31,7 +31,7 @@ module Parlour
       # @param block A block which the new instance yields itself to.
       # @return [void]
       def initialize(generator, name, final, sealed, superclass, abstract, &block)
-        super(generator, name, final, sealed, &block)
+        super(generator, name, final, sealed, &T.cast(block, T.nilable(T.proc.params(x: Namespace).void)))
         @superclass = superclass
         @abstract = abstract
       end

--- a/lib/parlour/rbi_generator/enum_class_namespace.rb
+++ b/lib/parlour/rbi_generator/enum_class_namespace.rb
@@ -30,7 +30,7 @@ module Parlour
       # @param block A block which the new instance yields itself to.
       # @return [void]
       def initialize(generator, name, final, sealed, enums, abstract, &block)
-        super(generator, name, final, sealed, 'T::Enum', abstract, &block)
+        super(generator, name, final, sealed, 'T::Enum', abstract, &T.cast(block, T.nilable(T.proc.params(x: Namespace).void)))
         @enums = enums
       end
 

--- a/lib/parlour/rbi_generator/module_namespace.rb
+++ b/lib/parlour/rbi_generator/module_namespace.rb
@@ -31,7 +31,7 @@ module Parlour
       # @param block A block which the new instance yields itself to.
       # @return [void]
       def initialize(generator, name, final, sealed, interface, abstract, &block)
-        super(generator, name, final, sealed, &block)
+        super(generator, name, final, sealed, &T.cast(block, T.nilable(T.proc.params(x: Namespace).void)))
         @name = name
         @interface = interface
         @abstract = abstract

--- a/lib/parlour/rbi_generator/struct_class_namespace.rb
+++ b/lib/parlour/rbi_generator/struct_class_namespace.rb
@@ -31,7 +31,7 @@ module Parlour
       # @param block A block which the new instance yields itself to.
       # @return [void]
       def initialize(generator, name, final, sealed, props, abstract, &block)
-        super(generator, name, final, sealed, 'T::Struct', abstract, &block)
+        super(generator, name, final, sealed, 'T::Struct', abstract, &T.cast(block, T.nilable(T.proc.params(x: Namespace).void)))
         @props = props
       end
 

--- a/lib/parlour/rbs_generator/attribute.rb
+++ b/lib/parlour/rbs_generator/attribute.rb
@@ -29,11 +29,11 @@ module Parlour
         @kind = kind
         case kind
         when :accessor, :reader
-          super(generator, name, [MethodSignature.new([], type)], &block)
+          super(generator, name, [MethodSignature.new([], type)], &T.cast(block, T.nilable(T.proc.params(x: Method).void)))
         when :writer
           super(generator, name, [MethodSignature.new([
             Parameter.new(name, type: type)
-          ], type)], &block)
+          ], type)], &T.cast(block, T.nilable(T.proc.params(x: Method).void)))
         else
           raise 'unknown kind'
         end

--- a/lib/parlour/rbs_generator/class_namespace.rb
+++ b/lib/parlour/rbs_generator/class_namespace.rb
@@ -25,7 +25,7 @@ module Parlour
       # @param block A block which the new instance yields itself to.
       # @return [void]
       def initialize(generator, name, superclass, &block)
-        super(generator, name, &block)
+        super(generator, name, &T.cast(block, T.nilable(T.proc.params(x: Namespace).void)))
         @superclass = superclass
       end
 


### PR DESCRIPTION
Fixes type checking failures introduced by `--typed-super` becoming the default: sorbet/sorbet@db48e97

I tried just disabling `--typed-super`, but we support Ruby versions (2.4-2.6) whose newest Sorbet versions don't have this option