### PR TITLE
Don't generate Proc.params() when Proc takes no parameters

### DIFF
--- a/lib/parlour/types.rb
+++ b/lib/parlour/types.rb
@@ -551,9 +551,9 @@ module Parlour
         rbi_params = parameters.map do |param|
           RbiGenerator::Parameter.new(param.name, type: param.type, default: param.default)
         end
-        "T.proc.params(#{rbi_params.map(&:to_sig_param).join(', ')}).#{
-          @return_type ? "returns(#{@return_type.generate_rbi})" : 'void'
-        }"
+        "T.proc." +
+          (rbi_params.empty? ? "" : "params(#{rbi_params.map(&:to_sig_param).join(', ')}).") +
+          (@return_type ? "returns(#{@return_type.generate_rbi})" : 'void')
       end
 
       sig { override.returns(String) }
@@ -575,4 +575,3 @@ module Parlour
     end
   end
 end
-

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe Parlour::Types do
     it { expect(type.describe).to eq('Set<String>') }
   end
 
+  describe 'Proc' do
+    subject(:type) {
+      Parlour::Types::Proc.new([], 'void')
+    }
+
+    it { expect(type.generate_rbi).to eq('T.proc.returns(void)]') }
+    it { expect(type.generate_rbs).to eq('() -> void') }
+    it { expect(type.describe).to eq('() -> void') }
+  end
+
   describe 'Range' do
     subject(:type) {
       Parlour::Types::Range.new('String')

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Parlour::Types do
       Parlour::Types::Proc.new([], 'void')
     }
 
-    it { expect(type.generate_rbi).to eq('T.proc.returns(void)]') }
+    it { expect(type.generate_rbi).to eq('T.proc.returns(void)') }
     it { expect(type.generate_rbs).to eq('() -> void') }
     it { expect(type.describe).to eq('() -> void') }
   end


### PR DESCRIPTION
Sorbet does not support a no-argument form of Proc.params(); current code generates RBI which fails in 'srb tc' with:

```
<filename>:<line>: params must be given arguments https://srb.help/5003
       <line> |  sig { params(task_name: String, block: T.proc.params().returns(Object)).returns(Object) }
```