### PR TITLE
Fix I/O deadlock issue

### DIFF
--- a/lib/parlour/type_loader.rb
+++ b/lib/parlour/type_loader.rb
@@ -61,7 +61,9 @@ module Parlour
         chdir: root
       )
 
-      if stdout == '' || !io_status.success?
+      # ignore output code, which may indicate type checking issues
+      # that aren't blocking us
+      if stdout == ''
         raise "unable to get Sorbet file table with #{cmd.inspect}; " \
               'the project may be empty or not have Sorbet initialised'
       end

--- a/lib/parlour/type_loader.rb
+++ b/lib/parlour/type_loader.rb
@@ -55,14 +55,15 @@ module Parlour
       expanded_inclusions = inclusions.map { |i| File.expand_path(i, root) }
       expanded_exclusions = exclusions.map { |e| File.expand_path(e, root) }
 
-      stdin, stdout, stderr, wait_thr = T.unsafe(Open3).popen3(
-        'bundle exec srb tc -p file-table-json',
+      cmd = 'bundle exec srb tc -p file-table-json'
+      stdout, _stderr, io_status = T.unsafe(Open3).capture3(
+        cmd,
         chdir: root
       )
 
-      stdout = T.must(stdout.read)
-      if stdout == ''
-        raise 'unable to get Sorbet file table; the project may be empty or not have Sorbet initialised'
+      if stdout == '' || !io_status.success?
+        raise 'unable to get Sorbet file table with #{cmd.inspect}; ' \
+              'the project may be empty or not have Sorbet initialised'
       end
 
       file_table_hash = JSON.parse(stdout)

--- a/lib/parlour/type_loader.rb
+++ b/lib/parlour/type_loader.rb
@@ -62,7 +62,7 @@ module Parlour
       )
 
       if stdout == '' || !io_status.success?
-        raise 'unable to get Sorbet file table with #{cmd.inspect}; ' \
+        raise "unable to get Sorbet file table with #{cmd.inspect}; " \
               'the project may be empty or not have Sorbet initialised'
       end
 


### PR DESCRIPTION
I found this in a larger project; Open3.popen3 requires either threaded or select() based reading to avoid one full buffer on an output stream blocking the process continuing to execute while you wait for input on another sttream.

Open3.capture3() handles all of this for you if you don't mind not streaming the read.