### PR TITLE
Fix type loader when type check output overflows the buffer

### DIFF
--- a/lib/parlour/type_loader.rb
+++ b/lib/parlour/type_loader.rb
@@ -55,13 +55,12 @@ module Parlour
       expanded_inclusions = inclusions.map { |i| File.expand_path(i, root) }
       expanded_exclusions = exclusions.map { |e| File.expand_path(e, root) }
 
-      stdin, stdout, stderr, wait_thr = T.unsafe(Open3).popen3(
+      stdout, status = Open3.capture2(
         'bundle exec srb tc -p file-table-json',
         chdir: root
       )
 
-      stdout = T.must(stdout.read)
-      if stdout == ''
+      unless status.success?
         raise 'unable to get Sorbet file table; the project may be empty or not have Sorbet initialised'
       end
 


### PR DESCRIPTION
When running the parlour CLI and you have a large amount of sorbet typecheck errors,
the parlour process will hang.

`Parlour::TypeLoader` uses `Open3.capture3` which comes with this warning
>Take care to avoid deadlocks. Output streams stdout and stderr have fixed-size buffers, so reading extensively from one but not the other can cause a deadlock when the unread buffer fills. To avoid that, stdout and stderr should be read simultaneously (using threads or IO.select).

-- https://ruby-doc.org/3.4.1/stdlibs/open3/Open3.html#method-c-popen3

The code that calls `Open3.capture3` only reads from stdout. So instead of implementing a fix for this, I switched to using `Open3.capture2`. Which returns stdout as a string and a `Process::Status` object.

This change should not affect the functionality of the CLI.
