### PR TITLE
Remove YARD `@abstract` directives

### DIFF
--- a/lib/parlour/plugin.rb
+++ b/lib/parlour/plugin.rb
@@ -1,7 +1,8 @@
 # typed: true
 module Parlour
   # The base class for user-defined RBI generation plugins.
-  # @abstract
+  #
+  # This class is *abstract*.
   class Plugin
     extend T::Sig
     extend T::Helpers
@@ -57,7 +58,8 @@ module Parlour
     # Plugin subclasses should redefine this method and do their RBI generation
     # inside it.
     #
-    # @abstract
+    # This method is *abstract*.
+    #
     # @param root [RbiGenerator::Namespace] The root {RbiGenerator::Namespace}.
     # @return [void]
     def generate(root); end

--- a/lib/parlour/rbi_generator/rbi_object.rb
+++ b/lib/parlour/rbi_generator/rbi_object.rb
@@ -5,7 +5,8 @@ module Parlour
     # entire lines of an RBI, such as {Namespace} and {Method}. (As an example,
     # {Parameter} is _not_ a subclass because it does not generate lines, only
     # segments of definition and signature lines.)
-    # @abstract
+    # 
+    # This class is *abstract*.
     class RbiObject < TypedObject
       abstract!
       
@@ -35,7 +36,8 @@ module Parlour
       end
       # Generates the RBI lines for this object.
       #
-      # @abstract
+      # This method is *abstract*.
+      #
       # @param indent_level [Integer] The indentation level to generate the lines at.
       # @param options [Options] The formatting options to use.
       # @return [Array<String>] The RBI lines, formatted as specified.
@@ -50,7 +52,8 @@ module Parlour
       # into this instance using {merge_into_self}. Each subclass will have its
       # own criteria on what allows objects to be mergeable.
       #
-      # @abstract
+      # This method is *abstract*.
+      #
       # @param others [Array<RbiGenerator::RbiObject>] An array of other {RbiObject} instances.
       # @return [Boolean] Whether this instance may be merged with them.
       def mergeable?(others); end
@@ -64,7 +67,8 @@ module Parlour
       # subclass will do this differently.
       # You MUST ensure that {mergeable?} is true for those instances.
       #
-      # @abstract
+      # This method is *abstract*.
+      #
       # @param others [Array<RbiGenerator::RbiObject>] An array of other {RbiObject} instances.
       # @return [void]
       def merge_into_self(others); end
@@ -74,7 +78,8 @@ module Parlour
       # been specified as RBI-style types, generalises them into type instances
       # from the {Parlour::Types} module.
       #
-      # @abstract
+      # This method is *abstract*.
+      #
       # @return [void]
       def generalize_from_rbi!; end
     end

--- a/lib/parlour/rbs_generator/rbs_object.rb
+++ b/lib/parlour/rbs_generator/rbs_object.rb
@@ -5,7 +5,8 @@ module Parlour
     # entire lines of an RBS, such as {Namespace} and {Method}. (As an example,
     # {Parameter} is _not_ a subclass because it does not generate lines, only
     # segments of definition lines.)
-    # @abstract
+    #
+    # This class is *abstract*.
     class RbsObject < TypedObject
       abstract!
       
@@ -35,7 +36,8 @@ module Parlour
       end
       # Generates the RBS lines for this object.
       #
-      # @abstract
+      # This method is *abstract*.
+      #
       # @param indent_level [Integer] The indentation level to generate the lines at.
       # @param options [Options] The formatting options to use.
       # @return [Array<String>] The RBS lines, formatted as specified.
@@ -50,7 +52,8 @@ module Parlour
       # into this instance using {merge_into_self}. Each subclass will have its
       # own criteria on what allows objects to be mergeable.
       #
-      # @abstract
+      # This method is *abstract*.
+      #
       # @param others [Array<RbsGenerator::RbsObject>] An array of other {RbsObject} instances.
       # @return [Boolean] Whether this instance may be merged with them.
       def mergeable?(others); end
@@ -64,7 +67,8 @@ module Parlour
       # subclass will do this differently.
       # You MUST ensure that {mergeable?} is true for those instances.
       #
-      # @abstract
+      # This method is *abstract*.
+      #
       # @param others [Array<RbsGenerator::RbsObject>] An array of other {RbsObject} instances.
       # @return [void]
       def merge_into_self(others); end

--- a/lib/parlour/typed_object.rb
+++ b/lib/parlour/typed_object.rb
@@ -148,7 +148,8 @@ module Parlour
     #   - If it is a hash, it must be of the format { Symbol => String }. The
     #     given string will be used instead of calling the symbol.
     #
-    # @abstract
+    # This method is *abstract*.
+    #
     # @return [<Symbol, String>]
     def describe_attrs; end
 


### PR DESCRIPTION
Tapioca now converts some RBS directives into Sorbet directives, including `@abstract`, which happens to match YARD's syntax.

Unfortunatley this clashes with the `abstract!` directive, and gives an error that we've duplicated it.

This is very convenient, but I think Sorbet's comment syntax is still experimental - so I'd rather remove this than the classic `abstract!` directive.

(This documentation mostly appears on classes/methods that a Parlour user won't be interacting with, anyway.)

Closes #147.