### PR TITLE
Generate heredoc bodies in constants

### DIFF
--- a/lib/parlour/rbi_generator/namespace.rb
+++ b/lib/parlour/rbi_generator/namespace.rb
@@ -564,7 +564,7 @@ module Parlour
         returned_includables
       end
 
-      sig { params(name: String, value: String, eigen_constant: T::Boolean, block: T.nilable(T.proc.params(x: Constant).void)).returns(Constant) }
+      sig { params(name: String, value: String, eigen_constant: T::Boolean, heredocs: T.nilable(String), block: T.nilable(T.proc.params(x: Constant).void)).returns(Constant) }
       # Adds a new constant definition to this namespace.
       #
       # @example Add an +Elem+ constant to the class.
@@ -574,14 +574,16 @@ module Parlour
       # @param value [String] The value of the constant, as a Ruby code string.
       # @param eigen_constant [Boolean] Whether this constant is defined on the
       #   eigenclass of the current namespace.
+      # @param heredocs [String,nil] Values of the heredocs used, in order
       # @param block A block which the new instance yields itself to.
       # @return [RbiGenerator::Constant]
-      def create_constant(name, value:, eigen_constant: false, &block)
+      def create_constant(name, value:, eigen_constant: false, heredocs: nil, &block)
         new_constant = RbiGenerator::Constant.new(
           generator,
           name: name,
           value: value,
           eigen_constant: eigen_constant,
+          heredocs: heredocs,
           &block
         )
         move_next_comments(new_constant)

--- a/lib/parlour/type_parser.rb
+++ b/lib/parlour/type_parser.rb
@@ -420,7 +420,7 @@ module Parlour
     #
     # this method would return "  bar\nHEREDOC\n"
     def find_heredocs(body)
-      heredocs = nil
+      heredocs = T.let(nil, T.nilable(String))
 
       return heredocs if body.nil?
 

--- a/rbi/parlour.rbi
+++ b/rbi/parlour.rbi
@@ -238,6 +238,9 @@ module Parlour
 
     end
 
+    sig { params(body: T.nilable(Parser::AST::Node)).returns(T.nilable(String)) }
+    def find_heredocs(body); end
+
     sig { params(path: NodePath).returns(IntermediateSig) }
     def parse_sig_into_sig(path); end
 
@@ -836,16 +839,20 @@ module Parlour
           name: String,
           value: Types::TypeLike,
           eigen_constant: T::Boolean,
+          heredocs: T.nilable(String),
           block: T.nilable(T.proc.params(x: Constant).void)
         ).void
       end
-      def initialize(generator, name: '', value: '', eigen_constant: false, &block); end
+      def initialize(generator, name: '', value: '', eigen_constant: false, heredocs: nil, &block); end
 
       sig { returns(Types::TypeLike) }
       attr_reader :value
 
       sig { returns(T.untyped) }
       attr_reader :eigen_constant
+
+      sig { returns(T.untyped) }
+      attr_reader :heredocs
 
       sig { params(other: Object).returns(T::Boolean) }
       def ==(other); end
@@ -1234,10 +1241,11 @@ module Parlour
           name: String,
           value: String,
           eigen_constant: T::Boolean,
+          heredocs: T.nilable(String),
           block: T.nilable(T.proc.params(x: Constant).void)
         ).returns(Constant)
       end
-      def create_constant(name, value:, eigen_constant: false, &block); end
+      def create_constant(name, value:, eigen_constant: false, heredocs: nil, &block); end
 
       sig { params(name: String, type: Types::TypeLike, block: T.nilable(T.proc.params(x: TypeAlias).void)).returns(TypeAlias) }
       def create_type_alias(name, type:, &block); end

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe Parlour::RbiGenerator do
           bar.create_include( 'Z')
           bar.create_type_alias('Text', type: 'T.any(String, Symbol)')
           bar.create_constant('PI', value: '3.14')
+          bar.create_constant('TAU', value: '<<EOF', heredocs: "6.28\nEOF")
           bar.create_class('A')
           bar.create_class('B')
           bar.create_class('C')
@@ -178,6 +179,9 @@ RSpec.describe Parlour::RbiGenerator do
             extend Y
             Text = T.type_alias { T.any(String, Symbol) }
             PI = 3.14
+            TAU = <<EOF
+        6.28
+        EOF
 
             class A
             end


### PR DESCRIPTION
Fixes invalid heredoc bodies which were generated in .rbi files because the body of them was not generated.

RBI generated before - Sorbet scans to the end of the file to find the 'HEREDOC' tag, doesn't find it, emits an error and ignores the rest of the .rbi file.

```
  FOO = T.let(<<~HEREDOC, String)
```

After:

```
  FOO = T.let(<<~HEREDOC, String)
    foo
  HEREDOC
```